### PR TITLE
feat(rag): add in-memory embedding cache with ingest invalidation

### DIFF
--- a/app/backend/rag/retriever.py
+++ b/app/backend/rag/retriever.py
@@ -58,17 +58,10 @@ async def retrieve(
         all_chunks_loaded = await repository.list_chunks()
         if not all_chunks_loaded:
             return []
-        try:
-            candidate_matrix = np.array(
-                [chunk["embedding"] for chunk in all_chunks_loaded], dtype=np.float32
-            )  # shape: (N, D)
-        except Exception:
-            # Leave globals as None so next call retries cleanly
-            _cached_chunks = None
-            _cached_matrix = None
-            raise
+        _cached_matrix = np.array(
+            [chunk["embedding"] for chunk in all_chunks_loaded], dtype=np.float32
+        )  # shape: (N, D)
         _cached_chunks = all_chunks_loaded
-        _cached_matrix = candidate_matrix
         logger.info("Embedding cache populated: %d chunks", len(_cached_chunks))
 
     assert _cached_chunks is not None

--- a/app/backend/rag/retriever.py
+++ b/app/backend/rag/retriever.py
@@ -16,6 +16,21 @@ from backend.db import repository
 
 logger = logging.getLogger(__name__)
 
+_cached_chunks: list[dict] | None = None
+_cached_matrix: np.ndarray | None = None
+
+
+def invalidate_embedding_cache() -> None:
+    """Clear the in-memory embedding cache.
+
+    Call this after new chunks are written to the DB so the next
+    call to retrieve() reloads from the updated database.
+    """
+    global _cached_chunks, _cached_matrix
+    _cached_chunks = None
+    _cached_matrix = None
+    logger.info("Embedding cache invalidated.")
+
 
 async def retrieve(
     query_embedding: list[float],
@@ -37,15 +52,20 @@ async def retrieve(
           - score: float (cosine similarity, -1.0 to 1.0)
         Sorted by score descending. Returns [] if the DB has no chunks.
     """
-    # Load all chunks from the DB (includes deserialized embeddings)
-    all_chunks = await repository.list_chunks()
-    if not all_chunks:
-        return []
+    global _cached_chunks, _cached_matrix
 
-    # Build the matrix of stored embeddings
-    chunk_embeddings = np.array(
-        [chunk["embedding"] for chunk in all_chunks], dtype=np.float32
-    )  # shape: (N, D)
+    if _cached_chunks is None or _cached_matrix is None:
+        all_chunks = await repository.list_chunks()
+        if not all_chunks:
+            return []
+        _cached_chunks = all_chunks
+        _cached_matrix = np.array(
+            [chunk["embedding"] for chunk in _cached_chunks], dtype=np.float32
+        )  # shape: (N, D)
+        logger.info("Embedding cache populated: %d chunks", len(_cached_chunks))
+
+    all_chunks = _cached_chunks
+    chunk_embeddings = _cached_matrix
 
     query_vec = np.array(query_embedding, dtype=np.float32)  # shape: (D,)
 

--- a/app/backend/rag/retriever.py
+++ b/app/backend/rag/retriever.py
@@ -55,15 +55,24 @@ async def retrieve(
     global _cached_chunks, _cached_matrix
 
     if _cached_chunks is None or _cached_matrix is None:
-        all_chunks = await repository.list_chunks()
-        if not all_chunks:
+        all_chunks_loaded = await repository.list_chunks()
+        if not all_chunks_loaded:
             return []
-        _cached_chunks = all_chunks
-        _cached_matrix = np.array(
-            [chunk["embedding"] for chunk in _cached_chunks], dtype=np.float32
-        )  # shape: (N, D)
+        try:
+            candidate_matrix = np.array(
+                [chunk["embedding"] for chunk in all_chunks_loaded], dtype=np.float32
+            )  # shape: (N, D)
+        except Exception:
+            # Leave globals as None so next call retries cleanly
+            _cached_chunks = None
+            _cached_matrix = None
+            raise
+        _cached_chunks = all_chunks_loaded
+        _cached_matrix = candidate_matrix
         logger.info("Embedding cache populated: %d chunks", len(_cached_chunks))
 
+    assert _cached_chunks is not None
+    assert _cached_matrix is not None
     all_chunks = _cached_chunks
     chunk_embeddings = _cached_matrix
 

--- a/app/backend/routes/ingest.py
+++ b/app/backend/routes/ingest.py
@@ -17,6 +17,7 @@ from pydantic import AnyUrl, BaseModel, Field, field_validator
 from backend.db import repository
 from backend.rag.chunker import chunk_video
 from backend.rag.embeddings import embed_batch
+from backend.rag.retriever import invalidate_embedding_cache
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,8 @@ async def ingest_video(body: IngestRequest) -> IngestResponse:
         )
 
     logger.info("Ingestion complete for '%s': %d chunks stored", body.title, len(chunk_texts))
+
+    invalidate_embedding_cache()
 
     return IngestResponse(
         video_id=video_id,

--- a/app/backend/tests/test_retriever_cache.py
+++ b/app/backend/tests/test_retriever_cache.py
@@ -1,0 +1,77 @@
+"""Regression tests for the in-memory embedding cache in retriever.py."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.rag import retriever
+
+
+FAKE_CHUNKS = [
+    {
+        "id": "chunk-1",
+        "video_id": "vid-1",
+        "content": "Hello world",
+        "embedding": [1.0, 0.0],
+        "chunk_index": 0,
+    },
+    {
+        "id": "chunk-2",
+        "video_id": "vid-1",
+        "content": "Goodbye world",
+        "embedding": [0.0, 1.0],
+        "chunk_index": 1,
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Ensure the module-level cache is clean before and after each test."""
+    retriever.invalidate_embedding_cache()
+    yield
+    retriever.invalidate_embedding_cache()
+
+
+async def test_cache_populated_on_first_retrieve():
+    """retrieve() loads from DB on first call and populates the cache."""
+    mock_get_video = AsyncMock(return_value={"title": "Test Video"})
+    with (
+        patch("backend.rag.retriever.repository.list_chunks", new=AsyncMock(return_value=FAKE_CHUNKS)),
+        patch("backend.rag.retriever.repository.get_video", new=mock_get_video),
+    ):
+        await retriever.retrieve([1.0, 0.0], k=1)
+
+    assert retriever._cached_chunks is not None
+    assert retriever._cached_matrix is not None
+    assert len(retriever._cached_chunks) == 2
+
+
+async def test_cache_not_reloaded_on_second_retrieve():
+    """retrieve() does NOT call list_chunks() again on second call (cache hit)."""
+    mock_list_chunks = AsyncMock(return_value=FAKE_CHUNKS)
+    mock_get_video = AsyncMock(return_value={"title": "Test Video"})
+    with (
+        patch("backend.rag.retriever.repository.list_chunks", new=mock_list_chunks),
+        patch("backend.rag.retriever.repository.get_video", new=mock_get_video),
+    ):
+        await retriever.retrieve([1.0, 0.0], k=1)
+        await retriever.retrieve([1.0, 0.0], k=1)
+
+    assert mock_list_chunks.call_count == 1
+
+
+async def test_cache_reloaded_after_invalidation():
+    """After invalidate_embedding_cache(), retrieve() calls list_chunks() again."""
+    mock_list_chunks = AsyncMock(return_value=FAKE_CHUNKS)
+    mock_get_video = AsyncMock(return_value={"title": "Test Video"})
+    with (
+        patch("backend.rag.retriever.repository.list_chunks", new=mock_list_chunks),
+        patch("backend.rag.retriever.repository.get_video", new=mock_get_video),
+    ):
+        await retriever.retrieve([1.0, 0.0], k=1)
+        retriever.invalidate_embedding_cache()
+        await retriever.retrieve([1.0, 0.0], k=1)
+
+    assert mock_list_chunks.call_count == 2

--- a/app/backend/tests/test_retriever_cache.py
+++ b/app/backend/tests/test_retriever_cache.py
@@ -64,6 +64,20 @@ async def test_cache_not_reloaded_on_second_retrieve():
     assert mock_list_chunks.call_count == 1
 
 
+async def test_empty_db_returns_empty_and_does_not_cache():
+    """retrieve() returns [] and leaves cache unpopulated when DB has no chunks."""
+    with patch(
+        "backend.rag.retriever.repository.list_chunks",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await retriever.retrieve([1.0, 0.0], k=5)
+
+    assert result == []
+    # Cache must remain cold so the next call re-queries the DB
+    assert retriever._cached_chunks is None
+    assert retriever._cached_matrix is None
+
+
 async def test_cache_reloaded_after_invalidation():
     """After invalidate_embedding_cache(), retrieve() calls list_chunks() again."""
     mock_list_chunks = AsyncMock(return_value=FAKE_CHUNKS)

--- a/app/backend/tests/test_retriever_cache.py
+++ b/app/backend/tests/test_retriever_cache.py
@@ -1,4 +1,5 @@
 """Regression tests for the in-memory embedding cache in retriever.py."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
@@ -6,7 +7,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from backend.rag import retriever
-
 
 FAKE_CHUNKS = [
     {
@@ -38,7 +38,9 @@ async def test_cache_populated_on_first_retrieve():
     """retrieve() loads from DB on first call and populates the cache."""
     mock_get_video = AsyncMock(return_value={"title": "Test Video"})
     with (
-        patch("backend.rag.retriever.repository.list_chunks", new=AsyncMock(return_value=FAKE_CHUNKS)),
+        patch(
+            "backend.rag.retriever.repository.list_chunks", new=AsyncMock(return_value=FAKE_CHUNKS)
+        ),
         patch("backend.rag.retriever.repository.get_video", new=mock_get_video),
     ):
         await retriever.retrieve([1.0, 0.0], k=1)


### PR DESCRIPTION
## Summary

- Adds a module-level in-memory embedding cache (`_cached_chunks`, `_cached_matrix`) to `rag/retriever.py` using the same lazy-init singleton pattern as `embeddings.py`
- `retrieve()` now skips the DB call on cache hits, loading from SQLite only on the first query or after ingest invalidation
- Exposes `invalidate_embedding_cache()` which `routes/ingest.py` calls after all chunks are stored, ensuring the next query sees fresh data
- Adds three regression tests verifying: cache is populated on first call, DB is not re-queried on subsequent calls, and cache is rebuilt after invalidation

Fixes #25

## Changes

| File | Action | Description |
|------|--------|-------------|
| `app/backend/rag/retriever.py` | Updated | Module-level cache vars + `invalidate_embedding_cache()` + cache-aware `retrieve()` |
| `app/backend/routes/ingest.py` | Updated | Calls `invalidate_embedding_cache()` after all chunks stored |
| `app/backend/tests/test_retriever_cache.py` | Created | 3 regression tests for cache behavior |

## Motivation

Every call to `retrieve()` previously loaded all chunk embeddings from SQLite, deserializing every JSON embedding and rebuilding the NumPy matrix from scratch. For a library with 10,000 chunks at 1536 dims, this is ~236 MB of JSON parsing discarded on every query. The same data is reloaded identically unless a new video is ingested.

## Validation

| Check | Result |
|-------|--------|
| `uv run ruff check .` | Pass (0 errors) |
| `uv run ruff format --check .` | Pass (0 errors) |
| `uv run mypy .` | Pass (0 issues in 20 source files) |
| `uv run pytest tests -xvs` | Pass (5/5 tests) |
| RAG invariants | All pass — no changes to chunker, embeddings model, retrieval algorithm, chat model, SSE format, or citations |

## Dependencies

No new dependencies. The cache uses `numpy` (already a project dependency) and Python built-ins only.