### PR TITLE
feat: rate-limit signup per-IP and globally (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,4 +481,7 @@ Any PR touching them must be human-authored:
 - `app/backend/rate_limit.py` — implements MISSION §10 invariant #1 (25 msg/user/24h cap, hardcoded)
 - `app/backend/db/user_messages_repo.py` — audit-table access for the rate-limit counter
 - `app/backend/routes/messages.py` — the rate-limit enforcement call site (also listed above for owner-only conversations)
+- `app/backend/signup_rate_limit.py` — signup abuse guard (1/IP/hr + 25 global/10min, hardcoded; see issue #54)
+- `app/backend/db/signup_attempts_repo.py` — audit-table access for the signup rate-limiter
+- `deploy/Dockerfile` — uvicorn `--proxy-headers --forwarded-allow-ips="*"` flags; signup IP trust boundary depends on these (see module docstring in `signup_rate_limit.py`)
 - `MISSION.md` §10 invariant #1 (the cap value itself — 25 is not configurable)

--- a/app/backend/db/postgres.py
+++ b/app/backend/db/postgres.py
@@ -53,6 +53,31 @@ CREATE INDEX IF NOT EXISTS user_messages_user_id_created_at_idx
 """
 
 
+SIGNUP_ATTEMPTS_SCHEMA = """
+CREATE EXTENSION IF NOT EXISTS citext;
+
+-- Audit trail for signup rate-limiting (issue #54).
+-- Per-IP limit counts only `accepted` rows; the global cap counts everything
+-- except `invalid` (which is never written today — Pydantic 400s short-circuit
+-- before the handler). Full IPs retained for forensics; future issue may add
+-- a pruning job. `email_attempted` is nullable to accommodate malformed bodies.
+CREATE TABLE IF NOT EXISTS signup_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ip INET NOT NULL,
+    email_attempted CITEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN (
+        'accepted','ip_limited','global_limited','duplicate','invalid'
+    )),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS signup_attempts_ip_created_at_idx
+    ON signup_attempts (ip, created_at DESC);
+CREATE INDEX IF NOT EXISTS signup_attempts_created_at_idx
+    ON signup_attempts (created_at DESC);
+"""
+
+
 async def init_pg_pool() -> asyncpg.Pool:
     """Create the asyncpg pool if not already created. Idempotent."""
     global _pool
@@ -97,3 +122,11 @@ async def init_users_schema() -> None:
     async with pool.acquire() as conn:
         await conn.execute(USERS_SCHEMA)
     logger.info("Users schema ready.")
+
+
+async def init_signup_attempts_schema() -> None:
+    """Run the signup_attempts migration. Idempotent."""
+    pool = await init_pg_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(SIGNUP_ATTEMPTS_SCHEMA)
+    logger.info("Signup-attempts schema ready.")

--- a/app/backend/db/signup_attempts_repo.py
+++ b/app/backend/db/signup_attempts_repo.py
@@ -1,0 +1,73 @@
+"""
+signup_attempts repository — audit-table access for signup rate-limiting.
+
+Backed by the Postgres `signup_attempts` table created in `postgres.py`. One
+row per signup attempt (accepted, duplicate, or rate-limited). The sliding
+windows are `count(*) WHERE created_at > now() - interval '...'`, filtered
+by IP (for the per-IP window) or not (for the global window).
+
+All functions take a live asyncpg Connection so the caller controls the
+transaction — `signup_rate_limit.check` needs count+insert atomicity under a
+pg_advisory_xact_lock, same pattern as `user_messages_repo.py`.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+
+
+async def insert_attempt(
+    conn: asyncpg.Connection,
+    ip: str,
+    email_attempted: str | None,
+    outcome: str,
+) -> None:
+    """Append one row to the signup_attempts audit table."""
+    await conn.execute(
+        """
+        INSERT INTO signup_attempts (ip, email_attempted, outcome)
+        VALUES ($1::inet, $2, $3)
+        """,
+        ip,
+        email_attempted,
+        outcome,
+    )
+
+
+async def count_for_ip_in_window(
+    conn: asyncpg.Connection, ip: str, window_seconds: int
+) -> int:
+    """Count `accepted` signups from `ip` in the last `window_seconds` seconds.
+
+    Per-IP limit counts only successful signups — a typo'd password shouldn't
+    lock the user out of their household for an hour.
+    """
+    count = await conn.fetchval(
+        f"""
+        SELECT count(*) FROM signup_attempts
+        WHERE ip = $1::inet
+          AND outcome = 'accepted'
+          AND created_at > now() - interval '{int(window_seconds)} seconds'
+        """,
+        ip,
+    )
+    return int(count or 0)
+
+
+async def count_global_in_window(
+    conn: asyncpg.Connection, window_seconds: int
+) -> int:
+    """Count all signup attempts globally in the last `window_seconds`.
+
+    Excludes `invalid` (Pydantic 400s — never written today, reserved). Counts
+    `accepted`, `duplicate`, `ip_limited`, `global_limited` so an attacker
+    cycling through IPs still trips the global cap.
+    """
+    count = await conn.fetchval(
+        f"""
+        SELECT count(*) FROM signup_attempts
+        WHERE outcome <> 'invalid'
+          AND created_at > now() - interval '{int(window_seconds)} seconds'
+        """,
+    )
+    return int(count or 0)

--- a/app/backend/db/users_repo.py
+++ b/app/backend/db/users_repo.py
@@ -10,14 +10,26 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+import asyncpg
+
 from backend.db.postgres import get_pg_pool
 
 
-async def create_user(email: str, password_hash: str) -> dict[str, Any]:
-    """Insert a new user. Raises asyncpg.UniqueViolationError on duplicate email."""
-    pool = get_pg_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
+async def create_user(
+    email: str,
+    password_hash: str,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> dict[str, Any]:
+    """Insert a new user. Raises asyncpg.UniqueViolationError on duplicate email.
+
+    If `conn` is supplied the caller owns the transaction (used by the signup
+    handler so the user insert and the rate-limit audit row commit together
+    under the same advisory lock). Otherwise grab a pool connection.
+    """
+
+    async def _insert(c: asyncpg.Connection) -> dict[str, Any]:
+        row = await c.fetchrow(
             """
             INSERT INTO users (email, password_hash)
             VALUES ($1, $2)
@@ -26,8 +38,15 @@ async def create_user(email: str, password_hash: str) -> dict[str, Any]:
             email,
             password_hash,
         )
-    assert row is not None  # RETURNING always yields a row on successful INSERT
-    return dict(row)
+        assert row is not None  # RETURNING always yields a row on successful INSERT
+        return dict(row)
+
+    if conn is not None:
+        return await _insert(conn)
+
+    pool = get_pg_pool()
+    async with pool.acquire() as new_conn:
+        return await _insert(new_conn)
 
 
 async def get_user_by_email(email: str) -> dict[str, Any] | None:

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -18,7 +18,7 @@ from fastapi.staticfiles import StaticFiles
 from backend.auth.dependencies import get_current_user
 from backend.config import DATABASE_URL, DB_PATH
 from backend.data.seed import seed_if_empty
-from backend.db.postgres import close_pg_pool, init_users_schema
+from backend.db.postgres import close_pg_pool, init_signup_attempts_schema, init_users_schema
 from backend.db.schema import init_db
 
 logging.basicConfig(level=logging.INFO)
@@ -33,6 +33,7 @@ async def lifespan(app: FastAPI):
     if DATABASE_URL:
         logger.info("DATABASE_URL set — initialising Postgres users schema…")
         await init_users_schema()
+        await init_signup_attempts_schema()
     else:
         logger.warning("DATABASE_URL not set; auth endpoints will fail until configured.")
     logger.info("Database ready. Checking seed data…")

--- a/app/backend/routes/auth.py
+++ b/app/backend/routes/auth.py
@@ -12,15 +12,17 @@ import logging
 from typing import Any
 
 import asyncpg
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, Field
 
-from backend import rate_limit
+from backend import rate_limit, signup_rate_limit
 from backend.auth.dependencies import COOKIE_NAME, get_current_user
 from backend.auth.password import hash_password, verify_password
 from backend.auth.tokens import encode_token
 from backend.config import JWT_EXPIRY_SECONDS
 from backend.db import users_repo
+from backend.db.postgres import get_pg_pool
 
 logger = logging.getLogger(__name__)
 
@@ -74,16 +76,74 @@ def _user_to_response(user: dict[str, Any]) -> UserResponse:
     return UserResponse(id=str(user["id"]), email=str(user["email"]))
 
 
+def _client_ip(request: Request) -> str:
+    """Return the real client IP.
+
+    With uvicorn's `--proxy-headers --forwarded-allow-ips="*"`, Starlette has
+    already rewritten `request.client` to the left-most `X-Forwarded-For`
+    value set by Caddy. We don't hand-parse the header in application code —
+    the trust boundary is declared once, at process boot. See
+    `signup_rate_limit.py` docstring for the threat model.
+    """
+    return request.client.host if request.client else "0.0.0.0"
+
+
 @router.post("/signup", status_code=status.HTTP_201_CREATED, response_model=UserResponse)
-async def signup(body: SignupRequest, response: Response) -> UserResponse:
-    """Create a user, set session cookie, return {id, email}. 409 on duplicate email."""
-    password_hash = hash_password(body.password)
-    try:
-        user = await users_repo.create_user(email=body.email, password_hash=password_hash)
-    except asyncpg.UniqueViolationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT, detail="Email already registered"
-        ) from exc
+async def signup(
+    body: SignupRequest, request: Request, response: Response
+) -> UserResponse | JSONResponse:
+    """Create a user, set session cookie, return {id, email}.
+
+    Order: rate-limit check → bcrypt → insert. Rate-limit is cheapest, runs
+    first so bots can't burn CPU via repeated 429'd calls. Every attempt is
+    audited to `signup_attempts` with its final outcome.
+
+    Returns 429 on rate-limit (per-IP wins over global — more specific error),
+    409 on duplicate email, 201 with session cookie on success.
+    """
+    ip = _client_ip(request)
+    pool = get_pg_pool()
+
+    async with pool.acquire() as conn, conn.transaction():
+        try:
+            await signup_rate_limit.check(ip, conn)
+        except signup_rate_limit.SignupRateLimited as exc:
+            outcome = "ip_limited" if exc.scope == "ip" else "global_limited"
+            await signup_rate_limit.record(
+                conn, ip=ip, email_attempted=body.email, outcome=outcome
+            )
+            return JSONResponse(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                content={
+                    "error": "signup_rate_limited",
+                    "message": exc.message,
+                    "scope": exc.scope,
+                },
+            )
+
+        password_hash = hash_password(body.password)
+        try:
+            user = await users_repo.create_user(
+                email=body.email, password_hash=password_hash, conn=conn
+            )
+        except asyncpg.UniqueViolationError as exc:
+            # The user insert that raised left the transaction in an aborted
+            # state (asyncpg's savepoint semantics). Record the duplicate on
+            # a fresh connection so the audit row still lands; the outer txn
+            # will roll back harmlessly.
+            pool_for_record = get_pg_pool()
+            async with pool_for_record.acquire() as record_conn:
+                await signup_rate_limit.record(
+                    record_conn, ip=ip, email_attempted=body.email, outcome="duplicate"
+                )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Email already registered"
+            ) from exc
+
+        await signup_rate_limit.record(
+            conn, ip=ip, email_attempted=body.email, outcome="accepted"
+        )
+
     _set_session_cookie(response, str(user["id"]))
     return _user_to_response(user)
 

--- a/app/backend/signup_rate_limit.py
+++ b/app/backend/signup_rate_limit.py
@@ -1,0 +1,119 @@
+"""
+Signup rate-limiter (issue #54).
+
+Two independent sliding windows protect `POST /api/auth/signup`:
+
+- **Per-IP**: 1 accepted signup per IP per hour (PER_IP_LIMIT / PER_IP_WINDOW_SECONDS)
+- **Global**: 25 signup attempts per 10 minutes across the whole service
+  (GLOBAL_LIMIT / GLOBAL_WINDOW_SECONDS)
+
+Both limits return HTTP 429 with a structured body. Per-IP is checked first —
+it's the more specific, more actionable error for a real user who clicked
+twice. Global only fires under coordinated abuse.
+
+Constants are **hardcoded**. No environment variable, no config override. If
+a PR touches these values it must be reviewed by a human — see
+FACTORY_RULES.md §2.7 and the protected-paths list in CLAUDE.md. A structural
+test asserts this module's source contains no environment-variable lookups.
+
+### Trust boundary
+
+The route handler passes `request.client.host` as `ip`. In production, uvicorn
+is started with `--proxy-headers --forwarded-allow-ips="*"`, so Starlette has
+already rewritten `request.client` to the left-most `X-Forwarded-For` value
+set by Caddy. This is safe because the app containers do not publish a host
+port — only Caddy can reach uvicorn on the internal Docker network. If anyone
+publishes `ports: - "8000:8000"` on the app service, IP spoofing becomes
+possible and this assumption breaks.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from backend.db import signup_attempts_repo
+
+# Hardcoded — do not change. Any adjustment requires a human-reviewed PR.
+PER_IP_WINDOW_SECONDS: int = 3600  # 1 hour
+PER_IP_LIMIT: int = 1
+GLOBAL_WINDOW_SECONDS: int = 600  # 10 minutes
+GLOBAL_LIMIT: int = 25
+
+
+Scope = Literal["ip", "global"]
+
+
+class SignupRateLimited(Exception):
+    """Raised by `check` when the caller should be rejected with 429."""
+
+    def __init__(self, scope: Scope, message: str):
+        self.scope: Scope = scope
+        self.message: str = message
+        super().__init__(f"signup_rate_limited[{scope}]: {message}")
+
+
+# Human-facing copy rendered verbatim by the frontend.
+_IP_MESSAGE = (
+    "Only one signup per hour from this network. "
+    "Please try again later or log in if you already have an account."
+)
+_GLOBAL_MESSAGE = (
+    "We're receiving a lot of signups right now. "
+    "Please try again in a few minutes."
+)
+
+
+def _now() -> datetime:
+    """Wall-clock now in UTC. Monkeypatched by tests that want to freeze time."""
+    return datetime.now(UTC)
+
+
+# Stable signed-bigint key for pg_advisory_xact_lock.
+# Serialises signup attempts globally so two concurrent requests can't both
+# see count=24 and both insert (which would let 26 through the global cap).
+# Value = hash("dynachat:signup_rate_limit") folded into int64 space;
+# computed once at import time from a literal, no runtime config involved.
+_ADVISORY_LOCK_KEY: int = 0x53_69_67_6E_55_70_52_4C  # "SignUpRL" as bytes
+if _ADVISORY_LOCK_KEY >= 1 << 63:
+    _ADVISORY_LOCK_KEY -= 1 << 64
+
+
+async def check(ip: str, conn) -> None:
+    """Raise `SignupRateLimited` if this request should be rejected.
+
+    Does NOT insert — the caller records the attempt explicitly so the
+    audit row captures the final outcome (accepted / duplicate / etc.).
+
+    Takes the advisory lock on the caller's connection (which must already
+    be inside `conn.transaction()`). The lock releases on transaction end.
+    """
+    await conn.execute("SELECT pg_advisory_xact_lock($1)", _ADVISORY_LOCK_KEY)
+
+    ip_count = await signup_attempts_repo.count_for_ip_in_window(
+        conn, ip, window_seconds=PER_IP_WINDOW_SECONDS
+    )
+    if ip_count >= PER_IP_LIMIT:
+        raise SignupRateLimited(scope="ip", message=_IP_MESSAGE)
+
+    global_count = await signup_attempts_repo.count_global_in_window(
+        conn, window_seconds=GLOBAL_WINDOW_SECONDS
+    )
+    if global_count >= GLOBAL_LIMIT:
+        raise SignupRateLimited(scope="global", message=_GLOBAL_MESSAGE)
+
+
+async def record(
+    conn,
+    ip: str,
+    email_attempted: str | None,
+    outcome: str,
+) -> None:
+    """Append one row to the audit table.
+
+    Thin pass-through to keep the route handler's import surface small and
+    match `rate_limit.check_and_record`'s public-API feel.
+    """
+    await signup_attempts_repo.insert_attempt(
+        conn, ip=ip, email_attempted=email_attempted, outcome=outcome
+    )

--- a/app/backend/tests/conftest.py
+++ b/app/backend/tests/conftest.py
@@ -20,7 +20,7 @@ os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/tes
 import pytest
 
 import backend.rag.retriever as retriever_module
-from backend import rate_limit
+from backend import rate_limit, signup_rate_limit
 
 
 @pytest.fixture(autouse=True)
@@ -79,3 +79,70 @@ def patch_rate_limit(monkeypatch, message_store):
 
     monkeypatch.setattr(rate_limit, "check_and_record", fake_check_and_record)
     monkeypatch.setattr(rate_limit, "get_status", fake_get_status)
+
+
+class _FakeConn:
+    """No-op connection for tests that go through the signup route.
+
+    The real route opens `pool.acquire() → conn.transaction()` and passes the
+    connection into `signup_rate_limit.check/.record` and `users_repo.create_user`.
+    All three are monkeypatched by the test suite, so the connection is never
+    actually used — but the context-manager plumbing still needs to succeed.
+    """
+
+    async def execute(self, *args, **kwargs):
+        return None
+
+    def transaction(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def acquire(self):
+        return self
+
+    async def __aenter__(self):
+        return _FakeConn()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def patch_pg_pool(monkeypatch):
+    """Return a no-op pool so `pool.acquire()`/`conn.transaction()` succeed in tests."""
+    from backend.db import postgres as pg
+    from backend.routes import auth as auth_route
+
+    fake = _FakePool()
+    monkeypatch.setattr(pg, "get_pg_pool", lambda: fake)
+    monkeypatch.setattr(auth_route, "get_pg_pool", lambda: fake)
+
+
+@pytest.fixture(autouse=True)
+def patch_signup_rate_limit(monkeypatch):
+    """Permissive stub for `signup_rate_limit.check` and `.record`.
+
+    Most test suites (test_auth.py, test_rate_limit.py, etc.) sign up multiple
+    users per test and would trip the real 1/IP/hr limit. This stub
+    short-circuits both functions to no-ops so those suites are unaffected.
+
+    Tests in `test_signup_rate_limit.py` opt OUT of this fixture by providing
+    their own override that restores the real implementation (exercised
+    against a real Postgres).
+    """
+
+    async def fake_check(ip, conn):
+        return None
+
+    async def fake_record(conn, ip, email_attempted, outcome):
+        return None
+
+    monkeypatch.setattr(signup_rate_limit, "check", fake_check)
+    monkeypatch.setattr(signup_rate_limit, "record", fake_record)

--- a/app/backend/tests/test_auth.py
+++ b/app/backend/tests/test_auth.py
@@ -25,7 +25,7 @@ def fake_users_repo(monkeypatch):
     """Replace Postgres-backed users_repo with an in-memory dict."""
     store: dict[str, dict[str, Any]] = {}
 
-    async def create_user(email: str, password_hash: str) -> dict[str, Any]:
+    async def create_user(email: str, password_hash: str, **kwargs: Any) -> dict[str, Any]:
         import asyncpg
 
         email_lower = email.lower()

--- a/app/backend/tests/test_conversation_scoping.py
+++ b/app/backend/tests/test_conversation_scoping.py
@@ -48,7 +48,7 @@ def fake_users_repo(monkeypatch):
     """Replace the Postgres-backed users_repo with an in-memory dict."""
     store: dict[str, dict[str, Any]] = {}
 
-    async def create_user(email: str, password_hash: str) -> dict[str, Any]:
+    async def create_user(email: str, password_hash: str, **kwargs: Any) -> dict[str, Any]:
         import asyncpg
 
         email_lower = email.lower()

--- a/app/backend/tests/test_rate_limit.py
+++ b/app/backend/tests/test_rate_limit.py
@@ -134,7 +134,7 @@ async def fresh_sqlite_schema():
 def fake_users_repo(monkeypatch):
     store: dict[str, dict[str, Any]] = {}
 
-    async def create_user(email: str, password_hash: str) -> dict[str, Any]:
+    async def create_user(email: str, password_hash: str, **kwargs: Any) -> dict[str, Any]:
         import asyncpg
 
         for u in store.values():

--- a/app/backend/tests/test_signup_rate_limit.py
+++ b/app/backend/tests/test_signup_rate_limit.py
@@ -1,0 +1,356 @@
+"""
+Real-Postgres integration tests for signup rate-limiting (issue #54).
+
+Unlike `test_auth.py` (which stubs users_repo in memory), this file runs
+against an actual Postgres instance because the limiter's correctness depends
+on asyncpg's `pg_advisory_xact_lock` semantics and on the `signup_attempts`
+table's index-backed sliding-window queries.
+
+Run pre-reqs (throw-away container, started by the developer before pytest):
+
+    docker run -d --name dynachat-signup-test -p 127.0.0.1:5435:5432 \
+      -e POSTGRES_PASSWORD=test -e POSTGRES_USER=test -e POSTGRES_DB=test \
+      postgres:16-alpine
+
+The backend's ASGI lifespan runs `init_users_schema` + `init_signup_attempts_schema`
+against this container. Each test truncates both tables before running so
+counts are deterministic.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import tempfile
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+# Point DATABASE_URL + DB_PATH at throw-away storage BEFORE any backend imports.
+os.environ["DATABASE_URL"] = "postgresql://test:test@127.0.0.1:5435/test"
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+_tmp_dir = tempfile.mkdtemp(prefix="dynachat-signup-test-")
+os.environ["DB_PATH"] = str(Path(_tmp_dir) / "chat.db")
+
+import asyncpg  # noqa: E402
+import pytest  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from backend import signup_rate_limit  # noqa: E402
+
+DSN = os.environ["DATABASE_URL"]
+
+
+# ---------------------------------------------------------------------------
+# Fixture overrides — disable the permissive conftest stubs so the real
+# `signup_rate_limit` module runs against real Postgres.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def patch_signup_rate_limit():
+    """Override conftest stub — exercise the real limiter."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def patch_pg_pool(monkeypatch):
+    """Override conftest stub — create a real backend pool against the test DB.
+
+    ASGITransport does not run the FastAPI lifespan, so we bring the pool up
+    (and the two schemas) ourselves. The backend's DATABASE_URL was captured
+    at `backend.config` import time (which happened from conftest) — we patch
+    the module-level constant in `postgres.py` to point at the test DB before
+    creating the pool.
+    """
+    from backend.db import postgres as pg
+
+    monkeypatch.setattr(pg, "DATABASE_URL", DSN)
+    # Ensure a clean pool bound to this test's event loop — a stale pool from a
+    # previous test is bound to the previous asyncio loop and raises on use.
+    await pg.close_pg_pool()
+    await pg.init_pg_pool()
+    await pg.init_users_schema()
+    await pg.init_signup_attempts_schema()
+    yield
+    await pg.close_pg_pool()
+
+
+# ---------------------------------------------------------------------------
+# Per-test table truncation + direct asyncpg conn for seeding/asserting
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db() -> AsyncIterator[asyncpg.Connection]:
+    """Standalone asyncpg connection for seeding rows and asserting counts.
+
+    Independent of the backend's pool so it survives ASGI lifespan teardown.
+    """
+    # Ensure schemas exist (idempotent — harmless if backend already ran it).
+    conn = await asyncpg.connect(DSN)
+    try:
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS citext;")
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto;")
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                email CITEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                last_login_at TIMESTAMPTZ
+            );
+            CREATE TABLE IF NOT EXISTS signup_attempts (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                ip INET NOT NULL,
+                email_attempted CITEXT,
+                outcome TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+            """
+        )
+        await conn.execute("TRUNCATE signup_attempts, users CASCADE;")
+        yield conn
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# ASGI client — triggers the real lifespan so the backend pool is initialised.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[AsyncClient]:
+    from backend.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://testserver") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _signup(
+    client: AsyncClient,
+    email: str,
+    password: str = "password123",
+) -> Any:
+    return await client.post(
+        "/api/auth/signup", json={"email": email, "password": password}
+    )
+
+
+def _with_ip(monkeypatch, ip: str) -> None:
+    """Force the route's `_client_ip` helper to return a specific IP.
+
+    ASGITransport's synthetic `request.client.host` is `testclient` — patching
+    at the helper level is cleaner than rigging proxy headers."""
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(auth_route, "_client_ip", lambda _req: ip)
+
+
+async def _count(db: asyncpg.Connection, outcome: str | None = None) -> int:
+    if outcome:
+        return int(
+            await db.fetchval(
+                "SELECT count(*) FROM signup_attempts WHERE outcome = $1", outcome
+            )
+        )
+    return int(await db.fetchval("SELECT count(*) FROM signup_attempts"))
+
+
+# ---------------------------------------------------------------------------
+# Happy path + basic per-IP
+# ---------------------------------------------------------------------------
+
+
+async def test_first_signup_records_accepted_and_returns_201(
+    db, client, monkeypatch
+):
+    _with_ip(monkeypatch, "10.0.0.1")
+    r = await _signup(client, "alice@example.com")
+    assert r.status_code == 201, r.text
+    assert await _count(db, "accepted") == 1
+    assert await _count(db) == 1
+
+
+async def test_second_signup_same_ip_within_hour_returns_429_ip_scope(
+    db, client, monkeypatch
+):
+    _with_ip(monkeypatch, "10.0.0.2")
+    r1 = await _signup(client, "first@example.com")
+    assert r1.status_code == 201
+    r2 = await _signup(client, "second@example.com")
+    assert r2.status_code == 429, r2.text
+    body = r2.json()
+    assert body["error"] == "signup_rate_limited"
+    assert body["scope"] == "ip"
+    assert isinstance(body["message"], str) and body["message"]
+    assert await _count(db, "accepted") == 1
+    assert await _count(db, "ip_limited") == 1
+
+
+async def test_different_ip_not_blocked_by_other_ips_cap(
+    db, client, monkeypatch
+):
+    _with_ip(monkeypatch, "10.0.0.10")
+    assert (await _signup(client, "a@example.com")).status_code == 201
+
+    _with_ip(monkeypatch, "10.0.0.11")
+    r = await _signup(client, "b@example.com")
+    assert r.status_code == 201, r.text
+    assert await _count(db, "accepted") == 2
+
+
+async def test_duplicate_email_records_duplicate_and_returns_409(
+    db, client, monkeypatch
+):
+    _with_ip(monkeypatch, "10.0.0.20")
+    assert (await _signup(client, "dup@example.com")).status_code == 201
+    # Different IP so the per-IP check passes and we reach the uniqueness check.
+    _with_ip(monkeypatch, "10.0.0.21")
+    r = await _signup(client, "dup@example.com")
+    assert r.status_code == 409, r.text
+    assert await _count(db, "accepted") == 1
+    assert await _count(db, "duplicate") == 1
+
+
+# ---------------------------------------------------------------------------
+# Global cap
+# ---------------------------------------------------------------------------
+
+
+async def test_global_cap_25_per_10min_returns_429_global_scope(
+    db, client, monkeypatch
+):
+    for i in range(signup_rate_limit.GLOBAL_LIMIT):
+        await db.execute(
+            """
+            INSERT INTO signup_attempts (ip, email_attempted, outcome, created_at)
+            VALUES ($1::inet, $2, 'accepted', now() - interval '30 seconds')
+            """,
+            f"10.1.0.{i}",
+            f"seed{i}@example.com",
+        )
+
+    _with_ip(monkeypatch, "10.1.1.99")
+    r = await _signup(client, "fresh@example.com")
+    assert r.status_code == 429, r.text
+    body = r.json()
+    assert body["scope"] == "global"
+    assert await _count(db, "accepted") == signup_rate_limit.GLOBAL_LIMIT
+    assert await _count(db, "global_limited") == 1
+
+
+async def test_global_window_rolls_off_after_10_min(db, client, monkeypatch):
+    for i in range(signup_rate_limit.GLOBAL_LIMIT):
+        await db.execute(
+            """
+            INSERT INTO signup_attempts (ip, email_attempted, outcome, created_at)
+            VALUES ($1::inet, $2, 'accepted', now() - interval '11 minutes')
+            """,
+            f"10.2.0.{i}",
+            f"old{i}@example.com",
+        )
+    _with_ip(monkeypatch, "10.2.1.99")
+    r = await _signup(client, "new@example.com")
+    assert r.status_code == 201, r.text
+
+
+async def test_per_ip_window_rolls_off_after_1h(db, client, monkeypatch):
+    await db.execute(
+        """
+        INSERT INTO signup_attempts (ip, email_attempted, outcome, created_at)
+        VALUES ('10.3.0.1'::inet, 'ancient@example.com', 'accepted',
+                now() - interval '61 minutes')
+        """
+    )
+    _with_ip(monkeypatch, "10.3.0.1")
+    r = await _signup(client, "reborn@example.com")
+    assert r.status_code == 201, r.text
+
+
+# ---------------------------------------------------------------------------
+# Precedence + ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_ip_precedence_over_global(db, client, monkeypatch):
+    target_ip = "10.4.0.99"
+    await db.execute(
+        """
+        INSERT INTO signup_attempts (ip, email_attempted, outcome, created_at)
+        VALUES ($1::inet, 'target@example.com', 'accepted',
+                now() - interval '30 seconds')
+        """,
+        target_ip,
+    )
+    for i in range(signup_rate_limit.GLOBAL_LIMIT - 1):
+        await db.execute(
+            """
+            INSERT INTO signup_attempts (ip, email_attempted, outcome, created_at)
+            VALUES ($1::inet, $2, 'accepted', now() - interval '30 seconds')
+            """,
+            f"10.4.1.{i}",
+            f"filler{i}@example.com",
+        )
+    _with_ip(monkeypatch, target_ip)
+    r = await _signup(client, "new@example.com")
+    assert r.status_code == 429
+    assert r.json()["scope"] == "ip"
+
+
+async def test_429_ip_does_not_call_bcrypt(db, client, monkeypatch):
+    """Rate-limit check must run before password hashing — attackers shouldn't
+    be able to burn server CPU via repeated 429'd requests."""
+    await db.execute(
+        """
+        INSERT INTO signup_attempts (ip, email_attempted, outcome, created_at)
+        VALUES ('10.5.0.1'::inet, 'prior@example.com', 'accepted', now())
+        """
+    )
+
+    called = {"hashed": False}
+
+    def tripwire(_password: str) -> str:
+        called["hashed"] = True
+        raise AssertionError("bcrypt was called on a rate-limited request")
+
+    from backend.auth import password as password_module
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(password_module, "hash_password", tripwire)
+    monkeypatch.setattr(auth_route, "hash_password", tripwire)
+
+    _with_ip(monkeypatch, "10.5.0.1")
+    r = await _signup(client, "late@example.com")
+    assert r.status_code == 429
+    assert called["hashed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants — constants cannot be env-configurable
+# ---------------------------------------------------------------------------
+
+
+def test_constants_are_hardcoded_exact_values():
+    assert signup_rate_limit.PER_IP_WINDOW_SECONDS == 3600
+    assert signup_rate_limit.PER_IP_LIMIT == 1
+    assert signup_rate_limit.GLOBAL_WINDOW_SECONDS == 600
+    assert signup_rate_limit.GLOBAL_LIMIT == 25
+
+
+def test_module_does_not_read_environment():
+    src = inspect.getsource(signup_rate_limit)
+    assert "os.environ" not in src, "signup_rate_limit.py must not read env vars"
+    assert "getenv" not in src, "signup_rate_limit.py must not read env vars"
+
+
+_ = uuid4  # kept for ad-hoc use; silences unused-import lint

--- a/app/frontend/src/lib/authApi.ts
+++ b/app/frontend/src/lib/authApi.ts
@@ -29,11 +29,20 @@ export interface AuthMeResponse extends AuthUser {
   rate_window_resets_at: string | null;
 }
 
+/**
+ * Scope of a signup 429. `"ip"` = this visitor just signed up; `"global"` =
+ * the whole service is throttling. The frontend uses this to pick the copy.
+ */
+export type SignupRateLimitScope = 'ip' | 'global';
+
 export class AuthError extends Error {
   status: number;
-  constructor(status: number, message: string) {
+  /** Present only when the backend returned a structured 429 for signup. */
+  rateLimitScope?: SignupRateLimitScope;
+  constructor(status: number, message: string, rateLimitScope?: SignupRateLimitScope) {
     super(message);
     this.status = status;
+    this.rateLimitScope = rateLimitScope;
   }
 }
 
@@ -45,13 +54,19 @@ async function authRequest<T>(path: string, init: RequestInit): Promise<T> {
   });
   if (!res.ok) {
     let detail = res.statusText;
+    let scope: SignupRateLimitScope | undefined;
     try {
       const body = await res.json();
-      if (body?.detail) detail = body.detail;
+      if (body?.error === 'signup_rate_limited' && typeof body?.message === 'string') {
+        detail = body.message;
+        if (body.scope === 'ip' || body.scope === 'global') scope = body.scope;
+      } else if (body?.detail) {
+        detail = body.detail;
+      }
     } catch {
       // fall through with statusText
     }
-    throw new AuthError(res.status, detail);
+    throw new AuthError(res.status, detail, scope);
   }
   if (res.status === 204) return undefined as unknown as T;
   return res.json() as Promise<T>;

--- a/app/frontend/src/pages/Signup.tsx
+++ b/app/frontend/src/pages/Signup.tsx
@@ -1,12 +1,15 @@
 import { FormEvent, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import { AuthError } from '../lib/authApi';
+
+type FormErrorKind = 'error' | 'warning';
 
 export function Signup() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<{ kind: FormErrorKind; msg: string } | null>(null);
 
   const { signup } = useAuth();
   const navigate = useNavigate();
@@ -15,7 +18,7 @@ export function Signup() {
     e.preventDefault();
     setFormError(null);
     if (password.length < 8) {
-      setFormError('Password must be at least 8 characters');
+      setFormError({ kind: 'error', msg: 'Password must be at least 8 characters' });
       return;
     }
     setSubmitting(true);
@@ -23,8 +26,14 @@ export function Signup() {
       await signup(email, password);
       navigate('/', { replace: true });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Signup failed';
-      setFormError(msg);
+      // 429 from signup rate-limit is a soft "try again later" — render it as
+      // a yellow warning rather than a red error so real users aren't scared.
+      if (err instanceof AuthError && err.status === 429 && err.rateLimitScope) {
+        setFormError({ kind: 'warning', msg: err.message });
+      } else {
+        const msg = err instanceof Error ? err.message : 'Signup failed';
+        setFormError({ kind: 'error', msg });
+      }
     } finally {
       setSubmitting(false);
     }
@@ -60,9 +69,22 @@ export function Signup() {
             className="mt-1 w-full px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
           />
         </label>
-        {formError && (
+        {formError && formError.kind === 'error' && (
           <div className="text-sm text-[var(--danger)]" role="alert">
-            {formError}
+            {formError.msg}
+          </div>
+        )}
+        {formError && formError.kind === 'warning' && (
+          <div
+            className="text-sm rounded px-3 py-2 border"
+            role="alert"
+            style={{
+              color: 'var(--warning)',
+              backgroundColor: 'var(--warning-bg)',
+              borderColor: 'var(--warning-border)',
+            }}
+          >
+            {formError.msg}
           </div>
         )}
         <button

--- a/app/frontend/src/styles/globals.css
+++ b/app/frontend/src/styles/globals.css
@@ -17,6 +17,9 @@
   --assistant-bubble: #1e293b;
   --success: #10b981;
   --danger: #ef4444;
+  --warning: #f59e0b;
+  --warning-bg: rgba(245, 158, 11, 0.12);
+  --warning-border: rgba(245, 158, 11, 0.35);
 }
 
 * {

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -72,4 +72,14 @@ HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
     CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=3).status == 200 else 1)" || exit 1
 
 # Run from /app so the `backend.main:app` module path resolves.
-CMD ["uv", "--project", "backend", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+#
+# `--proxy-headers --forwarded-allow-ips="*"` tells Starlette to rewrite
+# `request.client.host` from the left-most `X-Forwarded-For` value. Safe here
+# because the app container does NOT publish a host port in compose (only
+# Caddy reaches uvicorn, on the internal Docker network). If anyone ever adds
+# `ports: - "8000:8000"` to this service, IP spoofing becomes possible and
+# signup_rate_limit.py's per-IP cap can be bypassed. See signup_rate_limit.py
+# module docstring for the full trust-boundary argument.
+CMD ["uv", "--project", "backend", "run", "uvicorn", "backend.main:app", \
+     "--host", "0.0.0.0", "--port", "8000", \
+     "--proxy-headers", "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
## Summary
- Adds `signup_rate_limit.py`: 1 accepted signup / IP / hour + 25 global attempts / 10 min, both hardcoded. `pg_advisory_xact_lock` serialises the check so concurrent requests can't both slip past the global cap.
- New `signup_attempts` audit table (ip/email_attempted/outcome) + repo. Every signup attempt is recorded regardless of outcome (`accepted`, `duplicate`, `ip_limited`, `global_limited`).
- `deploy/Dockerfile` enables uvicorn `--proxy-headers --forwarded-allow-ips="*"` so the IP seen by the rate-limiter is the real client IP set by Caddy, not the Docker network hop. Module docstring documents the trust boundary.
- Frontend: `AuthError` surfaces the 429 `scope` field; `Signup.tsx` renders the 429 as a **yellow warning** (new `--warning*` theme vars) because the common trigger is a real user double-clicking, not an attack.
- `CLAUDE.md` protected-paths list extended with the new security-critical files.

Closes #54.

## Test plan
- [x] `uv run pytest tests/` — **48 passed** (11 new real-Postgres tests in `test_signup_rate_limit.py`, covering happy path, per-IP limit, duplicate audit, global limit, window roll-off, IP precedence, bcrypt-skip on 429, hardcoded-constant invariant, no env-var lookup)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — no new errors
- [x] `biome check` on modified frontend files — clean
- [x] `tsc --noEmit` — clean
- [x] **E2E browser validation (agent-browser, Chrome for Testing)**:
  - Happy path: `/signup` → submit → 201 → redirected to `/`, dashboard shows `0/25 messages today`
  - 429 path: logout, back to `/signup`, same IP → stays on `/signup`, yellow banner with exact `_IP_MESSAGE` copy, computed color `rgb(245,158,11)`
  - DB audit: `signup_attempts` has `(127.0.0.1, e2e-first, accepted)` then `(127.0.0.1, e2e-second, ip_limited)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)