### PR TITLE
Fix: Auto-scroll broken during active conversation

### DIFF
--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -212,7 +212,7 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
 
   const chatInputRef = useRef<ChatInputHandle>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const bottomRef = useRef<HTMLDivElement>(null)
+
   const autoScrollRef = useRef(true)
   const [, forceUpdate] = useState(0)
 
@@ -224,7 +224,9 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
 
   // ── Auto-scroll logic ──
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    bottomRef.current?.scrollIntoView({ behavior, block: 'end' })
+    const el = scrollContainerRef.current
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight, behavior })
   }, [])
 
   useEffect(() => {
@@ -354,7 +356,7 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
           display: 'flex',
           flexDirection: 'column',
           padding: '24px 0 0',
-          paddingBottom: 140,
+          paddingBottom: 220,
         }}
       >
         {showEmpty && <EmptyState onStarterClick={handleStarterClick} />}
@@ -403,7 +405,7 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
           </div>
         )}
 
-        <div ref={bottomRef} style={{ height: 1 }} />
+
       </div>
 
       {/* ── Gradient fade above input ── */}

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -356,7 +356,7 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
           display: 'flex',
           flexDirection: 'column',
           padding: '24px 0 0',
-          paddingBottom: 220,
+          paddingBottom: 220, // clears the absolutely-positioned input overlay (max textarea ≈188px + 24px pad)
         }}
       >
         {showEmpty && <EmptyState onStarterClick={handleStarterClick} />}
@@ -404,7 +404,6 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
             )}
           </div>
         )}
-
 
       </div>
 

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -336,8 +336,6 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
   const showMessages = !loading && !error && !showEmpty
   const showSkeleton = loading && !showEmpty
 
-  const showStreamingBubble = isStreaming
-
   return (
     <div style={{
       display: 'flex',
@@ -386,7 +384,7 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
             )}
 
             {/* Streaming assistant bubble */}
-            {showStreamingBubble && (
+            {isStreaming && (
               <Message
                 role="assistant"
                 content={streamingContent}


### PR DESCRIPTION
## Summary

- `scrollToBottom` was using `scrollIntoView({ block: 'end' })` on a 1px sentinel element, which positioned the sentinel at the bottom edge of the viewport — behind the absolutely-positioned chat input overlay
- Messages sent and streaming responses were hidden beneath the input bar; at stream end the view appeared to snap back to the user message
- Fixed by switching to `scrollContainerRef.current.scrollTo({ top: scrollHeight })`, which scrolls the container to its maximum position and makes the `paddingBottom` clearance visible
- Removed the now-dead `bottomRef` ref and sentinel `<div>`
- Increased `paddingBottom` from 140px to 220px to ensure clearance when the textarea is at max height (6 lines ≈ 188px overlay)

## Changes

- `app/frontend/src/components/ChatArea.tsx` (+6/-4)
  - `scrollToBottom`: replace `bottomRef.current.scrollIntoView(...)` with `el.scrollTo({ top: el.scrollHeight, behavior })`
  - Remove `const bottomRef = useRef<HTMLDivElement>(null)` declaration
  - Remove `<div ref={bottomRef} style={{ height: 1 }} />` sentinel element
  - Increase scroll container `paddingBottom` from `140` to `220`

## Validation

| Check | Result |
|-------|--------|
| TypeScript / build (`npm run build`) | ✅ Pass |
| Lint | N/A (no lint script) |
| Tests | N/A (no test script) |

Build completed successfully with no type errors. Two pre-existing non-blocking warnings remain (Vite CJS deprecation notice, chunk size warning for `index-DWiVfvBR.js`).

## Manual verification steps

1. Send a message — view auto-scrolls to show the user message and streaming response
2. While streaming, view follows the growing response
3. When streaming completes, view stays at the assistant response (no snap-back)
4. Send a second message — view scrolls down correctly
5. Manually scroll up during streaming — auto-scroll pauses; scroll back to bottom to resume
6. Type a long message (up to 6 lines) — last messages remain visible above the expanded input

Fixes #7