### PR TITLE
feat: containerize app with blue/green deploy

### DIFF
--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -20,7 +20,11 @@ logger = logging.getLogger(__name__)
 
 
 def _find_and_load_env() -> None:
-    """Search parent directories for .env and load it."""
+    """Search parent directories for .env and load it.
+
+    In containerized deploys there is no .env file on disk — env vars are
+    injected by docker-compose. Missing .env is therefore not an error.
+    """
     current = Path(__file__).resolve()
     # Try each parent directory up to the filesystem root
     for parent in current.parents:
@@ -29,13 +33,7 @@ def _find_and_load_env() -> None:
             load_dotenv(dotenv_path=candidate, override=False)
             logger.info(f"Loaded .env from {candidate}")
             return
-    # Fallback: try the standard absolute path mentioned in the spec
-    fallback = Path(__file__).resolve().parents[4] / ".env"
-    if fallback.exists():
-        load_dotenv(dotenv_path=fallback, override=False)
-        logger.info(f"Loaded .env from fallback {fallback}")
-    else:
-        print("WARNING: No .env file found in parent directories.", file=sys.stderr)
+    logger.info("No .env file found on disk; assuming env vars are injected (container deploy).")
 
 
 _find_and_load_env()
@@ -53,8 +51,10 @@ OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
 EMBEDDING_MODEL: str = "openai/text-embedding-3-small"
 CHAT_MODEL: str = "anthropic/claude-sonnet-4.6"
 
-# Database
-DB_PATH: Path = Path(__file__).resolve().parent / "data" / "chat.db"
+# Database — env-overridable so containerized deploys can point at a mounted volume.
+# Default preserves the existing local dev behaviour (app/backend/data/chat.db).
+_default_db_path = Path(__file__).resolve().parent / "data" / "chat.db"
+DB_PATH: Path = Path(os.environ.get("DB_PATH", str(_default_db_path)))
 DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 # RAG settings

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -4,13 +4,16 @@ Handles lifespan startup (DB init + seeding) and route registration.
 """
 
 import logging
+import os
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
+from fastapi.staticfiles import StaticFiles
 
 from backend.config import DB_PATH
 from backend.data.seed import seed_if_empty
@@ -100,3 +103,15 @@ async def stream_test():
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Frontend static assets (production only — Vite serves them in dev)
+#
+# When FRONTEND_DIST env var points at a built `dist/`, mount it at `/` so
+# FastAPI serves index.html + hashed JS/CSS from the same origin as `/api/*`.
+# This mount is registered LAST so the `/api/*` routes above take precedence.
+# ---------------------------------------------------------------------------
+_frontend_dist = os.environ.get("FRONTEND_DIST", "")
+if _frontend_dist and Path(_frontend_dist).is_dir():
+    app.mount("/", StaticFiles(directory=_frontend_dist, html=True), name="frontend")

--- a/deploy/.dockerignore
+++ b/deploy/.dockerignore
@@ -1,0 +1,52 @@
+# Stop build context from ballooning + shipping anything we shouldn't.
+# Paths are relative to the build context (the repo root).
+
+# Git / editor
+.git
+.gitignore
+.github
+.vscode
+.idea
+
+# Docs + governance (not needed in the image)
+*.md
+!app/backend/README.md
+FACTORY_RULES.md
+MISSION.md
+CLAUDE.md
+spec.md
+
+# Python
+**/__pycache__
+**/*.pyc
+**/.venv
+**/venv
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+
+# Node / frontend
+**/node_modules
+**/.vite
+app/frontend/dist
+
+# Local data + secrets — never leak these into an image layer
+**/.env
+**/.env.*
+app/backend/data/*.db
+app/backend/data/*.db-*
+
+# Archon / factory scaffolding (not needed at runtime)
+.archon
+.claude
+
+# Test output
+**/coverage
+**/.coverage
+**/htmlcov
+
+# Dev tooling
+.pre-commit-config.yaml
+
+# Deploy artefacts (we don't ship the deploy files inside the image)
+deploy

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -5,13 +5,9 @@
 chat.dynamous.ai {
     encode zstd gzip
 
-    # Backend API
-    handle /api/* {
-        reverse_proxy host.docker.internal:8000
-    }
-
-    # Frontend (Vite dev for now; swap to static build once app has Dockerfile)
-    handle {
-        reverse_proxy host.docker.internal:5173
-    }
+    # Which app container is live is decided by upstream.conf, which the
+    # deploy script (/opt/dynachat/deploy.sh) rewrites on each blue/green
+    # swap and then triggers a graceful `caddy reload`. FastAPI serves
+    # both /api/* and the built frontend static assets from the same origin.
+    import /etc/caddy/upstream.conf
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+#
+# DynaChat single-container image.
+#   Stage 1: build the frontend with bun.
+#   Stage 2: python runtime that serves FastAPI + the built frontend.
+#
+# Build context is the repo root (see deploy/docker-compose.yml → build.context: ..).
+
+# ----------------------------------------------------------------------------
+# Stage 1 — frontend build
+# ----------------------------------------------------------------------------
+FROM oven/bun:1.2-alpine AS frontend-build
+
+WORKDIR /src/frontend
+
+# Install deps first for better layer caching.
+COPY app/frontend/package.json app/frontend/bun.lock ./
+RUN bun install --frozen-lockfile
+
+# Now bring in the source and build.
+COPY app/frontend/ ./
+RUN bun run build
+# Output: /src/frontend/dist
+
+# ----------------------------------------------------------------------------
+# Stage 2 — backend runtime
+# ----------------------------------------------------------------------------
+FROM python:3.11-slim AS runtime
+
+# Pull in the uv binary (pinned).
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+# Minimal runtime deps. curl isn't strictly required (healthcheck uses urllib)
+# but is useful for in-container debugging.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root user. Create /app ownership BEFORE volume mounts so the named
+# volume inherits correct ownership on first creation.
+RUN groupadd --system --gid 1000 app \
+ && useradd --system --uid 1000 --gid app --home /app app
+
+WORKDIR /app
+
+# Install Python deps first (separate layer for cache).
+COPY --chown=app:app app/backend/pyproject.toml app/backend/uv.lock ./backend/
+RUN cd backend && uv sync --frozen --no-dev
+
+# Copy backend source.
+COPY --chown=app:app app/backend/ ./backend/
+
+# Pull the built frontend from stage 1 into /app/frontend/dist.
+COPY --from=frontend-build --chown=app:app /src/frontend/dist /app/frontend/dist
+
+# Data dir for SQLite (mounted as a named volume in compose so blue/green
+# swaps preserve state).
+RUN mkdir -p /app/data && chown -R app:app /app
+
+USER app
+
+# Container serves FastAPI which in turn serves /api + static frontend.
+ENV DB_PATH=/app/data/chat.db \
+    FRONTEND_DIST=/app/frontend/dist \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+# Healthcheck hits /api/health (which does a DB query, so it validates the
+# app is truly ready — not just that the process started).
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=3).status == 200 else 1)" || exit 1
+
+# Run from /app so the `backend.main:app` module path resolves.
+CMD ["uv", "--project", "backend", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,10 +8,11 @@ services:
       - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./upstream.conf:/etc/caddy/upstream.conf:ro
       - caddy_data:/data
       - caddy_config:/config
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    # No extra_hosts — the app now lives in-network and is reachable by
+    # service name (app-blue / app-green). upstream.conf switches between them.
 
   postgres:
     image: pgvector/pgvector:pg16
@@ -31,7 +32,67 @@ services:
       timeout: 5s
       retries: 5
 
+  # ---- Blue/green app services --------------------------------------------
+  # Identical except for name. /opt/dynachat/deploy.sh rebuilds the inactive
+  # color, waits for its healthcheck, then rewrites upstream.conf and does a
+  # graceful `caddy reload` to swap. Neither publishes a host port — Caddy
+  # reaches them via the internal docker network by service name.
+  #
+  # Both mount the same named volume (app_data) for the SQLite DB so the
+  # swap preserves state. Brief overlap during swap is fine — SQLite WAL
+  # handles low-volume concurrent access.
+  app-blue:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    image: dynachat-app:latest
+    container_name: dynachat-app-blue
+    restart: unless-stopped
+    environment:
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      SUPADATA_API_KEY: ${SUPADATA_API_KEY:-}
+      DB_PATH: /app/data/chat.db
+      FRONTEND_DIST: /app/frontend/dist
+    volumes:
+      - app_data:/app/data
+    healthcheck:
+      test:
+        - "CMD"
+        - "python"
+        - "-c"
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=3).status == 200 else 1)"
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 5
+
+  app-green:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    image: dynachat-app:latest
+    container_name: dynachat-app-green
+    restart: unless-stopped
+    environment:
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      SUPADATA_API_KEY: ${SUPADATA_API_KEY:-}
+      DB_PATH: /app/data/chat.db
+      FRONTEND_DIST: /app/frontend/dist
+    volumes:
+      - app_data:/app/data
+    healthcheck:
+      test:
+        - "CMD"
+        - "python"
+        - "-c"
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=3).status == 200 else 1)"
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 5
+
 volumes:
   caddy_data:
   caddy_config:
   postgres_data:
+  app_data:

--- a/deploy/upstream.conf
+++ b/deploy/upstream.conf
@@ -1,0 +1,1 @@
+reverse_proxy app-blue:8000


### PR DESCRIPTION
## Summary

Fixes #48 — containerizes the DynaChat app with zero-downtime blue/green deploys on the prod VPS.

- Multi-stage `deploy/Dockerfile` (bun builds frontend → python runtime serves both)
- `deploy/docker-compose.yml` adds `app-blue` + `app-green` (identical except name)
- Caddyfile imports `upstream.conf`; the deploy script on the VPS rewrites it on each swap and triggers a graceful reload
- SQLite DB is mounted on a shared named volume so state survives swaps
- Minimal backend changes: env-configurable `DB_PATH`, gated StaticFiles mount, bug-fix for missing-\`.env\` in container

## Test plan

- [x] `docker compose --env-file .../.env -f deploy/docker-compose.yml config` parses cleanly
- [x] `docker build -f deploy/Dockerfile .` builds end-to-end (bun + uv layers)
- [x] Container smoke test (local): `/api/health` → 200, `/` → 200 (static served by FastAPI), `Health.Status` → `healthy`
- [ ] VPS first-deploy: `/opt/dynachat/deploy.sh` picks up merge, creates `upstream.conf` if missing, starts `app-blue`, waits for healthy, reloads Caddy
- [ ] `curl -sI https://chat.dynamous.ai/` → 200 (not 502)
- [ ] `systemctl enable --now dynachat-deploy.timer` (human step after first green deploy)

## Manual bootstrap (not factory-handled)

Per `CLAUDE.md` → *What the factory must never do*: `/opt/dynachat/deploy.sh`, systemd units, and `/opt/dynachat/.env` are not in this repo. The deploy infrastructure is already in place on the VPS and currently disabled. After this merges, a human runs the deploy once manually to verify, then enables the timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)