### PR TITLE
Fix: hide hamburger menu when sidebar is open on mobile

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -65,7 +65,7 @@ function ConversationPage() {
 }
 
 function LandingPage() {
-  return <AppLayout conversationId={undefined} />
+  return <AppLayout />
 }
 
 // ── Root app ─────────────────────────────────────────────────────

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -29,26 +29,28 @@ function AppLayout({ conversationId }: AppLayoutProps) {
       />
 
       <div className="main-area">
-        {/* Hamburger — visible only on mobile */}
-        <button
-          className="hamburger-btn"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open sidebar"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 18 18"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
+        {/* Hamburger — visible only on mobile when sidebar is closed */}
+        {!sidebarOpen && (
+          <button
+            className="hamburger-btn"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open sidebar"
           >
-            <line x1="2" y1="4.5" x2="16" y2="4.5" />
-            <line x1="2" y1="9"   x2="16" y2="9"   />
-            <line x1="2" y1="13.5" x2="16" y2="13.5" />
-          </svg>
-        </button>
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <line x1="2" y1="4.5" x2="16" y2="4.5" />
+              <line x1="2" y1="9"   x2="16" y2="9"   />
+              <line x1="2" y1="13.5" x2="16" y2="13.5" />
+            </svg>
+          </button>
+        )}
 
         <ChatArea conversationId={conversationId} />
       </div>


### PR DESCRIPTION
## Summary

- On mobile (≤767px), the hamburger menu button was rendered unconditionally, causing it to overlap the "New Chat" button in the sidebar when the sidebar was open
- Fixed by wrapping the hamburger `<button>` in a `{!sidebarOpen && (...)}` conditional in `app/frontend/src/App.tsx`, mirroring the pattern already used for the sidebar overlay element
- The hamburger reappears automatically when the sidebar closes (via overlay tap or conversation navigation), so no close button is needed in its place

## Changes

- `app/frontend/src/App.tsx`: wrapped hamburger `<button>` in `{!sidebarOpen && (...)}` conditional (+21/-19 lines net)

## Root Cause

The `{sidebarOpen && (...)}` guard was already applied to the `sidebar-overlay` div but was missing from the hamburger button. Both elements share `z-index: 20` on mobile, and the sidebar's "New Chat" button occupies the same top-left screen coordinates as the hamburger, causing the overlap.

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | ✅ Pass — no type errors |
| `npm run build` | ✅ Pass — compiled successfully |

Build warnings present (CJS deprecation, chunk size) are pre-existing and unrelated to this change.

## Edge Cases Verified

- Tapping overlay to close sidebar → hamburger reappears (overlay click calls `setSidebarOpen(false)`)
- Navigating to a conversation closes sidebar → hamburger reappears (`Sidebar.tsx` calls `onClose()`)
- Desktop layout (>767px) → hamburger already hidden via CSS `display: none`; conditional render is a no-op

Fixes #10