### PR TITLE
Fix: Remove inaccurate seeding description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd app && ./start.sh
 cd app && start.bat
 ```
 
-This will set up the Python venv, install dependencies, seed the database with 10 sample videos, and start both servers.
+This will set up the Python venv, install dependencies, and start both servers.
 
 3. Open [http://localhost:5173](http://localhost:5173)
 


### PR DESCRIPTION
## Summary

- Removes the inaccurate claim that the `start.sh`/`start.bat` scripts seed the database with 10 sample videos
- The Quick Start section of the README stated: *"This will set up the Python venv, install dependencies, seed the database with 10 sample videos, and start both servers."* — the seeding part was false
- Line 65 now accurately reads: *"This will set up the Python venv, install dependencies, and start both servers."*

## Changes

| File | Action | Details |
|------|--------|---------|
| `README.md` | Updated | Removed false "seed the database with 10 sample videos" claim from Quick Start section (line 65) |

## Validation

- Verified `grep "seed the database" README.md` returns no output (phrase fully removed)
- Lines 63–67 of README reviewed — surrounding context is intact and grammatically correct
- Frontend build (`npm run build`) passes: 1402 modules transformed, no type errors

## Notes

This is a pure documentation fix. No code, configuration, or functionality was changed.

Fixes #3