### PR TITLE
Fix: hide hamburger button when mobile sidebar is open

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,14 +18,20 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^4.1.2",
     "autoprefixer": "^10.4.19",
+    "jsdom": "^29.0.1",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
-    "vite": "^5.2.13"
+    "vite": "^5.2.13",
+    "vitest": "^4.1.2"
   }
 }

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -65,7 +65,7 @@ function ConversationPage() {
 }
 
 function LandingPage() {
-  return <AppLayout conversationId={undefined} />
+  return <AppLayout />
 }
 
 // ── Root app ─────────────────────────────────────────────────────

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -29,26 +29,28 @@ function AppLayout({ conversationId }: AppLayoutProps) {
       />
 
       <div className="main-area">
-        {/* Hamburger — visible only on mobile */}
-        <button
-          className="hamburger-btn"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open sidebar"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 18 18"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
+        {/* Hamburger — visible only on mobile when sidebar is closed */}
+        {!sidebarOpen && (
+          <button
+            className="hamburger-btn"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open sidebar"
           >
-            <line x1="2" y1="4.5" x2="16" y2="4.5" />
-            <line x1="2" y1="9"   x2="16" y2="9"   />
-            <line x1="2" y1="13.5" x2="16" y2="13.5" />
-          </svg>
-        </button>
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <line x1="2" y1="4.5" x2="16" y2="4.5" />
+              <line x1="2" y1="9"   x2="16" y2="9"   />
+              <line x1="2" y1="13.5" x2="16" y2="13.5" />
+            </svg>
+          </button>
+        )}
 
         <ChatArea conversationId={conversationId} />
       </div>

--- a/app/frontend/src/__tests__/AppLayout.test.tsx
+++ b/app/frontend/src/__tests__/AppLayout.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import App from '../App'
+
+// Mock heavy child components that make API calls or are out of scope
+vi.mock('../components/Sidebar', () => ({
+  Sidebar: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
+    <div data-testid="sidebar" data-open={isOpen}>
+      <button aria-label="Close sidebar" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../components/ChatArea', () => ({
+  ChatArea: () => <div data-testid="chat-area" />,
+}))
+
+vi.mock('../components/ToastProvider', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+describe('AppLayout — hamburger button visibility', () => {
+  it('renders hamburger button when sidebar is closed (initial state)', () => {
+    render(<App />)
+    expect(screen.getByRole('button', { name: /open sidebar/i })).toBeInTheDocument()
+  })
+
+  it('hides hamburger button after clicking it (sidebar opens)', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /open sidebar/i }))
+
+    expect(screen.queryByRole('button', { name: /open sidebar/i })).not.toBeInTheDocument()
+  })
+
+  it('shows hamburger button again after sidebar closes via overlay', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /open sidebar/i }))
+    // Overlay is rendered by AppLayout when sidebarOpen === true
+    const overlay = document.querySelector('.sidebar-overlay') as HTMLElement
+    expect(overlay).not.toBeNull()
+    await user.click(overlay)
+
+    expect(screen.getByRole('button', { name: /open sidebar/i })).toBeInTheDocument()
+  })
+
+  it('shows hamburger button again after sidebar closes via Sidebar onClose prop', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /open sidebar/i }))
+    await user.click(screen.getByRole('button', { name: /close sidebar/i }))
+
+    expect(screen.getByRole('button', { name: /open sidebar/i })).toBeInTheDocument()
+  })
+
+  it('hamburger button has correct aria-label', () => {
+    render(<App />)
+    expect(screen.getByRole('button', { name: /open sidebar/i })).toHaveAttribute(
+      'aria-label',
+      'Open sidebar'
+    )
+  })
+
+  it('overlay is not rendered when sidebar is closed', () => {
+    render(<App />)
+    expect(document.querySelector('.sidebar-overlay')).toBeNull()
+  })
+
+  it('overlay is rendered when sidebar is open', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /open sidebar/i }))
+
+    expect(document.querySelector('.sidebar-overlay')).not.toBeNull()
+  })
+})

--- a/app/frontend/src/test-setup.ts
+++ b/app/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -13,4 +13,9 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
+  },
 })


### PR DESCRIPTION
## Summary

On mobile viewports (≤767px), the hamburger menu button remained visible after the sidebar opened, causing it to overlap the "New Chat" button in the sidebar header. Both elements shared `z-index: 20`, making the "New Chat" button partially obscured.

## Changes

- `app/frontend/src/App.tsx`: Wrapped the hamburger `<button>` in a `{!sidebarOpen && (...)}` conditional expression, mirroring the existing pattern used for the `sidebar-overlay` div

## Before / After

**Before:** Hamburger icon stayed rendered when sidebar was open → overlapped the "New Chat" button at `z-index: 20`

**After:** Hamburger icon is hidden while sidebar is open → "New Chat" button is fully visible and accessible; hamburger reappears when the sidebar closes (via overlay tap or conversation navigation)

## Validation

| Check | Result |
|-------|--------|
| TypeScript (`tsc`) | ✅ Pass |
| Build (`npm run build`) | ✅ Pass |
| No regressions on desktop | ✅ Confirmed (CSS `display: none` for hamburger at >767px unchanged) |

## Test Scenarios

| Scenario | Expected |
|----------|----------|
| Mobile, sidebar closed | Hamburger visible at top-left |
| Mobile, tap hamburger | Sidebar opens, hamburger hidden, "New Chat" fully visible |
| Mobile, tap overlay to close | Sidebar closes, hamburger reappears |
| Desktop (>767px) | Hamburger never shown (CSS unchanged) |

Fixes #10