### PR TITLE
Fix: auto-scroll to bottom when switching conversations

### DIFF
--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -232,10 +232,14 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
   }, [messages.length, streamingContent, scrollToBottom])
 
   useEffect(() => {
-    if (!loading && messages.length > 0) {
+    autoScrollRef.current = true
+  }, [conversationId])
+
+  useEffect(() => {
+    if (!loading && messages.length > 0 && autoScrollRef.current) {
       setTimeout(() => scrollToBottom('instant' as ScrollBehavior), 50)
     }
-  }, [loading, scrollToBottom]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [loading, messages.length, scrollToBottom])
 
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -239,7 +239,7 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
 
   useEffect(() => {
     if (!loading && messages.length > 0 && autoScrollRef.current) {
-      setTimeout(() => scrollToBottom('instant' as ScrollBehavior), 50)
+      setTimeout(() => scrollToBottom('instant'), 50)
     }
   }, [loading, messages.length, scrollToBottom])
 

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -231,6 +231,8 @@ export function ChatArea({ conversationId }: ChatAreaProps) {
     if (autoScrollRef.current) scrollToBottom()
   }, [messages.length, streamingContent, scrollToBottom])
 
+  // Must be declared before the load-complete effect below; React runs effects
+  // in declaration order, so this reset is guaranteed to fire first on conversationId change.
   useEffect(() => {
     autoScrollRef.current = true
   }, [conversationId])


### PR DESCRIPTION
## Summary

- When switching conversations, `autoScrollRef.current` was never reset to `true`, causing the scroll guard to silently block auto-scroll on every conversation load.
- The load-complete `useEffect` was missing `messages.length` from its dependency array (masked with `// eslint-disable-line`), creating a stale closure.
- Fix adds a new `useEffect` that resets `autoScrollRef.current = true` whenever `conversationId` changes, mirrors the existing pattern from `handleSend`, and corrects the dependency array.

## Changes

**`app/frontend/src/components/ChatArea.tsx`** (+6/-2)

1. Added a `useEffect` that resets `autoScrollRef.current = true` on every `conversationId` change, so each newly loaded conversation always auto-scrolls to the bottom.
2. Added `messages.length` to the load-complete `useEffect` dependency array, removing the stale closure and the `// eslint-disable-line react-hooks/exhaustive-deps` suppression.
3. Added `&& autoScrollRef.current` guard to the load-complete `useEffect` to prevent force-scrolling users who manually scrolled up during a slow load.

## Validation

| Check | Result |
|-------|--------|
| TypeScript (`tsc --noEmit` via `npm run build`) | ✅ Pass — no type errors |
| Lint | N/A — no ESLint config in project |
| Tests | N/A — no test setup in project |
| Build | ✅ Pass — compiled successfully |

### Manual verification steps

1. Open a conversation with many messages — confirm it auto-scrolls to bottom on load.
2. Scroll up in one conversation, then switch to another — confirm the new conversation scrolls to bottom.
3. Open a conversation, scroll up, send a new message — confirm it scrolls to bottom (existing `handleSend` behavior preserved).
4. Open a conversation, scroll up — confirm incoming streaming messages do NOT force-jump to bottom (existing `handleScroll` guard preserved).

Fixes #9