### PR TITLE
fix(security): scope conversations to their owner (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,7 +471,10 @@ Any PR touching them must be human-authored:
 
 - `app/backend/auth/` (entire directory)
 - `app/backend/routes/auth.py`
+- `app/backend/routes/conversations.py` — implements MISSION §10 #3 (owner-only conversations)
+- `app/backend/routes/messages.py` — implements MISSION §10 #3 (owner-only conversations)
 - `app/backend/db/users_repo.py`
+- `app/backend/db/repository.py` — conversation/message `user_id` scoping functions specifically
 - `app/backend/main.py` — auth router registration and `Depends(get_current_user)` wiring
 - `app/backend/config.py` — `JWT_SECRET` / `DATABASE_URL` handling
 - CORS middleware configuration anywhere in the backend

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -155,27 +155,38 @@ async def count_chunks() -> int:
 # ---------------------------------------------------------------------------
 
 
-async def create_conversation(title: str = "New Conversation") -> dict:
+async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict:
     conv_id = _new_id()
     now = _now()
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
-            "INSERT INTO conversations (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)",
-            (conv_id, title, now, now),
+            "INSERT INTO conversations (id, user_id, title, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (conv_id, user_id, title, now, now),
         )
         await db.commit()
-    return {"id": conv_id, "title": title, "created_at": now, "updated_at": now}
+    return {
+        "id": conv_id,
+        "user_id": user_id,
+        "title": title,
+        "created_at": now,
+        "updated_at": now,
+    }
 
 
-async def get_conversation(conv_id: str) -> dict | None:
+async def get_conversation(conv_id: str, user_id: str) -> dict | None:
+    """Return the conversation only if it belongs to the given user."""
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
-        async with db.execute("SELECT * FROM conversations WHERE id = ?", (conv_id,)) as cursor:
+        async with db.execute(
+            "SELECT * FROM conversations WHERE id = ? AND user_id = ?",
+            (conv_id, user_id),
+        ) as cursor:
             row = await cursor.fetchone()
     return dict(row) if row else None
 
 
-async def list_conversations() -> list[dict]:
+async def list_conversations(user_id: str) -> list[dict]:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
@@ -187,37 +198,45 @@ async def list_conversations() -> list[dict]:
                     ORDER BY created_at DESC
                     LIMIT 1) AS preview
             FROM conversations c
+            WHERE c.user_id = ?
             ORDER BY c.updated_at DESC
-            """
+            """,
+            (user_id,),
         ) as cursor:
             rows = await cursor.fetchall()
     return [dict(r) for r in rows]
 
 
-async def update_conversation_title(conv_id: str, title: str) -> None:
+async def update_conversation_title(conv_id: str, user_id: str, title: str) -> bool:
+    """Rename a conversation. Returns False if it does not belong to the user."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "UPDATE conversations SET title = ?, updated_at = ? "
+            "WHERE id = ? AND user_id = ?",
+            (title, _now(), conv_id, user_id),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def touch_conversation(conv_id: str, user_id: str) -> None:
+    """Update the updated_at timestamp (scoped to owner; silent no-op otherwise)."""
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
-            "UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?",
-            (title, _now(), conv_id),
+            "UPDATE conversations SET updated_at = ? WHERE id = ? AND user_id = ?",
+            (_now(), conv_id, user_id),
         )
         await db.commit()
 
 
-async def touch_conversation(conv_id: str) -> None:
-    """Update the updated_at timestamp."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "UPDATE conversations SET updated_at = ? WHERE id = ?",
-            (_now(), conv_id),
-        )
-        await db.commit()
-
-
-async def delete_conversation(conv_id: str) -> bool:
+async def delete_conversation(conv_id: str, user_id: str) -> bool:
     async with aiosqlite.connect(DB_PATH) as db:
         # Enable foreign keys so ON DELETE CASCADE removes associated messages
         await db.execute("PRAGMA foreign_keys=ON;")
-        cursor = await db.execute("DELETE FROM conversations WHERE id = ?", (conv_id,))
+        cursor = await db.execute(
+            "DELETE FROM conversations WHERE id = ? AND user_id = ?",
+            (conv_id, user_id),
+        )
         await db.commit()
         return cursor.rowcount > 0
 
@@ -230,19 +249,31 @@ async def delete_conversation(conv_id: str) -> bool:
 async def create_message(
     *,
     conversation_id: str,
+    user_id: str,
     role: str,
     content: str,
-) -> dict:
+) -> dict | None:
+    """Insert a message. Returns None if the conversation does not belong to the user."""
     msg_id = _new_id()
     now = _now()
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "INSERT INTO messages (id, conversation_id, role, content, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (msg_id, conversation_id, role, content, now),
+        # Verify ownership atomically — INSERT only succeeds if the conversation
+        # row exists for this user. Prevents cross-user message injection even
+        # if a route handler forgets to check.
+        cursor = await db.execute(
+            """
+            INSERT INTO messages (id, conversation_id, role, content, created_at)
+            SELECT ?, ?, ?, ?, ?
+            WHERE EXISTS (
+                SELECT 1 FROM conversations WHERE id = ? AND user_id = ?
+            )
+            """,
+            (msg_id, conversation_id, role, content, now, conversation_id, user_id),
         )
         await db.commit()
-    await touch_conversation(conversation_id)
+        if cursor.rowcount == 0:
+            return None
+    await touch_conversation(conversation_id, user_id)
     return {
         "id": msg_id,
         "conversation_id": conversation_id,
@@ -252,12 +283,19 @@ async def create_message(
     }
 
 
-async def list_messages(conversation_id: str) -> list[dict]:
+async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
+    """Return messages only if the conversation belongs to the given user."""
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at ASC",
-            (conversation_id,),
+            """
+            SELECT m.*
+            FROM messages m
+            JOIN conversations c ON c.id = m.conversation_id
+            WHERE m.conversation_id = ? AND c.user_id = ?
+            ORDER BY m.created_at ASC
+            """,
+            (conversation_id, user_id),
         ) as cursor:
             rows = await cursor.fetchall()
     return [dict(r) for r in rows]

--- a/app/backend/db/schema.py
+++ b/app/backend/db/schema.py
@@ -31,10 +31,15 @@ CREATE TABLE IF NOT EXISTS chunks (
 CREATE_CONVERSATIONS_TABLE = """
 CREATE TABLE IF NOT EXISTS conversations (
     id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL,
     title      TEXT NOT NULL DEFAULT 'New Conversation',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+"""
+
+CREATE_CONVERSATIONS_USER_ID_INDEX = """
+CREATE INDEX IF NOT EXISTS conversations_user_id_idx ON conversations (user_id);
 """
 
 CREATE_MESSAGES_TABLE = """
@@ -48,6 +53,20 @@ CREATE TABLE IF NOT EXISTS messages (
 """
 
 
+async def _migrate_conversations_user_id(db: aiosqlite.Connection) -> None:
+    """One-time migration: drop legacy conversations/messages tables if they
+    predate the user_id column (see issue #56). The issue explicitly green-lit
+    truncation — there was no real user data yet when auth shipped."""
+    async with db.execute("PRAGMA table_info(conversations)") as cursor:
+        columns = {row[1] for row in await cursor.fetchall()}
+    if not columns:
+        return  # Fresh DB; CREATE ... IF NOT EXISTS below will handle it
+    if "user_id" in columns:
+        return  # Already migrated
+    await db.execute("DROP TABLE IF EXISTS messages")
+    await db.execute("DROP TABLE IF EXISTS conversations")
+
+
 async def init_db() -> None:
     """Create all tables if they do not already exist."""
     async with aiosqlite.connect(DB_PATH) as db:
@@ -55,7 +74,9 @@ async def init_db() -> None:
         await db.execute("PRAGMA foreign_keys=ON;")
         await db.execute(CREATE_VIDEOS_TABLE)
         await db.execute(CREATE_CHUNKS_TABLE)
+        await _migrate_conversations_user_id(db)
         await db.execute(CREATE_CONVERSATIONS_TABLE)
+        await db.execute(CREATE_CONVERSATIONS_USER_ID_INDEX)
         await db.execute(CREATE_MESSAGES_TABLE)
         await db.commit()
     print(f"Database initialised at {DB_PATH}")

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -1,8 +1,17 @@
-"""Conversation management routes."""
+"""Conversation management routes.
 
-from fastapi import APIRouter, HTTPException
+All handlers are user-scoped (MISSION §10 #3). A conversation that exists but
+belongs to another user returns 404, not 403 — don't leak existence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from backend.auth.dependencies import get_current_user
 from backend.db import repository
 
 router = APIRouter()
@@ -13,29 +22,42 @@ class ConversationCreate(BaseModel):
 
 
 @router.get("/conversations")
-async def list_conversations():
-    return await repository.list_conversations()
+async def list_conversations(current_user: dict[str, Any] = Depends(get_current_user)):
+    return await repository.list_conversations(user_id=str(current_user["id"]))
 
 
 @router.post("/conversations", status_code=201)
-async def create_conversation(body: ConversationCreate | None = None):
+async def create_conversation(
+    body: ConversationCreate | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """Create a new empty conversation. Body is optional; defaults to title='New Conversation'."""
     title = body.title if body else "New Conversation"
-    return await repository.create_conversation(title)
+    return await repository.create_conversation(
+        user_id=str(current_user["id"]),
+        title=title,
+    )
 
 
 @router.get("/conversations/{conv_id}")
-async def get_conversation(conv_id: str):
-    conv = await repository.get_conversation(conv_id)
+async def get_conversation(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = str(current_user["id"])
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
-    messages = await repository.list_messages(conv_id)
+    messages = await repository.list_messages(conv_id, user_id=user_id)
     return {**conv, "messages": messages}
 
 
 @router.delete("/conversations/{conv_id}", status_code=204)
-async def delete_conversation(conv_id: str):
-    deleted = await repository.delete_conversation(conv_id)
+async def delete_conversation(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    deleted = await repository.delete_conversation(conv_id, user_id=str(current_user["id"]))
     if not deleted:
         raise HTTPException(status_code=404, detail="Conversation not found")
 

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -2,13 +2,14 @@
 Message routes — POST /api/conversations/{conv_id}/messages
 
 Orchestrates the full RAG pipeline:
-  1. Save user message
-  2. Embed the query
-  3. Retrieve top-K relevant chunks
-  4. Build prompt with context
-  5. Stream LLM response as SSE
-  6. Send sources event before [DONE]
-  7. Persist assistant message after stream completes
+  1. Verify conversation ownership (404 cross-user, no leak)
+  2. Save user message
+  3. Embed the query
+  4. Retrieve top-K relevant chunks
+  5. Build prompt with context
+  6. Stream LLM response as SSE
+  7. Send sources event before [DONE]
+  8. Persist assistant message after stream completes
 """
 
 from __future__ import annotations
@@ -16,11 +17,13 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import AsyncGenerator
+from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
+from backend.auth.dependencies import get_current_user
 from backend.db import repository
 from backend.llm.openrouter import stream_chat
 from backend.rag.embeddings import embed_text
@@ -48,7 +51,11 @@ class MessageCreate(BaseModel):
 
 
 @router.post("/conversations/{conv_id}/messages")
-async def create_message(conv_id: str, body: MessageCreate):
+async def create_message(
+    conv_id: str,
+    body: MessageCreate,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """
     Send a user message and stream the RAG-grounded assistant response.
 
@@ -57,23 +64,30 @@ async def create_message(conv_id: str, body: MessageCreate):
         Each SSE event: "data: <token>\n\n"
         Final event: "data: [DONE]\n\n"
     """
-    # 1. Verify conversation exists
-    conv = await repository.get_conversation(conv_id)
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user.
+    # 404 (not 403) — don't leak existence of other users' conversations.
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     # Content is already validated non-empty by Pydantic; strip for storage
     user_content = body.content.strip()
 
-    # 2. Persist the user message
-    await repository.create_message(
+    # 2. Persist the user message. create_message re-checks ownership atomically
+    # so a race between the check above and insert can't leak cross-user.
+    inserted = await repository.create_message(
         conversation_id=conv_id,
+        user_id=user_id,
         role="user",
         content=user_content,
     )
+    if inserted is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
 
     # 3. Retrieve conversation history for LLM context
-    all_messages = await repository.list_messages(conv_id)
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
 
     # 4. Embed the user query and retrieve relevant chunks
@@ -110,11 +124,12 @@ async def create_message(conv_id: str, body: MessageCreate):
                 try:
                     await repository.create_message(
                         conversation_id=conv_id,
+                        user_id=user_id,
                         role="assistant",
                         content=assistant_text,
                     )
                     # Auto-generate title on first assistant reply
-                    await _maybe_set_conversation_title(conv_id, user_content)
+                    await _maybe_set_conversation_title(conv_id, user_id, user_content)
                 except Exception as exc:
                     logger.error("Failed to persist assistant message: %s", exc)
 
@@ -168,12 +183,14 @@ def _extract_text_from_sse(sse_chunks: list[str]) -> str:
     return "".join(tokens)
 
 
-async def _maybe_set_conversation_title(conv_id: str, first_user_message: str) -> None:
+async def _maybe_set_conversation_title(
+    conv_id: str, user_id: str, first_user_message: str
+) -> None:
     """
     If the conversation title is still the default, auto-generate one from
     the first user message (simple truncation for Sprint 2; LLM-based in Sprint 6).
     """
-    conv = await repository.get_conversation(conv_id)
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
     if not conv:
         return
     if conv.get("title") == "New Conversation":
@@ -181,4 +198,4 @@ async def _maybe_set_conversation_title(conv_id: str, first_user_message: str) -
             title = first_user_message[:47].strip() + "…"
         else:
             title = first_user_message.strip()
-        await repository.update_conversation_title(conv_id, title)
+        await repository.update_conversation_title(conv_id, user_id=user_id, title=title)

--- a/app/backend/tests/test_conversation_scoping.py
+++ b/app/backend/tests/test_conversation_scoping.py
@@ -1,0 +1,267 @@
+"""
+Cross-user scoping tests for conversations and messages (issue #56,
+MISSION §10 #3: "Conversations are private to their owner").
+
+Two signed-up users (A and B) must never be able to reach each other's
+conversations or messages through any endpoint. Ownership mismatches return
+404 (not 403) to avoid leaking existence.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+# Point DB_PATH at a temp file BEFORE any backend import so repository.py picks
+# up the isolated database. Each test module gets its own file on load.
+_tmp_dir = tempfile.mkdtemp(prefix="dynachat-test-")
+os.environ["DB_PATH"] = str(Path(_tmp_dir) / "chat.db")
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from backend.db.schema import init_db  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def fresh_sqlite_schema():
+    """Re-initialise the SQLite schema per test so data doesn't leak across tests."""
+    db_path = Path(os.environ["DB_PATH"])
+    if db_path.exists():
+        db_path.unlink()
+    await init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def fake_users_repo(monkeypatch):
+    """Replace the Postgres-backed users_repo with an in-memory dict."""
+    store: dict[str, dict[str, Any]] = {}
+
+    async def create_user(email: str, password_hash: str) -> dict[str, Any]:
+        import asyncpg
+
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                raise asyncpg.UniqueViolationError("duplicate email")
+        uid = str(uuid4())
+        row = {
+            "id": uid,
+            "email": email,
+            "password_hash": password_hash,
+            "created_at": None,
+            "last_login_at": None,
+        }
+        store[uid] = row
+        return {k: v for k, v in row.items() if k != "password_hash"}
+
+    async def get_user_by_email(email: str) -> dict[str, Any] | None:
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                return dict(u)
+        return None
+
+    async def get_user_by_id(user_id: Any) -> dict[str, Any] | None:
+        u = store.get(str(user_id))
+        if not u:
+            return None
+        return {k: v for k, v in u.items() if k != "password_hash"}
+
+    async def update_last_login(user_id: Any) -> None:
+        u = store.get(str(user_id))
+        if u:
+            u["last_login_at"] = "now"
+
+    from backend.auth import dependencies as auth_deps
+    from backend.db import users_repo
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(users_repo, "create_user", create_user)
+    monkeypatch.setattr(users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(users_repo, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(users_repo, "update_last_login", update_last_login)
+    monkeypatch.setattr(auth_deps.users_repo, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(auth_route.users_repo, "create_user", create_user)
+    monkeypatch.setattr(auth_route.users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(auth_route.users_repo, "update_last_login", update_last_login)
+
+    return store
+
+
+@pytest.fixture(autouse=True)
+def stub_pg_lifecycle(monkeypatch):
+    """The FastAPI lifespan calls init_users_schema + close_pg_pool — no-op both."""
+    from backend.db import postgres as pg
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(pg, "init_users_schema", noop)
+    monkeypatch.setattr(pg, "close_pg_pool", noop)
+
+
+async def _make_client() -> AsyncClient:
+    """Return a fresh AsyncClient bound to the FastAPI app."""
+    from backend.main import app
+
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="https://testserver")
+
+
+async def _signup_and_get_client(email: str, password: str = "password123") -> AsyncClient:
+    """Create a fresh signed-in client (cookie set) for the given user."""
+    client = await _make_client()
+    r = await client.post("/api/auth/signup", json={"email": email, "password": password})
+    assert r.status_code == 201, r.text
+    return client
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations — user scoping
+# ---------------------------------------------------------------------------
+
+
+async def test_list_conversations_returns_only_own():
+    alice = await _signup_and_get_client("alice@example.com")
+    bob = await _signup_and_get_client("bob@example.com")
+    try:
+        r_a = await alice.post("/api/conversations", json={"title": "Alice chat"})
+        assert r_a.status_code == 201
+        alice_conv_id = r_a.json()["id"]
+
+        r_b = await bob.post("/api/conversations", json={"title": "Bob chat"})
+        assert r_b.status_code == 201
+
+        r_list_a = await alice.get("/api/conversations")
+        assert r_list_a.status_code == 200
+        titles = {c["title"] for c in r_list_a.json()}
+        ids = {c["id"] for c in r_list_a.json()}
+        assert titles == {"Alice chat"}
+        assert alice_conv_id in ids
+
+        r_list_b = await bob.get("/api/conversations")
+        assert r_list_b.status_code == 200
+        assert {c["title"] for c in r_list_b.json()} == {"Bob chat"}
+    finally:
+        await alice.aclose()
+        await bob.aclose()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations/{id} — 404 on cross-user, not 403
+# ---------------------------------------------------------------------------
+
+
+async def test_get_other_users_conversation_returns_404():
+    alice = await _signup_and_get_client("alice@example.com")
+    bob = await _signup_and_get_client("bob@example.com")
+    try:
+        r_a = await alice.post("/api/conversations", json={"title": "Secret"})
+        alice_conv_id = r_a.json()["id"]
+
+        # Bob tries to fetch Alice's conversation.
+        r = await bob.get(f"/api/conversations/{alice_conv_id}")
+        assert r.status_code == 404, (
+            f"Expected 404 (not 403 — don't leak existence). Got {r.status_code}: {r.text}"
+        )
+
+        # Alice can still see her own conversation.
+        r_own = await alice.get(f"/api/conversations/{alice_conv_id}")
+        assert r_own.status_code == 200
+    finally:
+        await alice.aclose()
+        await bob.aclose()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/conversations/{id} — 404 and no mutation on cross-user
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_other_users_conversation_returns_404_and_no_mutation():
+    alice = await _signup_and_get_client("alice@example.com")
+    bob = await _signup_and_get_client("bob@example.com")
+    try:
+        r_a = await alice.post("/api/conversations", json={"title": "Untouchable"})
+        alice_conv_id = r_a.json()["id"]
+
+        r_delete = await bob.delete(f"/api/conversations/{alice_conv_id}")
+        assert r_delete.status_code == 404
+
+        # Conversation must still exist for Alice.
+        r_check = await alice.get(f"/api/conversations/{alice_conv_id}")
+        assert r_check.status_code == 200
+        assert r_check.json()["title"] == "Untouchable"
+    finally:
+        await alice.aclose()
+        await bob.aclose()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{id}/messages — 404 and no message written cross-user
+# ---------------------------------------------------------------------------
+
+
+async def test_post_message_into_other_users_conversation_returns_404():
+    alice = await _signup_and_get_client("alice@example.com")
+    bob = await _signup_and_get_client("bob@example.com")
+    try:
+        r_a = await alice.post("/api/conversations", json={"title": "Private"})
+        alice_conv_id = r_a.json()["id"]
+
+        # Bob attempts to post a message into Alice's conversation.
+        r = await bob.post(
+            f"/api/conversations/{alice_conv_id}/messages",
+            json={"content": "injected"},
+        )
+        assert r.status_code == 404
+
+        # Alice's conversation must still be empty (no assistant stream ran,
+        # and no user message was persisted).
+        r_detail = await alice.get(f"/api/conversations/{alice_conv_id}")
+        assert r_detail.status_code == 200
+        assert r_detail.json()["messages"] == []
+    finally:
+        await alice.aclose()
+        await bob.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Repository-layer guarantee: required user_id parameter
+# ---------------------------------------------------------------------------
+
+
+async def test_repository_functions_require_user_id():
+    """Every conversation/message repo function must take user_id.
+    This is a structural invariant — forgetting it is how cross-user leaks
+    happen. The test is inspection-based (no DB hits)."""
+    import inspect
+
+    from backend.db import repository
+
+    scoped = [
+        "create_conversation",
+        "get_conversation",
+        "list_conversations",
+        "update_conversation_title",
+        "touch_conversation",
+        "delete_conversation",
+        "create_message",
+        "list_messages",
+    ]
+    for name in scoped:
+        fn = getattr(repository, name)
+        params = inspect.signature(fn).parameters
+        assert "user_id" in params, f"repository.{name} must take a user_id parameter"


### PR DESCRIPTION
Closes #56.

## Summary

Every conversation/message route + repo function now requires `user_id` and refuses access to other users' data. Cross-user access returns **404** (not 403) — no existence leak. Implements **MISSION §10 #3** (\"Conversations are private to their owner\").

## The bug (pre-fix)

On `chat.dynamous.ai`, any signed-up user could:
- `GET /api/conversations` → see **every** conversation in the DB
- `GET /api/conversations/{any_id}` → read any user's chat
- `POST /api/conversations/{any_id}/messages` → inject into anyone's thread
- `DELETE /api/conversations/{any_id}` → delete any user's conversation

Root cause: `conversations` had no `user_id` column. #51 wrapped routes in `Depends(get_current_user)` but never threaded the user id into repo queries.

## Architecture note — no cross-DB FK

The issue AC asked for `user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE`. But today `users` lives in **Postgres** and `conversations`/`messages` live in **SQLite**. A cross-DB FK is not physically possible until #55 moves conversations to Postgres.

**Mitigation:** scoping is enforced at the repository layer by required `user_id` parameters + `WHERE user_id = ?` clauses on every read/write. That's the authoritative guard; FK would be defense-in-depth. Once #55 lands, add the FK in that PR.

Cascade is moot today — there is no user-delete flow yet. If one is added later, it must also clean up the user's conversations (trivial once conversations moves to Postgres).

## Changes

**Schema (`app/backend/db/schema.py`):**
- `conversations.user_id TEXT NOT NULL` + index on `user_id`
- One-time migration in `init_db()` drops legacy `conversations` + `messages` tables if they predate `user_id`. Issue explicitly greenlights truncation — no real user data had accumulated when auth shipped.

**Repository (`app/backend/db/repository.py`):**
- `create_conversation`, `get_conversation`, `list_conversations`, `update_conversation_title`, `touch_conversation`, `delete_conversation`, `create_message`, `list_messages` — all now require `user_id: str`.
- Writes that would touch another user's data return `None`/`False`.
- `create_message` uses an atomic `INSERT ... SELECT ... WHERE EXISTS` so a race between the handler's ownership check and the insert can't leak cross-user.

**Routes:**
- `routes/conversations.py` and `routes/messages.py` — every handler takes `current_user = Depends(get_current_user)` and threads `current_user[\"id\"]` into every repo call.
- 404 (not 403) on cross-user or missing resources.

## Testing

**Unit / integration (`app/backend/tests/test_conversation_scoping.py`, new):**
- `test_list_conversations_returns_only_own`
- `test_get_other_users_conversation_returns_404`
- `test_delete_other_users_conversation_returns_404_and_no_mutation`
- `test_post_message_into_other_users_conversation_returns_404`
- `test_repository_functions_require_user_id` — structural guard: inspection-based test that forbids adding a new conversation/message repo function without a `user_id` param

All 26 backend tests pass locally (21 pre-existing + 5 new). Ruff clean.

**agent-browser CLI validation** (local Postgres + fresh SQLite backend):
Two isolated browser sessions driven via `agent-browser eval` with real cookies.

| Call | Expected | Actual |
|---|---|---|
| Alice signup | 201 | ✅ 201 |
| Alice create conversation | 201 w/ `user_id` | ✅ 201, `user_id` matches |
| Alice list | 1 own conv | ✅ |
| **Bob (fresh browser)** signup | 201 | ✅ 201 |
| Bob list | `[]` | ✅ `[]` — Alice's conv invisible |
| Bob `GET /conversations/{alice_id}` | 404 | ✅ 404 `Conversation not found` |
| Bob `DELETE /conversations/{alice_id}` | 404, no mutation | ✅ 404, Alice's conv unchanged |
| Bob `POST .../{alice_id}/messages` | 404, no inject | ✅ 404, `message_count=0` after |
| Alice re-login → list | conv intact | ✅ same id, title, `updated_at` |

Evidence scripts + RESULTS.md saved to `.claude/scratch/issue-56-validation/` locally.

## Protected paths (CLAUDE.md)

Added to the factory-reject list:
- `app/backend/routes/conversations.py`
- `app/backend/routes/messages.py`
- `app/backend/db/repository.py` — conversation/message scoping functions

## Acceptance criteria

- [x] `conversations.user_id` NOT NULL (FK deferred to #55 — explained above)
- [x] User A cannot see user B's conversations in `GET /api/conversations`
- [x] User A gets 404 on `GET /api/conversations/{B_conv_id}`
- [x] User A gets 404 on `DELETE` cross-user — conversation not deleted
- [x] User A gets 404 on `POST messages` cross-user — no message created
- [x] New conversations are created with the current user's ID
- [x] Tests cover all four endpoints cross-user
- [x] No repo function for conversations/messages exists without a `user_id` parameter

## Deploy note

On cutover the existing `/opt/dynachat` SQLite chat.db will auto-run the `_migrate_conversations_user_id` step on startup, dropping legacy conversations + messages (issue greenlighted this — essentially zero real data). Cole restarts the app container; the migration runs idempotently.