### PR TITLE
feat: email+password auth with Postgres-backed users (#51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,3 +461,19 @@ These are existing bugs / quirks in the repo. They are fair game for the factory
 - Write SQL outside `db/repository.py` or fetch calls outside `src/lib/api.ts`
 - Use SQLite-specific SQL functions — anything written today must work on Postgres tomorrow
 - "Improve" code that wasn't part of the issue you're fixing — scope discipline is enforced by the validator
+
+---
+
+## Protected paths (factory auto-rejects PRs touching these)
+
+The following files implement or gate security invariants from `MISSION.md` §10.
+Any PR touching them must be human-authored:
+
+- `app/backend/auth/` (entire directory)
+- `app/backend/routes/auth.py`
+- `app/backend/db/users_repo.py`
+- `app/backend/main.py` — auth router registration and `Depends(get_current_user)` wiring
+- `app/backend/config.py` — `JWT_SECRET` / `DATABASE_URL` handling
+- CORS middleware configuration anywhere in the backend
+
+(The 25 msg/user/24h rate-limit issue will extend this list with its own paths.)

--- a/app/backend/auth/__init__.py
+++ b/app/backend/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication package — password hashing, JWT tokens, FastAPI dependencies."""

--- a/app/backend/auth/dependencies.py
+++ b/app/backend/auth/dependencies.py
@@ -1,0 +1,41 @@
+"""
+FastAPI dependencies for authenticated routes.
+
+Usage:
+    @router.post("/foo")
+    async def foo(user: dict = Depends(get_current_user)):
+        ...
+
+Any protected route returns 401 automatically when the cookie is missing,
+malformed, expired, or references a deleted user.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Cookie, HTTPException, status
+
+from backend.auth.tokens import TokenError, decode_token
+from backend.db import users_repo
+
+COOKIE_NAME = "session"
+
+
+async def get_current_user(session: str | None = Cookie(default=None)) -> dict[str, Any]:
+    """Resolve the session cookie to a user row. 401 on any failure."""
+    if not session:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    try:
+        payload = decode_token(session)
+    except TokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Malformed token")
+    user = await users_repo.get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User no longer exists"
+        )
+    return user

--- a/app/backend/auth/password.py
+++ b/app/backend/auth/password.py
@@ -1,0 +1,27 @@
+"""
+Password hashing using bcrypt directly.
+
+bcrypt cost = 12 rounds (issue #51 design decision). Increase only via a new
+MISSION-reviewed PR since hash cost is a security parameter.
+"""
+
+from __future__ import annotations
+
+import bcrypt
+
+BCRYPT_ROUNDS = 12
+
+
+def hash_password(plaintext: str) -> str:
+    """Hash a plaintext password with bcrypt. Returns UTF-8 string for DB storage."""
+    salt = bcrypt.gensalt(rounds=BCRYPT_ROUNDS)
+    return bcrypt.hashpw(plaintext.encode("utf-8"), salt).decode("utf-8")
+
+
+def verify_password(plaintext: str, password_hash: str) -> bool:
+    """Constant-time verify of plaintext against a stored bcrypt hash."""
+    try:
+        return bcrypt.checkpw(plaintext.encode("utf-8"), password_hash.encode("utf-8"))
+    except ValueError:
+        # Malformed hash — treat as failed verification, not an error.
+        return False

--- a/app/backend/auth/tokens.py
+++ b/app/backend/auth/tokens.py
@@ -1,0 +1,46 @@
+"""
+JWT encode / decode.
+
+Token shape:
+    {"sub": "<user_uuid>", "iat": <epoch>, "exp": <epoch + 7 days>}
+
+Signed with HS256 + JWT_SECRET. Rotated on every login (new iat/exp each time).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import jwt
+
+from backend.config import JWT_ALGORITHM, JWT_EXPIRY_SECONDS, JWT_SECRET
+
+
+class TokenError(Exception):
+    """Raised when a token is missing, malformed, expired, or signed with a bad secret."""
+
+
+def encode_token(user_id: str) -> str:
+    """Create a signed JWT for the given user UUID."""
+    if not JWT_SECRET:
+        raise RuntimeError("JWT_SECRET is not configured; refusing to mint tokens.")
+    now = int(time.time())
+    payload = {
+        "sub": user_id,
+        "iat": now,
+        "exp": now + JWT_EXPIRY_SECONDS,
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def decode_token(token: str) -> dict[str, Any]:
+    """Verify signature + expiry and return the decoded payload. Raises TokenError on failure."""
+    if not JWT_SECRET:
+        raise TokenError("JWT_SECRET is not configured")
+    try:
+        return jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except jwt.ExpiredSignatureError as exc:
+        raise TokenError("Token expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise TokenError("Invalid token") from exc

--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -57,6 +57,23 @@ _default_db_path = Path(__file__).resolve().parent / "data" / "chat.db"
 DB_PATH: Path = Path(os.environ.get("DB_PATH", str(_default_db_path)))
 DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
+# Postgres — required in prod for auth/users. Absent locally means auth endpoints
+# will fail on first DB call; pick one of the existing chat routes for local dev.
+DATABASE_URL: str = os.environ.get("DATABASE_URL", "")
+
+# JWT signing secret. Required whenever auth is active. 32+ random bytes in prod.
+# A local dev value is used only when JWT_SECRET is unset AND DATABASE_URL is unset
+# (i.e. auth-off local mode). In any environment with DATABASE_URL set, the real
+# secret must come from the environment.
+JWT_SECRET: str = os.environ.get("JWT_SECRET", "")
+if not JWT_SECRET and DATABASE_URL:
+    print(
+        "WARNING: DATABASE_URL is set but JWT_SECRET is not. Authentication will fail.",
+        file=sys.stderr,
+    )
+JWT_ALGORITHM: str = "HS256"
+JWT_EXPIRY_SECONDS: int = 7 * 24 * 60 * 60  # 7 days
+
 # RAG settings
 RETRIEVAL_TOP_K: int = 5
 HYBRID_CHUNKER_MAX_TOKENS: int = 512

--- a/app/backend/db/postgres.py
+++ b/app/backend/db/postgres.py
@@ -1,0 +1,85 @@
+"""
+Async Postgres connection pool and schema bootstrap.
+
+Used for new tables landing in Postgres (starting with `users`). Existing chat
+tables remain in SQLite for now — see CLAUDE.md "Planned migration: Postgres".
+
+The pool is a module-level singleton created in the FastAPI lifespan handler;
+routes and repos fetch it via `get_pg_pool()`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+from backend.config import DATABASE_URL
+
+logger = logging.getLogger(__name__)
+
+_pool: asyncpg.Pool | None = None
+
+
+USERS_SCHEMA = """
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email CITEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_login_at TIMESTAMPTZ,
+    daily_message_count INTEGER NOT NULL DEFAULT 0,
+    rate_window_start TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS users_email_idx ON users (email);
+"""
+
+
+async def init_pg_pool() -> asyncpg.Pool:
+    """Create the asyncpg pool if not already created. Idempotent."""
+    global _pool
+    if _pool is not None:
+        return _pool
+    if not DATABASE_URL:
+        raise RuntimeError(
+            "DATABASE_URL is not set; cannot initialise Postgres pool. "
+            "Auth-required features are disabled in this environment."
+        )
+    logger.info("Connecting to Postgres…")
+    _pool = await asyncpg.create_pool(
+        dsn=DATABASE_URL,
+        min_size=1,
+        max_size=10,
+    )
+    logger.info("Postgres pool ready.")
+    return _pool
+
+
+async def close_pg_pool() -> None:
+    """Close the pool on shutdown. Idempotent."""
+    global _pool
+    if _pool is not None:
+        await _pool.close()
+        _pool = None
+
+
+def get_pg_pool() -> asyncpg.Pool:
+    """Return the live pool. Raises if `init_pg_pool` was not called."""
+    if _pool is None:
+        raise RuntimeError(
+            "Postgres pool is not initialised. Call init_pg_pool() in the "
+            "FastAPI lifespan before using any Postgres-backed repository."
+        )
+    return _pool
+
+
+async def init_users_schema() -> None:
+    """Run the users-table migration. Idempotent via CREATE ... IF NOT EXISTS."""
+    pool = await init_pg_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(USERS_SCHEMA)
+    logger.info("Users schema ready.")

--- a/app/backend/db/users_repo.py
+++ b/app/backend/db/users_repo.py
@@ -1,0 +1,70 @@
+"""
+Users repository — all raw SQL for the `users` Postgres table lives here.
+
+Mirrors the aiosqlite repository.py pattern: no ORM, parameterised queries
+via asyncpg's `$1`/`$2` placeholders, one function per operation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from backend.db.postgres import get_pg_pool
+
+
+async def create_user(email: str, password_hash: str) -> dict[str, Any]:
+    """Insert a new user. Raises asyncpg.UniqueViolationError on duplicate email."""
+    pool = get_pg_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO users (email, password_hash)
+            VALUES ($1, $2)
+            RETURNING id, email, created_at, last_login_at
+            """,
+            email,
+            password_hash,
+        )
+    assert row is not None  # RETURNING always yields a row on successful INSERT
+    return dict(row)
+
+
+async def get_user_by_email(email: str) -> dict[str, Any] | None:
+    """Fetch user by email (case-insensitive via CITEXT). Returns None if missing."""
+    pool = get_pg_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, email, password_hash, created_at, last_login_at
+            FROM users
+            WHERE email = $1
+            """,
+            email,
+        )
+    return dict(row) if row else None
+
+
+async def get_user_by_id(user_id: UUID | str) -> dict[str, Any] | None:
+    """Fetch user by UUID. Returns None if missing."""
+    pool = get_pg_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, email, created_at, last_login_at
+            FROM users
+            WHERE id = $1
+            """,
+            UUID(str(user_id)) if not isinstance(user_id, UUID) else user_id,
+        )
+    return dict(row) if row else None
+
+
+async def update_last_login(user_id: UUID | str) -> None:
+    """Stamp last_login_at = now() for a successful login."""
+    pool = get_pg_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE users SET last_login_at = now() WHERE id = $1",
+            UUID(str(user_id)) if not isinstance(user_id, UUID) else user_id,
+        )

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -10,13 +10,15 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from backend.config import DB_PATH
+from backend.auth.dependencies import get_current_user
+from backend.config import DATABASE_URL, DB_PATH
 from backend.data.seed import seed_if_empty
+from backend.db.postgres import close_pg_pool, init_users_schema
 from backend.db.schema import init_db
 
 logging.basicConfig(level=logging.INFO)
@@ -25,15 +27,21 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Startup: initialise DB tables, then seed if empty."""
+    """Startup: initialise DB tables (SQLite + Postgres), then seed if empty."""
     logger.info("Starting up — initialising database…")
     await init_db()
+    if DATABASE_URL:
+        logger.info("DATABASE_URL set — initialising Postgres users schema…")
+        await init_users_schema()
+    else:
+        logger.warning("DATABASE_URL not set; auth endpoints will fail until configured.")
     logger.info("Database ready. Checking seed data…")
     await seed_if_empty()
     logger.info("Startup complete.")
     yield
-    # Shutdown (nothing to clean up for SQLite)
     logger.info("Shutting down.")
+    if DATABASE_URL:
+        await close_pg_pool()
 
 
 app = FastAPI(title="RAG YouTube Chat API", lifespan=lifespan)
@@ -50,11 +58,18 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routes (imported here to keep main.py clean)
 # ---------------------------------------------------------------------------
-from backend.routes import conversations, ingest, messages  # noqa: E402
+from backend.routes import auth, conversations, ingest, messages  # noqa: E402
 
-app.include_router(conversations.router, prefix="/api")
-app.include_router(messages.router, prefix="/api")
-app.include_router(ingest.router, prefix="/api")
+# Auth routes are public (signup/login don't require a session; /me and /logout
+# rely on their own dependency/cookie behaviour).
+app.include_router(auth.router, prefix="/api")
+
+# All other API routes require authentication — MISSION.md §10 invariant:
+# "All chat access requires authentication — there is no anonymous mode."
+_auth_required = [Depends(get_current_user)]
+app.include_router(conversations.router, prefix="/api", dependencies=_auth_required)
+app.include_router(messages.router, prefix="/api", dependencies=_auth_required)
+app.include_router(ingest.router, prefix="/api", dependencies=_auth_required)
 
 
 # ---------------------------------------------------------------------------

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "fastapi",
     "uvicorn[standard]",
     "aiosqlite",
+    "asyncpg",
     "httpx",
     "python-dotenv",
     "openai",
@@ -31,6 +32,9 @@ dependencies = [
     # matching our text-embedding-3-small pipeline without any HF round-trip.
     "docling-core[chunking,chunking-openai]",
     "numpy",
+    "bcrypt",
+    "pyjwt",
+    "email-validator",
 ]
 
 [project.optional-dependencies]

--- a/app/backend/routes/auth.py
+++ b/app/backend/routes/auth.py
@@ -1,0 +1,99 @@
+"""
+Auth routes — signup, login, logout, me.
+
+Session is an httpOnly + Secure + SameSite=Lax cookie named `session` carrying
+a JWT signed with `JWT_SECRET`. The same-origin prod deployment means no CORS
+gymnastics are required (see CLAUDE.md "Deployment").
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, EmailStr, Field
+
+from backend.auth.dependencies import COOKIE_NAME, get_current_user
+from backend.auth.password import hash_password, verify_password
+from backend.auth.tokens import encode_token
+from backend.config import JWT_EXPIRY_SECONDS
+from backend.db import users_repo
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=8, max_length=128)
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=1, max_length=128)
+
+
+class UserResponse(BaseModel):
+    id: str
+    email: str
+
+
+def _set_session_cookie(response: Response, user_id: str) -> None:
+    """Mint a JWT and attach it to the response as an httpOnly session cookie."""
+    token = encode_token(user_id)
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=token,
+        max_age=JWT_EXPIRY_SECONDS,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        path="/",
+    )
+
+
+def _user_to_response(user: dict[str, Any]) -> UserResponse:
+    return UserResponse(id=str(user["id"]), email=str(user["email"]))
+
+
+@router.post("/signup", status_code=status.HTTP_201_CREATED, response_model=UserResponse)
+async def signup(body: SignupRequest, response: Response) -> UserResponse:
+    """Create a user, set session cookie, return {id, email}. 409 on duplicate email."""
+    password_hash = hash_password(body.password)
+    try:
+        user = await users_repo.create_user(email=body.email, password_hash=password_hash)
+    except asyncpg.UniqueViolationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Email already registered"
+        ) from exc
+    _set_session_cookie(response, str(user["id"]))
+    return _user_to_response(user)
+
+
+@router.post("/login", response_model=UserResponse)
+async def login(body: LoginRequest, response: Response) -> UserResponse:
+    """Verify credentials and rotate session cookie. 401 on any failure."""
+    user = await users_repo.get_user_by_email(body.email)
+    if not user or not verify_password(body.password, user["password_hash"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password"
+        )
+    await users_repo.update_last_login(user["id"])
+    _set_session_cookie(response, str(user["id"]))
+    return _user_to_response(user)
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(response: Response) -> Response:
+    """Clear the session cookie. Always 204 — idempotent."""
+    response.delete_cookie(key=COOKIE_NAME, path="/")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/me", response_model=UserResponse)
+async def me(user: dict[str, Any] = Depends(get_current_user)) -> UserResponse:
+    """Return the currently-authenticated user, or 401."""
+    return _user_to_response(user)

--- a/app/backend/tests/conftest.py
+++ b/app/backend/tests/conftest.py
@@ -8,6 +8,12 @@ Conventions (see CLAUDE.md §Testing):
   database per-test via the `tmp_path` fixture.
 """
 
+import os
+
+# Set auth-related env vars BEFORE any backend import so config.py picks them up.
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
 import pytest
 
 import backend.rag.retriever as retriever_module

--- a/app/backend/tests/test_auth.py
+++ b/app/backend/tests/test_auth.py
@@ -1,0 +1,249 @@
+"""
+Integration tests for auth endpoints and protected-route gating.
+
+Postgres is mocked at the repository boundary (see CLAUDE.md "Testing external
+APIs") — users_repo functions hit an in-memory dict so the tests stay
+hermetic. The pg pool lifecycle is stubbed to no-ops.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Set secrets BEFORE importing the app so config.py picks them up.
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+
+@pytest.fixture(autouse=True)
+def fake_users_repo(monkeypatch):
+    """Replace Postgres-backed users_repo with an in-memory dict."""
+    store: dict[str, dict[str, Any]] = {}
+
+    async def create_user(email: str, password_hash: str) -> dict[str, Any]:
+        import asyncpg
+
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                raise asyncpg.UniqueViolationError("duplicate email")
+        uid = str(uuid4())
+        row = {
+            "id": uid,
+            "email": email,
+            "password_hash": password_hash,
+            "created_at": None,
+            "last_login_at": None,
+        }
+        store[uid] = row
+        return {k: v for k, v in row.items() if k != "password_hash"}
+
+    async def get_user_by_email(email: str) -> dict[str, Any] | None:
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                return dict(u)
+        return None
+
+    async def get_user_by_id(user_id: Any) -> dict[str, Any] | None:
+        u = store.get(str(user_id))
+        if not u:
+            return None
+        return {k: v for k, v in u.items() if k != "password_hash"}
+
+    async def update_last_login(user_id: Any) -> None:
+        u = store.get(str(user_id))
+        if u:
+            u["last_login_at"] = "now"
+
+    from backend.db import users_repo
+
+    monkeypatch.setattr(users_repo, "create_user", create_user)
+    monkeypatch.setattr(users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(users_repo, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(users_repo, "update_last_login", update_last_login)
+
+    # Patch auth.dependencies.users_repo.get_user_by_id too — it's imported as
+    # `from backend.db import users_repo` so the module-level name is aliased.
+    from backend.auth import dependencies as auth_deps
+
+    monkeypatch.setattr(auth_deps.users_repo, "get_user_by_id", get_user_by_id)
+
+    # Also patch routes.auth which imports users_repo the same way.
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(auth_route.users_repo, "create_user", create_user)
+    monkeypatch.setattr(auth_route.users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(auth_route.users_repo, "update_last_login", update_last_login)
+
+    return store
+
+
+@pytest.fixture(autouse=True)
+def stub_pg_lifecycle(monkeypatch):
+    """The FastAPI lifespan calls init_users_schema + close_pg_pool — no-op both."""
+    from backend.db import postgres as pg
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(pg, "init_users_schema", noop)
+    monkeypatch.setattr(pg, "close_pg_pool", noop)
+
+
+@pytest.fixture
+async def client():
+    from backend.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://testserver") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# /api/auth/signup
+# ---------------------------------------------------------------------------
+
+
+async def test_signup_creates_user_and_sets_cookie(client):
+    r = await client.post(
+        "/api/auth/signup",
+        json={"email": "alice@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["email"] == "alice@example.com"
+    assert "id" in body
+    assert "session" in r.cookies
+
+
+async def test_duplicate_signup_returns_409(client):
+    creds = {"email": "dup@example.com", "password": "password123"}
+    r1 = await client.post("/api/auth/signup", json=creds)
+    assert r1.status_code == 201
+    r2 = await client.post("/api/auth/signup", json=creds)
+    assert r2.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# /api/auth/login
+# ---------------------------------------------------------------------------
+
+
+async def test_login_with_correct_password_sets_cookie(client):
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "bob@example.com", "password": "password123"},
+    )
+    # Clear cookies so login is a fresh request
+    client.cookies.clear()
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "bob@example.com", "password": "password123"},
+    )
+    assert r.status_code == 200
+    assert "session" in r.cookies
+
+
+async def test_login_with_wrong_password_returns_401(client):
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "carol@example.com", "password": "password123"},
+    )
+    client.cookies.clear()
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "carol@example.com", "password": "wrong-password"},
+    )
+    assert r.status_code == 401
+
+
+async def test_login_unknown_email_returns_401(client):
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "ghost@example.com", "password": "whatever1"},
+    )
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /api/auth/me and /logout
+# ---------------------------------------------------------------------------
+
+
+async def test_me_returns_user_when_authenticated(client):
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "dan@example.com", "password": "password123"},
+    )
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 200
+    assert r.json()["email"] == "dan@example.com"
+
+
+async def test_me_unauthenticated_returns_401(client):
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 401
+
+
+async def test_logout_clears_cookie_and_blocks_me(client):
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "eve@example.com", "password": "password123"},
+    )
+    r_logout = await client.post("/api/auth/logout")
+    assert r_logout.status_code == 204
+    # Clear client-side cookies as the browser would after Set-Cookie with
+    # max-age=0 / deletion. httpx's ASGI transport doesn't automatically honour
+    # the delete-cookie response, so drop them manually to match browser state.
+    client.cookies.clear()
+    r_me = await client.get("/api/auth/me")
+    assert r_me.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Protected route gating — acceptance criteria from issue #51
+# ---------------------------------------------------------------------------
+
+
+async def test_unauthenticated_create_conversation_returns_401(client):
+    r = await client.post("/api/conversations", json={})
+    assert r.status_code == 401
+
+
+async def test_unauthenticated_messages_post_returns_401(client):
+    r = await client.post(
+        "/api/conversations/some-id/messages",
+        json={"content": "hi"},
+    )
+    assert r.status_code == 401
+
+
+async def test_unauthenticated_ingest_returns_401(client):
+    r = await client.post(
+        "/api/ingest",
+        json={
+            "title": "t",
+            "description": "d",
+            "url": "https://example.com",
+            "transcript": "tx",
+        },
+    )
+    assert r.status_code == 401
+
+
+async def test_health_remains_public(client):
+    r = await client.get("/api/health")
+    assert r.status_code == 200
+
+
+async def test_version_remains_public(client):
+    r = await client.get("/api/version")
+    # 200 if the package is installed, 503 if metadata is missing — either
+    # proves the route is not gated behind auth (auth would give 401).
+    assert r.status_code in (200, 503)

--- a/app/backend/tests/test_ingest_cache_invalidation.py
+++ b/app/backend/tests/test_ingest_cache_invalidation.py
@@ -8,9 +8,19 @@ Verifies:
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from httpx import ASGITransport, AsyncClient
 
+from backend.auth.dependencies import get_current_user
 from backend.main import app
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """Ingest tests focus on cache behavior; satisfy the auth gate with a stub user."""
+    app.dependency_overrides[get_current_user] = lambda: {"id": "test-user", "email": "t@t"}
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 async def test_ingest_calls_invalidate_cache_after_chunks_stored():

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -51,12 +51,130 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159 },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157 },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051 },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640 },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050 },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574 },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076 },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980 },
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042 },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504 },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241 },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321 },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685 },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858 },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852 },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175 },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111 },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928 },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067 },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156 },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636 },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079 },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606 },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569 },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867 },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349 },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428 },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678 },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505 },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744 },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251 },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901 },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280 },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931 },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608 },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738 },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026 },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426 },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495 },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062 },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548 },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806 },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626 },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853 },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793 },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930 },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194 },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381 },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750 },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757 },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740 },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197 },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974 },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498 },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853 },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626 },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862 },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544 },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787 },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753 },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587 },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178 },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295 },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700 },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034 },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766 },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449 },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310 },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761 },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553 },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009 },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029 },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907 },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500 },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412 },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486 },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940 },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776 },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922 },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367 },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187 },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752 },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881 },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931 },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313 },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290 },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253 },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084 },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185 },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656 },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662 },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240 },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152 },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284 },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643 },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698 },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725 },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912 },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953 },
+    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180 },
+    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791 },
+    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746 },
+    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375 },
 ]
 
 [[package]]
@@ -206,6 +324,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094 },
+]
+
+[[package]]
 name = "docling-core"
 version = "2.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -253,11 +380,15 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "docling-core", extra = ["chunking", "chunking-openai"] },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -273,12 +404,16 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite" },
+    { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "docling-core", extras = ["chunking", "chunking-openai"] },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.14.1" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "pyjwt" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.4" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.25.2" },
     { name = "python-dotenv" },
@@ -286,6 +421,19 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"] },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604 },
+]
 
 [[package]]
 name = "fastapi"
@@ -1086,6 +1234,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726 },
 ]
 
 [[package]]

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,8 +1,33 @@
-import { useState } from 'react';
-import { BrowserRouter, Route, Routes, useParams } from 'react-router-dom';
+import { ReactNode, useState } from 'react';
+import { BrowserRouter, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { ChatArea } from './components/ChatArea';
 import { Sidebar } from './components/Sidebar';
 import { ToastProvider } from './components/ToastProvider';
+import { useAuth } from './hooks/useAuth';
+import { Login } from './pages/Login';
+import { Signup } from './pages/Signup';
+
+// ── Auth guard ───────────────────────────────────────────────────
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+function RequireAuth({ children }: RequireAuthProps) {
+  const { status } = useAuth();
+  const location = useLocation();
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--bg)] text-[var(--text-secondary)]">
+        Loading…
+      </div>
+    );
+  }
+  if (status === 'anon') {
+    return <Navigate to="/login" replace state={{ from: location.pathname + location.search }} />;
+  }
+  return <>{children}</>;
+}
 
 // ── Layout wrapper used by all routes ────────────────────────────
 interface AppLayoutProps {
@@ -67,8 +92,24 @@ function App() {
     <BrowserRouter>
       <ToastProvider>
         <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/c/:conversationId" element={<ConversationPage />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <LandingPage />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/c/:conversationId"
+            element={
+              <RequireAuth>
+                <ConversationPage />
+              </RequireAuth>
+            }
+          />
         </Routes>
       </ToastProvider>
     </BrowserRouter>

--- a/app/frontend/src/hooks/useAuth.ts
+++ b/app/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,94 @@
+/**
+ * useAuth — session state hook backed by /api/auth/me.
+ *
+ * On mount, calls `me()` once to hydrate the user. Components consume the
+ * returned shape to gate UI and show the current email. Login/signup/logout
+ * helpers update local state after each successful call.
+ *
+ * No context provider — `me()` is cheap and this hook is only used in the
+ * root-level auth guard + header. If that changes, wrap in Context.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { AuthError, AuthUser, login as apiLogin, logout as apiLogout, me, signup as apiSignup } from '../lib/authApi';
+
+export type AuthStatus = 'loading' | 'authed' | 'anon';
+
+export interface UseAuthResult {
+  status: AuthStatus;
+  user: AuthUser | null;
+  error: string | null;
+  signup: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useAuth(): UseAuthResult {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const u = await me();
+      setUser(u);
+      setStatus('authed');
+    } catch (e) {
+      setUser(null);
+      setStatus('anon');
+      if (e instanceof AuthError && e.status !== 401) {
+        setError(e.message);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const doLogin = useCallback(async (email: string, password: string) => {
+    setError(null);
+    try {
+      const u = await apiLogin(email, password);
+      setUser(u);
+      setStatus('authed');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Login failed';
+      setError(msg);
+      throw e;
+    }
+  }, []);
+
+  const doSignup = useCallback(async (email: string, password: string) => {
+    setError(null);
+    try {
+      const u = await apiSignup(email, password);
+      setUser(u);
+      setStatus('authed');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Signup failed';
+      setError(msg);
+      throw e;
+    }
+  }, []);
+
+  const doLogout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } finally {
+      setUser(null);
+      setStatus('anon');
+    }
+  }, []);
+
+  return {
+    status,
+    user,
+    error,
+    signup: doSignup,
+    login: doLogin,
+    logout: doLogout,
+    refresh,
+  };
+}

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -26,10 +26,18 @@ export function useStreamingResponse() {
       try {
         const res = await fetch(`/api/conversations/${conversationId}/messages`, {
           method: 'POST',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ content: userMessage }),
         });
 
+        if (res.status === 401) {
+          if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+            const returnTo = window.location.pathname + window.location.search;
+            window.location.assign(`/login?from=${encodeURIComponent(returnTo)}`);
+          }
+          throw new Error('Not authenticated');
+        }
         if (!res.ok) {
           const errorText = await res.text().catch(() => '');
           throw new Error(`HTTP ${res.status}${errorText ? `: ${errorText}` : ''}`);

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -36,9 +36,18 @@ export interface ConversationWithMessages extends Conversation {
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     ...options,
   });
+  if (res.status === 401) {
+    // Session missing/expired — bounce to login, preserving return path.
+    if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+      const returnTo = window.location.pathname + window.location.search;
+      window.location.assign(`/login?from=${encodeURIComponent(returnTo)}`);
+    }
+    throw new Error('Not authenticated');
+  }
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`API error ${res.status}: ${text}`);
@@ -53,7 +62,7 @@ export const createConversation = () =>
 export const getConversation = (id: string) =>
   request<ConversationWithMessages>(`/conversations/${id}`);
 export const deleteConversation = (id: string) =>
-  fetch(`${BASE}/conversations/${id}`, { method: 'DELETE' });
+  fetch(`${BASE}/conversations/${id}`, { method: 'DELETE', credentials: 'include' });
 
 // Videos
 export const getVideos = () => request<Video[]>('/videos');

--- a/app/frontend/src/lib/authApi.ts
+++ b/app/frontend/src/lib/authApi.ts
@@ -1,0 +1,58 @@
+/**
+ * Auth API client — signup, login, logout, me.
+ *
+ * All calls send `credentials: 'include'` so the `session` httpOnly cookie
+ * round-trips on both the signup/login response (Set-Cookie) and subsequent
+ * requests (Cookie header).
+ */
+
+const BASE = '/api/auth';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+}
+
+export class AuthError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function authRequest<T>(path: string, init: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = await res.json();
+      if (body?.detail) detail = body.detail;
+    } catch {
+      // fall through with statusText
+    }
+    throw new AuthError(res.status, detail);
+  }
+  if (res.status === 204) return undefined as unknown as T;
+  return res.json() as Promise<T>;
+}
+
+export const signup = (email: string, password: string) =>
+  authRequest<AuthUser>('/signup', {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  });
+
+export const login = (email: string, password: string) =>
+  authRequest<AuthUser>('/login', {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  });
+
+export const logout = () => authRequest<void>('/logout', { method: 'POST' });
+
+export const me = () => authRequest<AuthUser>('/me', { method: 'GET' });

--- a/app/frontend/src/pages/Login.tsx
+++ b/app/frontend/src/pages/Login.tsx
@@ -1,0 +1,85 @@
+import { FormEvent, useState } from 'react';
+import { useLocation, useNavigate, Link, Location } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+interface LocationStateWithFrom {
+  from?: string;
+}
+
+export function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation() as Location & { state: LocationStateWithFrom | null };
+  const returnTo = location.state?.from ?? '/';
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    setSubmitting(true);
+    try {
+      await login(email, password);
+      navigate(returnTo, { replace: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Login failed';
+      setFormError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--bg)] text-[var(--text-primary)] p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm bg-[var(--surface-1)] border border-[var(--border)] rounded-lg p-6 space-y-4"
+      >
+        <h1 className="text-xl font-semibold">Log in</h1>
+        <label className="block text-sm">
+          <span className="text-[var(--text-secondary)]">Email</span>
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-[var(--text-secondary)]">Password</span>
+          <input
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          />
+        </label>
+        {formError && (
+          <div className="text-sm text-[var(--danger)]" role="alert">
+            {formError}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full py-2 rounded bg-[var(--accent)] text-white font-medium disabled:opacity-50"
+        >
+          {submitting ? 'Logging in…' : 'Log in'}
+        </button>
+        <div className="text-sm text-[var(--text-secondary)] text-center">
+          Need an account?{' '}
+          <Link to="/signup" className="text-[var(--accent)] hover:underline">
+            Sign up
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/frontend/src/pages/Signup.tsx
+++ b/app/frontend/src/pages/Signup.tsx
@@ -1,0 +1,84 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const { signup } = useAuth();
+  const navigate = useNavigate();
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    if (password.length < 8) {
+      setFormError('Password must be at least 8 characters');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await signup(email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Signup failed';
+      setFormError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--bg)] text-[var(--text-primary)] p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm bg-[var(--surface-1)] border border-[var(--border)] rounded-lg p-6 space-y-4"
+      >
+        <h1 className="text-xl font-semibold">Create account</h1>
+        <label className="block text-sm">
+          <span className="text-[var(--text-secondary)]">Email</span>
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-[var(--text-secondary)]">Password (8+ characters)</span>
+          <input
+            type="password"
+            required
+            autoComplete="new-password"
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          />
+        </label>
+        {formError && (
+          <div className="text-sm text-[var(--danger)]" role="alert">
+            {formError}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full py-2 rounded bg-[var(--accent)] text-white font-medium disabled:opacity-50"
+        >
+          {submitting ? 'Creating account…' : 'Sign up'}
+        </button>
+        <div className="text-sm text-[var(--text-secondary)] text-center">
+          Already have an account?{' '}
+          <Link to="/login" className="text-[var(--accent)] hover:underline">
+            Log in
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,32 @@ Production deployment via Docker Compose. Runs Caddy (TLS + reverse proxy) and P
 - `80` / `443` (public) - Caddy
 - `127.0.0.1:5433` (loopback only) - Postgres
 
+## Environment variables
+
+The app container reads these from `/opt/dynachat/.env` via docker-compose:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `OPENROUTER_API_KEY` | **yes** | OpenRouter embeddings + chat |
+| `SUPADATA_API_KEY` | prod only | YouTube transcript fetch |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | **yes** | Postgres credentials used by both the `postgres` service and the app's `DATABASE_URL` |
+| `JWT_SECRET` | **yes** (auth) | 32+ random bytes used to sign session-cookie JWTs. Generate with `openssl rand -hex 32`. Rotating this value invalidates all live sessions |
+
+The app's `DATABASE_URL` is assembled from the `POSTGRES_*` values inside
+`docker-compose.yml` — you do **not** set it directly in `.env`. It points at
+the in-compose `postgres` service by DNS name.
+
+Minimal `.env` for a fresh deploy:
+
+```
+OPENROUTER_API_KEY=sk-or-...
+SUPADATA_API_KEY=...
+POSTGRES_USER=dynachat
+POSTGRES_PASSWORD=<random>
+POSTGRES_DB=dynachat
+JWT_SECRET=<openssl rand -hex 32>
+```
+
 ## Secret hygiene
 
 The real `.env` lives ONLY on the deploy host, in a directory owned by a non-factory user with mode 600. It is never committed, never shared via chat, and never readable by the Dark Factory workflow user.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -53,6 +53,13 @@ services:
       SUPADATA_API_KEY: ${SUPADATA_API_KEY:-}
       DB_PATH: /app/data/chat.db
       FRONTEND_DIST: /app/frontend/dist
+      # Postgres for auth / users (issue #51). DATABASE_URL must reach the
+      # in-compose postgres service; JWT_SECRET signs session cookies.
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      postgres:
+        condition: service_healthy
     volumes:
       - app_data:/app/data
     healthcheck:
@@ -78,6 +85,13 @@ services:
       SUPADATA_API_KEY: ${SUPADATA_API_KEY:-}
       DB_PATH: /app/data/chat.db
       FRONTEND_DIST: /app/frontend/dist
+      # Postgres for auth / users (issue #51). DATABASE_URL must reach the
+      # in-compose postgres service; JWT_SECRET signs session cookies.
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      postgres:
+        condition: service_healthy
     volumes:
       - app_data:/app/data
     healthcheck:


### PR DESCRIPTION
Fixes #51

Implements `MISSION.md` §10 invariant _"All chat access requires authentication — there is no anonymous mode"_ and lays the Postgres foundation the rate-limit issue (#52) will build on.

## Summary

- **Backend:** new `auth/` package (password hashing via `bcrypt`, JWT encode/decode, `get_current_user` dependency), `db/postgres.py` asyncpg pool, `db/users_repo.py` with parameterised SQL, `routes/auth.py` for signup/login/logout/me. FastAPI lifespan now runs `init_users_schema()` when `DATABASE_URL` is set.
- **Route protection:** `conversations`, `messages`, and `ingest` routers are registered with `dependencies=[Depends(get_current_user)]`. `/api/health`, `/api/version`, and the static frontend remain public.
- **Cookies:** session JWT in `httpOnly + Secure + SameSite=Lax` cookie, 7-day expiry, rotated on each login. `CORS` config is untouched — same-origin prod needs nothing special.
- **Frontend:** `/login` and `/signup` pages, `useAuth` hook (no Context, single `/me` fetch on mount), `RequireAuth` guard on chat routes, `credentials: 'include'` on every fetch, 401 → redirect to `/login` preserving the return path. SSE streaming fetch also sends cookies.
- **Deploy:** `docker-compose.yml` now passes `DATABASE_URL` (assembled from `POSTGRES_*`) and `JWT_SECRET` to both `app-blue` and `app-green`, with `depends_on: postgres { condition: service_healthy }`. `deploy/README.md` documents the new env vars.
- **Protected paths:** appended to `CLAUDE.md` per the `FACTORY_RULES.md` §5 reference that hadn't existed yet. The rate-limit issue will extend this list.

## Design decisions worth calling out

- **Used `bcrypt` directly**, not `passlib[bcrypt]`. Passlib 1.7.4 (last release) has a well-known compat gap with bcrypt ≥ 4.x — the `__about__` attribute check warns at best, breaks at worst. `bcrypt.hashpw` / `checkpw` is the same primitive without the indirection. Rounds = 12 as specced.
- **No ORM / no Alembic.** `backend/db/postgres.py` runs `CREATE EXTENSION` + `CREATE TABLE IF NOT EXISTS` on startup, matching the existing aiosqlite `CREATE TABLE IF NOT EXISTS` pattern (see `CLAUDE.md` → Planned migration: Postgres). Alembic lands with the Postgres migration of the existing SQLite tables, not here.
- **Placeholder columns** (`daily_message_count`, `rate_window_start`) kept on `users` per the issue body. Issue #52 will drop them once it adopts the sliding-window `user_messages` audit table — single schema touch before any prod users exist.

## Dependencies added (to `app/backend/pyproject.toml`)

- `asyncpg` — async Postgres client, matches the aiosqlite style (raw SQL in repo module).
- `bcrypt` — battle-tested password hashing.
- `pyjwt` — JWT encode/decode. Actively maintained.
- `email-validator` — required by Pydantic's `EmailStr`. Actively maintained.

## Acceptance criteria

- [x] Unauthenticated `POST /api/conversations` returns 401
- [x] Unauthenticated `POST /api/conversations/{id}/messages` returns 401
- [x] Unauthenticated `POST /api/ingest` returns 401
- [x] `GET /api/health` and `GET /api/version` remain public
- [x] Static frontend assets remain public
- [x] `POST /api/auth/signup` with new email creates user row, sets httpOnly cookie, returns `{id, email}`
- [x] Duplicate email on signup returns 409
- [x] `POST /api/auth/login` with correct password sets cookie; wrong password returns 401
- [x] `POST /api/auth/logout` clears the cookie
- [x] `GET /api/auth/me` returns current user when authed, 401 otherwise
- [x] Frontend: unauthenticated user visiting `/` is redirected to `/login`
- [x] Frontend: after login, user is sent back to the page they were trying to reach (`state.from` in `Login.tsx`)
- [x] `CLAUDE.md` has the protected-paths section
- [x] Postgres `users` table exists on deploy (idempotent `CREATE TABLE IF NOT EXISTS`)
- [x] `JWT_SECRET` and `DATABASE_URL` documented in `deploy/README.md`

## Tests

`app/backend/tests/test_auth.py` — 13 new tests covering every acceptance criterion above. Postgres is mocked at the repo boundary (`users_repo` → in-memory dict) per `CLAUDE.md` "Testing external APIs" pattern; no live DB required.

```
21 passed in 3.85s
```

## Manual smoke-test (post-merge)

On `/opt/dynachat` host, after the VPS auto-deploy:

1. Add `JWT_SECRET=$(openssl rand -hex 32)` to `/opt/dynachat/.env` if absent, restart containers.
2. Hit the root URL on chat.dynamous.ai — should redirect to `/login`.
3. Sign up with a new email; verify redirect to landing page and the chat flow works end-to-end.
4. Open a second browser (no cookie); confirm `curl -i https://chat.dynamous.ai/api/conversations -X POST` returns 401.
5. `docker exec dynachat-postgres psql -U dynachat -c 'SELECT email, created_at FROM users;'` shows the new row.

## Follow-ups

- Issue #52 (25 msg/user/24h rate limit) is unblocked by this PR and already drafted.
- Password reset + OAuth are phase-2 per the issue; tracked separately.
