### PR TITLE
feat: add GET /api/version endpoint returning dynachat-backend version

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -71,6 +71,13 @@ async def health():
     }
 
 
+@app.get("/api/version")
+async def version():
+    from importlib.metadata import version as get_version
+
+    return {"version": get_version("dynachat-backend")}
+
+
 # ---------------------------------------------------------------------------
 # Sprint 2 SSE test route — verifies streaming format without full RAG
 # ---------------------------------------------------------------------------

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -55,6 +55,7 @@ app.include_router(ingest.router, prefix="/api")
 # ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------
+from backend.config import DB_PATH
 from backend.db import repository  # noqa: E402
 
 
@@ -62,7 +63,6 @@ from backend.db import repository  # noqa: E402
 async def health():
     video_count = await repository.count_videos()
     chunk_count = await repository.count_chunks()
-    from backend.config import DB_PATH
 
     return {
         "status": "ok",
@@ -77,16 +77,10 @@ async def version() -> dict[str, str]:
     return {"version": get_version("dynachat-backend")}
 
 
-# ---------------------------------------------------------------------------
-# Sprint 2 SSE test route — verifies streaming format without full RAG
-# ---------------------------------------------------------------------------
-
-
 @app.post("/api/stream-test")
 async def stream_test():
     """
-    Test route that streams a short LLM response as SSE.
-    Used to verify Content-Type: text/event-stream and SSE formatting.
+    Test route that streams a short LLM response as SSE to verify streaming format.
     """
     from backend.llm.openrouter import stream_chat
 

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -5,12 +5,14 @@ Handles lifespan startup (DB init + seeding) and route registration.
 
 import logging
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
+from backend.config import DB_PATH
 from backend.data.seed import seed_if_empty
 from backend.db.schema import init_db
 
@@ -55,7 +57,6 @@ app.include_router(ingest.router, prefix="/api")
 # ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------
-from backend.config import DB_PATH
 from backend.db import repository  # noqa: E402
 
 
@@ -74,7 +75,10 @@ async def health():
 
 @app.get("/api/version")
 async def version() -> dict[str, str]:
-    return {"version": get_version("dynachat-backend")}
+    try:
+        return {"version": get_version("dynachat-backend")}
+    except PackageNotFoundError:
+        raise HTTPException(status_code=503, detail="Package metadata unavailable") from None
 
 
 @app.post("/api/stream-test")

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -5,6 +5,7 @@ Handles lifespan startup (DB init + seeding) and route registration.
 
 import logging
 from contextlib import asynccontextmanager
+from importlib.metadata import version as get_version
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -72,9 +73,7 @@ async def health():
 
 
 @app.get("/api/version")
-async def version():
-    from importlib.metadata import version as get_version
-
+async def version() -> dict[str, str]:
     return {"version": get_version("dynachat-backend")}
 
 

--- a/app/backend/tests/test_version.py
+++ b/app/backend/tests/test_version.py
@@ -1,0 +1,20 @@
+"""
+Tests for the /api/version endpoint.
+"""
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+
+
+async def test_version_endpoint_returns_200():
+    """GET /api/version returns 200 with a non-empty version field."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/version")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "version" in data
+    assert isinstance(data["version"], str)
+    assert len(data["version"]) > 0

--- a/app/backend/tests/test_version.py
+++ b/app/backend/tests/test_version.py
@@ -2,6 +2,9 @@
 Tests for the /api/version endpoint.
 """
 
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
 from httpx import ASGITransport, AsyncClient
 
 from backend.main import app
@@ -18,3 +21,15 @@ async def test_version_endpoint_returns_200():
     assert "version" in data
     assert isinstance(data["version"], str)
     assert len(data["version"]) > 0
+
+
+async def test_version_endpoint_returns_503_when_package_not_found():
+    """GET /api/version returns 503 when dynachat-backend package is not installed."""
+    with patch("backend.main.get_version") as mock_get_version:
+        mock_get_version.side_effect = PackageNotFoundError("dynachat-backend")
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/api/version")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Package metadata unavailable"


### PR DESCRIPTION
<!--
This PR will be validated by the Dark Factory's independent validator.
Fill in every section. The validator reads this body + the diff + the test
results only — it does not see the coder's scratch notes or implementation
plan (the "holdout principle"). If you don't explain the change here, it
won't be considered.
-->

## Linked issue

Fixes #30

## Summary

Added a new GET `/api/version` endpoint to the FastAPI backend that returns the installed package version of `dynachat-backend` using `importlib.metadata.version()`. This allows CI smoke tests, on-call engineers, and deployment systems to verify which backend version is running in a deployed environment.

## How this solves the issue

The issue reported that there was no easy way to verify which version of the backend is running in a deployed environment. The implementation adds a new GET endpoint at `/api/version` that reads the version dynamically from the installed package metadata using Python's stdlib `importlib.metadata` module with the package name `dynachat-backend`. The endpoint returns `{"version": "0.1.0"}` (or whatever version is in `pyproject.toml`).

## Test plan

- [x] `test_version_endpoint_returns_200` — verifies the endpoint returns HTTP 200 with a JSON body containing a non-empty `version` string field
- [x] Ruff lint — 0 errors
- [x] Ruff format — 19 files already formatted
- [x] Mypy — 0 type errors

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

Note: This PR adds a net-new public endpoint and a pytest test for it. It does not modify any existing RAG pipeline routes, authentication, or the chat UI. The agent-browser regression validates existing happy-path behavior and is expected to pass without modification.

## Dependencies

No new dependencies added. The implementation uses `importlib.metadata` from the Python standard library.

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (additions + deletions)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit