### PR TITLE
feat: add custom chat-bubble SVG favicon

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RAG YouTube Chat</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/app/frontend/public/favicon.svg
+++ b/app/frontend/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#6366f1"/>
+  <path d="M8 10c0-2.2 1.8-4 4-4h8c2.2 0 4 1.8 4 4v6c0 2.2-1.8 4-4 4h-2l-4 4v-4H10c-2.2 0-4-1.8-4-4V10z" fill="#ffffff"/>
+  <circle cx="12" cy="17" r="1.5" fill="#6366f1"/>
+  <circle cx="16" cy="17" r="1.5" fill="#6366f1"/>
+  <circle cx="20" cy="17" r="1.5" fill="#6366f1"/>
+</svg>


### PR DESCRIPTION
<!--
This PR will be validated by the Dark Factory's independent validator.
Fill in every section. The validator reads this body + the diff + the test
results only — it does not see the coder's scratch notes or implementation
plan (the \"holdout principle\"). If you don't explain the change here, it
won't be considered.
-->

## Linked issue

Fixes #44

## Summary

Added a custom chat-bubble SVG favicon to the frontend. The favicon is placed at `app/frontend/public/favicon.svg` and referenced in `app/frontend/index.html` via a `<link rel="icon">` tag, replacing the default browser favicon.

## How this solves the issue

The issue requested adding a favicon to the frontend. The implementation creates a custom chat-bubble SVG icon (a speech bubble with a small tail) at `app/frontend/public/favicon.svg` and updates `app/frontend/index.html` to reference it. This directly addresses the enhancement request.

## Test plan

- [x] Favicon file exists at `app/frontend/public/favicon.svg`
- [x] `index.html` references `/favicon.svg` correctly
- [x] Frontend `tsc --noEmit` passes (0 errors)
- [x] Frontend Biome check passes
- [x] Frontend Vitest tests pass (8 tests)

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

Note: This is a cosmetic change affecting only the favicon; the existing agent-browser regression suite covers the full happy path and will validate no regressions in streaming, citations, and the citation modal.

## Dependencies

<!-- No new dependencies added. -->

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (2 files changed, +8/-1 lines)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit

Files changed: `app/frontend/public/favicon.svg` (new), `app/frontend/index.html` (modified)