### PR TITLE
fix: make CORS origins configurable via CORS_ORIGINS env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,7 @@ All env var reads happen in `app/backend/config.py`. Add new variables there and
 | Variable | Required | Purpose |
 |---|---|---|
 | `OPENROUTER_API_KEY` | **yes** | Authenticates embeddings and chat completions to OpenRouter |
+| `CORS_ORIGINS` | no | Comma-separated list of allowed CORS origins (default: `http://localhost:{FRONTEND_PORT},http://127.0.0.1:{FRONTEND_PORT}`) |
 
 Everything else is currently hardcoded in `config.py` (model names, ports, chunk size, top-k). When adding configurability, add the constant to `config.py` with a sensible default:
 

--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -64,3 +64,10 @@ HYBRID_CHUNKER_MAX_TOKENS: int = 512
 # Server ports
 BACKEND_PORT: int = 8000
 FRONTEND_PORT: int = 5173
+
+# CORS — comma-separated list of allowed origins; defaults to localhost + frontend port
+_cors_raw: str = os.environ.get(
+    "CORS_ORIGINS",
+    f"http://localhost:{FRONTEND_PORT},http://127.0.0.1:{FRONTEND_PORT}",
+)
+CORS_ORIGINS: list[str] = [o.strip() for o in _cors_raw.split(",") if o.strip()]

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from backend.config import DB_PATH
+from backend.config import CORS_ORIGINS, DB_PATH
 from backend.data.seed import seed_if_empty
 from backend.db.schema import init_db
 
@@ -38,7 +38,7 @@ app = FastAPI(title="RAG YouTube Chat API", lifespan=lifespan)
 # Allow the Vite dev server to reach the API during development
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/backend/rag/retriever.py
+++ b/app/backend/rag/retriever.py
@@ -121,13 +121,15 @@ def _cosine_similarity_batch(
         return np.zeros(len(matrix), dtype=np.float32)
 
     # Normalize the query once
-    query_normalized = query / query_norm
+    query_normalized: np.ndarray = query / query_norm
 
     # Compute row norms for the matrix
-    matrix_norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    matrix_norms: np.ndarray = np.linalg.norm(matrix, axis=1, keepdims=True)
     # Avoid division by zero by clamping norms
-    matrix_norms = np.where(matrix_norms == 0, 1.0, matrix_norms)
-    matrix_normalized = matrix / matrix_norms
+    matrix_norms = np.where(matrix_norms == 0, np.float32(1.0), matrix_norms)
+    matrix_normalized: np.ndarray = matrix / matrix_norms
 
     # Dot product of normalized vectors = cosine similarity
-    return (matrix_normalized @ query_normalized).astype(np.float32)  # shape: (N,)
+    # Cast through np.asarray to satisfy mypy's ndarray return type inference
+    scores: np.ndarray = np.dot(matrix_normalized, query_normalized).astype(np.float32)
+    return scores  # shape: (N,)

--- a/app/backend/rag/retriever.py
+++ b/app/backend/rag/retriever.py
@@ -125,7 +125,7 @@ def _cosine_similarity_batch(
 
     # Compute row norms for the matrix
     matrix_norms: np.ndarray = np.linalg.norm(matrix, axis=1, keepdims=True)
-    # Avoid division by zero by clamping norms
+    # Avoid division by zero by clamping norms; cast to np.float32 for mypy
     matrix_norms = np.where(matrix_norms == 0, np.float32(1.0), matrix_norms)
     matrix_normalized: np.ndarray = matrix / matrix_norms
 

--- a/app/backend/tests/test_config.py
+++ b/app/backend/tests/test_config.py
@@ -1,0 +1,31 @@
+"""Tests for CORS_ORIGINS configuration parsing."""
+
+from backend.config import CORS_ORIGINS
+
+
+def test_default_cors_origins_includes_localhost():
+    """Default CORS_ORIGINS should include localhost with FRONTEND_PORT."""
+    assert "http://localhost:5173" in CORS_ORIGINS
+
+
+def test_default_cors_origins_includes_127():
+    """Default CORS_ORIGINS should include 127.0.0.1 with FRONTEND_PORT."""
+    assert "http://127.0.0.1:5173" in CORS_ORIGINS
+
+
+def test_custom_single_origin():
+    """Custom CORS_ORIGINS env var with single origin parses correctly."""
+    result = [o.strip() for o in "http://localhost:9999".split(",") if o.strip()]
+    assert result == ["http://localhost:9999"]
+
+
+def test_custom_multiple_origins():
+    """Custom CORS_ORIGINS env var with multiple origins parses correctly."""
+    result = [o.strip() for o in "http://localhost:9999,http://127.0.0.1:9999".split(",") if o.strip()]
+    assert result == ["http://localhost:9999", "http://127.0.0.1:9999"]
+
+
+def test_whitespace_ignored():
+    """Whitespace around origins is stripped."""
+    result = [o.strip() for o in "http://localhost:9999 ,  http://127.0.0.1:9999 ".split(",") if o.strip()]
+    assert result == ["http://localhost:9999", "http://127.0.0.1:9999"]

--- a/app/backend/tests/test_config.py
+++ b/app/backend/tests/test_config.py
@@ -21,11 +21,15 @@ def test_custom_single_origin():
 
 def test_custom_multiple_origins():
     """Custom CORS_ORIGINS env var with multiple origins parses correctly."""
-    result = [o.strip() for o in "http://localhost:9999,http://127.0.0.1:9999".split(",") if o.strip()]
+    result = [
+        o.strip() for o in "http://localhost:9999,http://127.0.0.1:9999".split(",") if o.strip()
+    ]
     assert result == ["http://localhost:9999", "http://127.0.0.1:9999"]
 
 
 def test_whitespace_ignored():
     """Whitespace around origins is stripped."""
-    result = [o.strip() for o in "http://localhost:9999 ,  http://127.0.0.1:9999 ".split(",") if o.strip()]
+    result = [
+        o.strip() for o in "http://localhost:9999 ,  http://127.0.0.1:9999 ".split(",") if o.strip()
+    ]
     assert result == ["http://localhost:9999", "http://127.0.0.1:9999"]

--- a/app/backend/tests/test_config.py
+++ b/app/backend/tests/test_config.py
@@ -1,35 +1,59 @@
 """Tests for CORS_ORIGINS configuration parsing."""
 
-from backend.config import CORS_ORIGINS
+import importlib
+
+import pytest
+
+from backend.config import CORS_ORIGINS as DEFAULT_CORS_ORIGINS
 
 
 def test_default_cors_origins_includes_localhost():
     """Default CORS_ORIGINS should include localhost with FRONTEND_PORT."""
-    assert "http://localhost:5173" in CORS_ORIGINS
+    assert "http://localhost:5173" in DEFAULT_CORS_ORIGINS
 
 
 def test_default_cors_origins_includes_127():
     """Default CORS_ORIGINS should include 127.0.0.1 with FRONTEND_PORT."""
-    assert "http://127.0.0.1:5173" in CORS_ORIGINS
+    assert "http://127.0.0.1:5173" in DEFAULT_CORS_ORIGINS
 
 
-def test_custom_single_origin():
+@pytest.fixture
+def reload_config_with_cors(monkeypatch):
+    """Patch CORS_ORIGINS env var and reload config to pick it up."""
+
+    def _do(cors_value: str):
+        monkeypatch.setenv("CORS_ORIGINS", cors_value)
+        import backend.config
+
+        importlib.reload(backend.config)
+        return backend.config.CORS_ORIGINS
+
+    yield _do
+    # Reload again to restore original state
+    import backend.config
+
+    importlib.reload(backend.config)
+
+
+def test_custom_single_origin(reload_config_with_cors):
     """Custom CORS_ORIGINS env var with single origin parses correctly."""
-    result = [o.strip() for o in "http://localhost:9999".split(",") if o.strip()]
+    result = reload_config_with_cors("http://localhost:9999")
     assert result == ["http://localhost:9999"]
 
 
-def test_custom_multiple_origins():
+def test_custom_multiple_origins(reload_config_with_cors):
     """Custom CORS_ORIGINS env var with multiple origins parses correctly."""
-    result = [
-        o.strip() for o in "http://localhost:9999,http://127.0.0.1:9999".split(",") if o.strip()
-    ]
+    result = reload_config_with_cors("http://localhost:9999,http://127.0.0.1:9999")
     assert result == ["http://localhost:9999", "http://127.0.0.1:9999"]
 
 
-def test_whitespace_ignored():
+def test_whitespace_ignored(reload_config_with_cors):
     """Whitespace around origins is stripped."""
-    result = [
-        o.strip() for o in "http://localhost:9999 ,  http://127.0.0.1:9999 ".split(",") if o.strip()
-    ]
+    result = reload_config_with_cors("http://localhost:9999 ,  http://127.0.0.1:9999 ")
     assert result == ["http://localhost:9999", "http://127.0.0.1:9999"]
+
+
+def test_empty_cors_origins_env_var(reload_config_with_cors):
+    """Empty CORS_ORIGINS env var results in empty list."""
+    result = reload_config_with_cors("")
+    assert result == []

--- a/app/backend/tests/test_cors_middleware.py
+++ b/app/backend/tests/test_cors_middleware.py
@@ -1,0 +1,64 @@
+"""Integration tests for CORS middleware configuration."""
+
+import importlib
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def reload_main_with_cors(monkeypatch):
+    """Patch CORS_ORIGINS env var and reload main+config to pick it up."""
+
+    def _do(cors_value: str):
+        monkeypatch.setenv("CORS_ORIGINS", cors_value)
+        import backend.config
+
+        importlib.reload(backend.config)
+        import backend.main
+
+        importlib.reload(backend.main)
+        return backend.main.app
+
+    yield _do
+    # Reload again to restore original state
+    import backend.config
+
+    importlib.reload(backend.config)
+    import backend.main
+
+    importlib.reload(backend.main)
+
+
+@pytest.mark.asyncio
+async def test_cors_middleware_uses_configured_origins(reload_main_with_cors):
+    """CORS headers reflect CORS_ORIGINS from config, not hardcoded values."""
+    app = reload_main_with_cors("http://localhost:9999,http://example.com")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.options(
+            "/api/health",
+            headers={
+                "Origin": "http://localhost:9999",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+    assert "http://localhost:9999" in response.headers.get("Access-Control-Allow-Origin", "")
+
+
+@pytest.mark.asyncio
+async def test_cors_middleware_rejects_unconfigured_origin(reload_main_with_cors):
+    """CORS headers do not include origins not in CORS_ORIGINS."""
+    app = reload_main_with_cors("http://localhost:9999,http://example.com")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.options(
+            "/api/health",
+            headers={
+                "Origin": "http://untrusted.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+    # Access-Control-Allow-Origin should not include untrusted.com
+    allowed_origin = response.headers.get("Access-Control-Allow-Origin", "")
+    assert "untrusted.com" not in allowed_origin


### PR DESCRIPTION
## Linked issue

Fixes #26

## Summary

Hardcoded `["http://localhost:5173"]` CORS origins in `main.py` caused API failures when the frontend ran on any port other than 5173. This change makes CORS origins configurable via the `CORS_ORIGINS` environment variable, defaulting to the previous hardcoded value for backward compatibility.

## How this solves the issue

The root cause was `CORSMiddleware` in `main.py` using a hardcoded `allow_origins=["http://localhost:5173"]`. When a user ran the frontend on a different port (e.g., 5175), the browser blocked all API responses with CORS errors, making the entire app unusable.

The fix:
1. Adds `CORS_ORIGINS` env var parsing in `config.py` — comma-separated list of origins, defaults to `"http://localhost:5173"`
2. Imports `CORS_ORIGINS` into `main.py` and replaces the hardcoded `allow_origins` value
3. Adds regression tests in `tests/test_config.py` covering single origin, multiple origins, and whitespace stripping

## Test plan

- [x] `uv run pytest tests/test_config.py -xvs` — tests CORS_ORIGINS parsing (single, multiple, whitespace)
- [x] `uv run mypy .` — passes (type annotations added to `rag/retriever.py` intermediate variables)
- [x] `uv run ruff check . && uv run ruff format --check .` — lint and format pass
- [ ] Full agent-browser happy-path regression (validator will run)

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

## Dependencies

No new dependencies added. This change only adds environment variable parsing using `python-dotenv` (already a dependency).

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (additions + deletions)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit