### PR TITLE
Fix: Remove incorrect database seeding claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd app && ./start.sh
 cd app && start.bat
 ```
 
-This will set up the Python venv, install dependencies, seed the database with 10 sample videos, and start both servers.
+This will set up the Python venv, install dependencies, and start both servers.
 
 3. Open [http://localhost:5173](http://localhost:5173)
 


### PR DESCRIPTION
## Summary

README.md line 65 incorrectly claimed that running the start script would seed the database with 10 sample videos. Inspection of `app/start.sh` confirms it only creates a Python venv, installs dependencies, and starts the backend/frontend servers — no seeding step exists anywhere in the script.

## Changes

- **`README.md`** (line 65): Removed the phrase `, seed the database with 10 sample videos,` from the start script description

**Before:**
> This will set up the Python venv, install dependencies, seed the database with 10 sample videos, and start both servers.

**After:**
> This will set up the Python venv, install dependencies, and start both servers.

## Validation

- `grep "seed the database" README.md` → zero matches ✅
- Line 65 reads correctly and is grammatically correct ✅
- No other content in README.md was modified ✅

Fixes #3