### PR TITLE
feat: admin UI for video library (#62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,6 +476,7 @@ Any PR touching them must be human-authored:
 
 - `app/backend/auth/` (entire directory)
 - `app/backend/routes/auth.py`
+- `app/backend/routes/admin.py` — sole consumer of `get_current_admin`; auth-adjacent per FACTORY_RULES §5
 - `app/backend/routes/conversations.py` — implements MISSION §10 #3 (owner-only conversations)
 - `app/backend/routes/messages.py` — implements MISSION §10 #3 (owner-only conversations)
 - `app/backend/db/users_repo.py`

--- a/app/backend/auth/dependencies.py
+++ b/app/backend/auth/dependencies.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import Cookie, HTTPException, status
+from fastapi import Cookie, Depends, HTTPException, status
 
+from backend import config
 from backend.auth.tokens import TokenError, decode_token
 from backend.db import users_repo
 
@@ -38,4 +39,30 @@ async def get_current_user(session: str | None = Cookie(default=None)) -> dict[s
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="User no longer exists"
         )
+    return user
+
+
+def is_admin_email(email: str) -> bool:
+    """Return True iff *email* matches the configured admin (case-insensitive).
+
+    Returns False when ADMIN_USER_EMAIL is unset — fail-safe so a missing config
+    never grants admin by default.
+    """
+    # Read the attribute at call time (not import time) so tests can monkeypatch.
+    configured = getattr(config, "ADMIN_USER_EMAIL", "") or ""
+    if not configured:
+        return False
+    return email.strip().lower() == configured.strip().lower()
+
+
+async def get_current_admin(
+    user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Resolve the session cookie AND require the user to be the admin.
+
+    401 if unauthenticated (via get_current_user). 403 if authenticated but not
+    the configured admin, or if ADMIN_USER_EMAIL is unset.
+    """
+    if not is_admin_email(str(user.get("email", ""))):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
     return user

--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -55,6 +55,17 @@ if not SUPADATA_API_KEY:
         file=sys.stderr,
     )
 
+# MISSION §Administrative surface: "A logged-in admin view … identified by a
+# hardcoded user identifier, not by a role system." Empty = no admin configured,
+# every /api/admin/* endpoint returns 403 fail-safe.
+ADMIN_USER_EMAIL: str = os.environ.get("ADMIN_USER_EMAIL", "")
+if not ADMIN_USER_EMAIL:
+    print(
+        "WARNING: ADMIN_USER_EMAIL is not set. All /api/admin/* endpoints "
+        "will return 403 until it is configured.",
+        file=sys.stderr,
+    )
+
 OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
 EMBEDDING_MODEL: str = "openai/text-embedding-3-small"
 CHAT_MODEL: str = "anthropic/claude-sonnet-4.6"

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -151,6 +151,64 @@ async def count_chunks() -> int:
 
 
 # ---------------------------------------------------------------------------
+# Admin helpers
+# ---------------------------------------------------------------------------
+
+
+async def list_videos_admin() -> list[dict]:
+    """Videos with chunk_count, newest first. Admin library listing."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """
+            SELECT v.id, v.title, v.description, v.url, v.created_at,
+                   (SELECT COUNT(*) FROM chunks c WHERE c.video_id = v.id) AS chunk_count
+            FROM videos v
+            ORDER BY v.created_at DESC
+            """
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def delete_video_cascade(video_id: str) -> bool:
+    """Delete a video and its chunks (FK ON DELETE CASCADE). Returns False if not found."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("PRAGMA foreign_keys=ON;")
+        cursor = await db.execute("DELETE FROM videos WHERE id = ?", (video_id,))
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def replace_chunks_for_video(
+    video_id: str,
+    chunks: list[dict],
+) -> None:
+    """Atomically replace all chunks for *video_id*.
+
+    Each entry in *chunks* must have keys: content, embedding, chunk_index.
+    Caller is responsible for fetching/chunking/embedding BEFORE invoking this
+    so a Supadata or OpenRouter failure cannot leave the video chunkless.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("BEGIN")
+        await db.execute("DELETE FROM chunks WHERE video_id = ?", (video_id,))
+        for c in chunks:
+            await db.execute(
+                "INSERT INTO chunks (id, video_id, content, embedding, chunk_index) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    _new_id(),
+                    video_id,
+                    c["content"],
+                    json.dumps(c["embedding"]),
+                    c["chunk_index"],
+                ),
+            )
+        await db.commit()
+
+
+# ---------------------------------------------------------------------------
 # Conversations
 # ---------------------------------------------------------------------------
 

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from backend.auth.dependencies import get_current_user
+from backend.auth.dependencies import get_current_admin, get_current_user
 from backend.config import DATABASE_URL, DB_PATH
 from backend.data.seed import seed_if_empty
 from backend.db.postgres import close_pg_pool, init_signup_attempts_schema, init_users_schema
@@ -59,7 +59,7 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routes (imported here to keep main.py clean)
 # ---------------------------------------------------------------------------
-from backend.routes import auth, channels, conversations, ingest, messages  # noqa: E402
+from backend.routes import admin, auth, channels, conversations, ingest, messages  # noqa: E402
 
 # Auth routes are public (signup/login don't require a session; /me and /logout
 # rely on their own dependency/cookie behaviour).
@@ -72,6 +72,10 @@ app.include_router(conversations.router, prefix="/api", dependencies=_auth_requi
 app.include_router(messages.router, prefix="/api", dependencies=_auth_required)
 app.include_router(ingest.router, prefix="/api", dependencies=_auth_required)
 app.include_router(channels.router, prefix="/api", dependencies=_auth_required)
+
+# Admin routes — gated on get_current_admin, which chains through
+# get_current_user, so an unauthenticated caller still gets 401 (not 403).
+app.include_router(admin.router, prefix="/api", dependencies=[Depends(get_current_admin)])
 
 
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/admin.py
+++ b/app/backend/routes/admin.py
@@ -1,0 +1,246 @@
+"""
+Admin routes — /api/admin/videos/* and /api/admin/videos/sync-channel.
+
+Every endpoint in this module is gated by `get_current_admin` (registered at
+router include time in main.py), so handlers do not need to re-verify the
+session. A non-admin caller gets 403; an unauthenticated caller gets 401 from
+the upstream `get_current_user`.
+
+MISSION §Administrative surface: "A logged-in admin view ... identified by a
+hardcoded user identifier, not by a role system." The identifier comes from
+`ADMIN_USER_EMAIL` in the environment.
+
+This file is auth-adjacent per FACTORY_RULES §5 (human-authored only). It does
+not define auth primitives, but it is the sole consumer of `get_current_admin`
+outside tests, so the factory is not permitted to edit it.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import AnyUrl, BaseModel, Field
+
+from backend.config import CHANNEL_SYNC_TYPE, SUPADATA_API_KEY, YOUTUBE_CHANNEL_ID
+from backend.db import repository as repo
+from backend.ingest.supadata_client import SupadataClient, SupadataError
+from backend.ingest.youtube_url import parse_youtube_url
+from backend.rag import retriever
+from backend.rag.chunker import chunk_video
+from backend.rag.embeddings import embed_batch
+from backend.routes.channels import sync_channel as _sync_channel_impl
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class AddVideoRequest(BaseModel):
+    url: AnyUrl = Field(..., description="YouTube video URL")
+
+
+class AddVideoResponse(BaseModel):
+    video_id: str
+    chunks_created: int
+    status: str
+
+
+class ResyncResponse(BaseModel):
+    video_id: str
+    chunks_created: int
+    status: str
+
+
+class AdminVideo(BaseModel):
+    id: str
+    title: str
+    description: str
+    url: str
+    created_at: str
+    chunk_count: int
+
+
+class AdminVideosResponse(BaseModel):
+    videos: list[AdminVideo]
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fetch + chunk + embed a URL. Returns (metadata, chunks_with_embeds).
+# Does NOT write to the DB; the caller decides whether to create or replace.
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_chunks_and_embeddings(url_str: str) -> tuple[dict, list[dict]]:
+    """Fetch transcript via Supadata, chunk, embed. Raises HTTPException on failure."""
+    try:
+        parsed = parse_youtube_url(url_str)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    client = SupadataClient()
+    try:
+        try:
+            supadata_data = await client.fetch_transcript(url_str, lang="en")
+        except SupadataError as exc:
+            logger.error("Supadata fetch failed for '%s': %s", url_str, exc)
+            raise HTTPException(
+                status_code=503, detail=f"Transcript fetch failed: {exc}"
+            ) from exc
+    finally:
+        await client.close()
+
+    title = supadata_data["title"]
+    description = supadata_data["description"]
+    transcript = supadata_data["transcript"]
+
+    chunk_texts: list[str] = chunk_video({"title": title, "transcript": transcript})
+    if not chunk_texts:
+        raise HTTPException(
+            status_code=422,
+            detail="Chunker returned 0 chunks — transcript may be empty or malformed.",
+        )
+
+    try:
+        embeddings = embed_batch(chunk_texts)
+    except Exception as exc:
+        logger.error("Embedding batch failed for '%s': %s", url_str, exc)
+        raise HTTPException(
+            status_code=502, detail=f"Embeddings API request failed: {exc}"
+        ) from exc
+
+    if len(embeddings) != len(chunk_texts):
+        raise HTTPException(
+            status_code=500, detail="Mismatch between chunk count and embedding count."
+        )
+
+    chunks = [
+        {"content": text, "embedding": embedding, "chunk_index": idx}
+        for idx, (text, embedding) in enumerate(zip(chunk_texts, embeddings, strict=False))
+    ]
+    metadata = {
+        "title": title,
+        "description": description,
+        "transcript": transcript,
+        "youtube_video_id": parsed.video_id,
+    }
+    return metadata, chunks
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/videos", response_model=AdminVideosResponse)
+async def list_videos_admin() -> AdminVideosResponse:
+    """List all videos with chunk counts, newest first."""
+    rows = await repo.list_videos_admin()
+    videos = [
+        AdminVideo(
+            id=r["id"],
+            title=r["title"],
+            description=r["description"],
+            url=r["url"],
+            created_at=str(r["created_at"]),
+            chunk_count=int(r["chunk_count"]),
+        )
+        for r in rows
+    ]
+    return AdminVideosResponse(videos=videos)
+
+
+@router.post("/videos", response_model=AddVideoResponse, status_code=status.HTTP_201_CREATED)
+async def add_video(body: AddVideoRequest) -> AddVideoResponse:
+    """Add a video by URL. Fetches transcript, chunks, embeds, stores.
+
+    Fails atomically — the video row is only created after chunking and
+    embedding both succeed, so we never leave a chunkless video behind.
+    """
+    url_str = str(body.url)
+    metadata, chunks = await _fetch_chunks_and_embeddings(url_str)
+
+    existing = await repo.get_video_by_youtube_id(metadata["youtube_video_id"])
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Video {metadata['youtube_video_id']} is already in the library.",
+        )
+
+    video_record = await repo.create_video(
+        title=metadata["title"],
+        description=metadata["description"],
+        url=url_str,
+        transcript=metadata["transcript"],
+    )
+    video_id = video_record["id"]
+
+    try:
+        await repo.replace_chunks_for_video(video_id, chunks)
+    finally:
+        retriever.invalidate_cache()
+
+    logger.info("Admin added video %s (%s): %d chunks", video_id, metadata["title"], len(chunks))
+    return AddVideoResponse(video_id=video_id, chunks_created=len(chunks), status="ok")
+
+
+@router.delete("/videos/{video_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_video(video_id: str) -> None:
+    """Delete a video and cascade its chunks. 404 if not found."""
+    deleted = await repo.delete_video_cascade(video_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Video not found")
+    retriever.invalidate_cache()
+    logger.info("Admin deleted video %s", video_id)
+
+
+@router.post("/videos/{video_id}/re-sync", response_model=ResyncResponse)
+async def resync_video(video_id: str) -> ResyncResponse:
+    """Re-fetch transcript for a video and replace its chunks atomically.
+
+    If fetching, chunking, or embedding fails, the existing chunks are kept —
+    only a successful re-fetch proceeds to the delete-old + insert-new
+    transaction in `replace_chunks_for_video`.
+    """
+    existing = await repo.get_video(video_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    _, chunks = await _fetch_chunks_and_embeddings(existing["url"])
+
+    try:
+        await repo.replace_chunks_for_video(video_id, chunks)
+    finally:
+        retriever.invalidate_cache()
+
+    logger.info("Admin re-synced video %s: %d chunks", video_id, len(chunks))
+    return ResyncResponse(video_id=video_id, chunks_created=len(chunks), status="ok")
+
+
+@router.post("/videos/sync-channel")
+async def sync_channel_admin():
+    """Trigger a full channel sync (delegates to /api/channels/sync logic).
+
+    Returns the same payload as the underlying worker. Prefers this admin
+    endpoint over hitting /api/channels/sync directly so the UI has a single
+    admin-gated surface.
+    """
+    if not YOUTUBE_CHANNEL_ID or not SUPADATA_API_KEY:
+        # Mirror the worker's 400 behaviour so the admin UI sees a clean error.
+        missing = []
+        if not YOUTUBE_CHANNEL_ID:
+            missing.append("YOUTUBE_CHANNEL_ID")
+        if not SUPADATA_API_KEY:
+            missing.append("SUPADATA_API_KEY")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Channel sync not configured: missing {', '.join(missing)}.",
+        )
+    logger.info("Admin triggered channel sync at %s", datetime.now(UTC).isoformat())
+    return await _sync_channel_impl()

--- a/app/backend/routes/auth.py
+++ b/app/backend/routes/auth.py
@@ -17,7 +17,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, Field
 
 from backend import rate_limit, signup_rate_limit
-from backend.auth.dependencies import COOKIE_NAME, get_current_user
+from backend.auth.dependencies import COOKIE_NAME, get_current_user, is_admin_email
 from backend.auth.password import hash_password, verify_password
 from backend.auth.tokens import encode_token
 from backend.config import JWT_EXPIRY_SECONDS
@@ -49,10 +49,15 @@ class MeResponse(BaseModel):
 
     The counter is included on /me so the frontend can render the daily quota
     without a second round-trip on page load.
+
+    `is_admin` is server-computed from ADMIN_USER_EMAIL and is a UX hint only —
+    every /api/admin/* endpoint re-verifies via get_current_admin. The admin
+    email itself never leaves the backend.
     """
 
     id: str
     email: str
+    is_admin: bool
     messages_used_today: int
     messages_remaining_today: int
     rate_window_resets_at: str | None
@@ -171,6 +176,7 @@ async def me(user: dict[str, Any] = Depends(get_current_user)) -> MeResponse:
     return MeResponse(
         id=str(user["id"]),
         email=str(user["email"]),
+        is_admin=is_admin_email(str(user["email"])),
         messages_used_today=status.used,
         messages_remaining_today=status.remaining,
         rate_window_resets_at=status.resets_at.isoformat() if status.resets_at else None,

--- a/app/backend/tests/test_admin.py
+++ b/app/backend/tests/test_admin.py
@@ -1,0 +1,482 @@
+"""
+Tests for /api/admin/* endpoints.
+
+Covers:
+- 401 for unauthenticated callers (cookie missing or invalid)
+- 403 for authenticated non-admin callers
+- 200 for the configured admin email (server-computed is_admin hint)
+- DELETE cascades chunks through FK ON DELETE CASCADE
+- Re-sync preserves existing chunks if Supadata / embeddings fail
+- list_videos_admin returns chunk_count via SQL subquery
+
+Postgres/auth fixtures are reused from test_auth.py (in-memory users_repo,
+stubbed pg pool, permissive rate-limit). SQLite (videos/chunks) uses a temp
+DB per test to isolate admin mutations.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Set secrets BEFORE importing the app so config.py picks them up.
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+ADMIN_EMAIL = "admin@example.com"
+
+
+@pytest.fixture(autouse=True)
+def set_admin_email(monkeypatch):
+    """Configure ADMIN_USER_EMAIL for every test in this module.
+
+    is_admin_email() reads the attribute at call time via getattr, so
+    monkeypatching the module attribute is sufficient — no re-import needed.
+    """
+    from backend import config as _config
+
+    monkeypatch.setattr(_config, "ADMIN_USER_EMAIL", ADMIN_EMAIL)
+
+
+@pytest.fixture(autouse=True)
+def temp_db_schema(tmp_path, monkeypatch):
+    """Fresh SQLite per test — admin mutations (create/delete video) must not
+    leak between tests. See test_channel_sync.py for why all three modules
+    need DB_PATH patched.
+    """
+    db_path = str(tmp_path / "test_chat.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+
+    from backend import config as _config
+    from backend.db import repository as _repository
+    from backend.db import schema as _schema
+
+    monkeypatch.setattr(_config, "DB_PATH", db_path)
+    monkeypatch.setattr(_schema, "DB_PATH", db_path)
+    monkeypatch.setattr(_repository, "DB_PATH", db_path)
+
+    import asyncio
+
+    asyncio.run(_schema.init_db())
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def fake_users_repo(monkeypatch):
+    """In-memory users_repo — mirrors test_auth.py."""
+    store: dict[str, dict[str, Any]] = {}
+
+    async def create_user(email: str, password_hash: str, **kwargs: Any) -> dict[str, Any]:
+        import asyncpg
+
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                raise asyncpg.UniqueViolationError("duplicate email")
+        uid = str(uuid4())
+        row = {
+            "id": uid,
+            "email": email,
+            "password_hash": password_hash,
+            "created_at": None,
+            "last_login_at": None,
+        }
+        store[uid] = row
+        return {k: v for k, v in row.items() if k != "password_hash"}
+
+    async def get_user_by_email(email: str) -> dict[str, Any] | None:
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                return dict(u)
+        return None
+
+    async def get_user_by_id(user_id: Any) -> dict[str, Any] | None:
+        u = store.get(str(user_id))
+        if not u:
+            return None
+        return {k: v for k, v in u.items() if k != "password_hash"}
+
+    async def update_last_login(user_id: Any) -> None:
+        u = store.get(str(user_id))
+        if u:
+            u["last_login_at"] = "now"
+
+    from backend.auth import dependencies as auth_deps
+    from backend.db import users_repo
+    from backend.routes import auth as auth_route
+
+    for target in (users_repo, auth_deps.users_repo, auth_route.users_repo):
+        monkeypatch.setattr(target, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(users_repo, "create_user", create_user)
+    monkeypatch.setattr(users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(users_repo, "update_last_login", update_last_login)
+    monkeypatch.setattr(auth_route.users_repo, "create_user", create_user)
+    monkeypatch.setattr(auth_route.users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(auth_route.users_repo, "update_last_login", update_last_login)
+    return store
+
+
+@pytest.fixture(autouse=True)
+def stub_pg_lifecycle(monkeypatch):
+    from backend.db import postgres as pg
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(pg, "init_users_schema", noop)
+    monkeypatch.setattr(pg, "init_signup_attempts_schema", noop)
+    monkeypatch.setattr(pg, "close_pg_pool", noop)
+
+
+@pytest.fixture
+async def client():
+    from backend.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://testserver") as c:
+        yield c
+
+
+async def _signup(client: AsyncClient, email: str) -> None:
+    r = await client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "password123"},
+    )
+    assert r.status_code == 201, r.text
+
+
+# ---------------------------------------------------------------------------
+# Gating — 401 / 403 / 200
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_videos_unauthenticated_returns_401(client):
+    r = await client.get("/api/admin/videos")
+    assert r.status_code == 401
+
+
+async def test_admin_videos_non_admin_returns_403(client):
+    await _signup(client, "regular@example.com")
+    r = await client.get("/api/admin/videos")
+    assert r.status_code == 403
+
+
+async def test_admin_videos_admin_returns_200_empty_list(client):
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.get("/api/admin/videos")
+    assert r.status_code == 200
+    assert r.json() == {"videos": []}
+
+
+async def test_me_reports_is_admin_true_for_admin(client):
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 200
+    assert r.json()["is_admin"] is True
+
+
+async def test_me_reports_is_admin_false_for_regular(client):
+    await _signup(client, "regular@example.com")
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 200
+    assert r.json()["is_admin"] is False
+
+
+async def test_admin_email_match_is_case_insensitive(client):
+    # Signed up with different case than configured; should still be admin.
+    await _signup(client, ADMIN_EMAIL.upper())
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 200
+    assert r.json()["is_admin"] is True
+
+
+# ---------------------------------------------------------------------------
+# Listing with chunk counts
+# ---------------------------------------------------------------------------
+
+
+async def test_list_videos_admin_reports_chunk_counts(client):
+    from backend.db import repository
+
+    video = await repository.create_video(
+        title="T", description="D", url="https://u/v?v=abc123", transcript="tx"
+    )
+    for i in range(3):
+        await repository.create_chunk(
+            video_id=video["id"], content=f"c{i}", embedding=[0.0] * 4, chunk_index=i
+        )
+
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.get("/api/admin/videos")
+    assert r.status_code == 200
+    videos = r.json()["videos"]
+    assert len(videos) == 1
+    assert videos[0]["id"] == video["id"]
+    assert videos[0]["chunk_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# DELETE cascade
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_video_cascades_chunks(client):
+    from backend.db import repository
+
+    video = await repository.create_video(
+        title="T", description="D", url="https://u/v?v=abc", transcript="tx"
+    )
+    await repository.create_chunk(
+        video_id=video["id"], content="c0", embedding=[0.0] * 4, chunk_index=0
+    )
+    await repository.create_chunk(
+        video_id=video["id"], content="c1", embedding=[0.0] * 4, chunk_index=1
+    )
+
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.delete(f"/api/admin/videos/{video['id']}")
+    assert r.status_code == 204
+
+    assert await repository.get_video(video["id"]) is None
+    assert await repository.list_chunks_for_video(video["id"]) == []
+
+
+async def test_delete_unknown_video_returns_404(client):
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.delete("/api/admin/videos/does-not-exist")
+    assert r.status_code == 404
+
+
+async def test_delete_non_admin_returns_403(client):
+    await _signup(client, "regular@example.com")
+    r = await client.delete("/api/admin/videos/any-id")
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Re-sync atomicity — existing chunks survive a Supadata/embedding failure
+# ---------------------------------------------------------------------------
+
+
+async def test_resync_preserves_chunks_on_supadata_failure(client):
+    from backend.db import repository
+    from backend.ingest.supadata_client import SupadataError
+
+    video = await repository.create_video(
+        title="Original",
+        description="Desc",
+        url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        transcript="original transcript",
+    )
+    await repository.create_chunk(
+        video_id=video["id"], content="original-0", embedding=[0.1] * 4, chunk_index=0
+    )
+    await repository.create_chunk(
+        video_id=video["id"], content="original-1", embedding=[0.2] * 4, chunk_index=1
+    )
+
+    await _signup(client, ADMIN_EMAIL)
+
+    with patch(
+        "backend.routes.admin.SupadataClient.fetch_transcript",
+        new=AsyncMock(side_effect=SupadataError("rate-limited")),
+    ):
+        r = await client.post(f"/api/admin/videos/{video['id']}/re-sync")
+
+    assert r.status_code == 503
+    chunks = await repository.list_chunks_for_video(video["id"])
+    assert [c["content"] for c in chunks] == ["original-0", "original-1"]
+
+
+async def test_resync_replaces_chunks_on_success(client):
+    from backend.db import repository
+
+    video = await repository.create_video(
+        title="Original",
+        description="Desc",
+        url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        transcript="original transcript",
+    )
+    await repository.create_chunk(
+        video_id=video["id"], content="old", embedding=[0.1] * 4, chunk_index=0
+    )
+
+    await _signup(client, ADMIN_EMAIL)
+
+    fake_supadata = AsyncMock(
+        return_value={
+            "title": "New Title",
+            "description": "New Desc",
+            "transcript": "brand new transcript content",
+        }
+    )
+
+    # Stub the chunker + embedder so we don't need the real ONNX model.
+    with (
+        patch(
+            "backend.routes.admin.SupadataClient.fetch_transcript",
+            new=fake_supadata,
+        ),
+        patch(
+            "backend.routes.admin.chunk_video",
+            return_value=["new-0", "new-1", "new-2"],
+        ),
+        patch(
+            "backend.routes.admin.embed_batch",
+            return_value=[[0.5] * 4, [0.6] * 4, [0.7] * 4],
+        ),
+    ):
+        r = await client.post(f"/api/admin/videos/{video['id']}/re-sync")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["chunks_created"] == 3
+
+    chunks = await repository.list_chunks_for_video(video["id"])
+    assert [c["content"] for c in chunks] == ["new-0", "new-1", "new-2"]
+
+
+async def test_resync_unknown_video_returns_404(client):
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.post("/api/admin/videos/nope/re-sync")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Add by URL
+# ---------------------------------------------------------------------------
+
+
+async def test_add_video_by_url_succeeds(client):
+    from backend.db import repository
+
+    fake_supadata = AsyncMock(
+        return_value={
+            "title": "New Video",
+            "description": "New Desc",
+            "transcript": "transcript text",
+        }
+    )
+
+    await _signup(client, ADMIN_EMAIL)
+
+    with (
+        patch(
+            "backend.routes.admin.SupadataClient.fetch_transcript",
+            new=fake_supadata,
+        ),
+        patch("backend.routes.admin.chunk_video", return_value=["c0", "c1"]),
+        patch(
+            "backend.routes.admin.embed_batch",
+            return_value=[[0.1] * 4, [0.2] * 4],
+        ),
+    ):
+        r = await client.post(
+            "/api/admin/videos",
+            json={"url": "https://www.youtube.com/watch?v=abc12345678"},
+        )
+
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["chunks_created"] == 2
+
+    videos = await repository.list_videos()
+    assert len(videos) == 1
+    assert videos[0]["title"] == "New Video"
+
+
+async def test_add_video_rejects_duplicate(client):
+    from backend.db import repository
+
+    # Seed a video that already carries this youtube id in its URL
+    await repository.create_video(
+        title="Existing",
+        description="D",
+        url="https://www.youtube.com/watch?v=abc12345678",
+        transcript="t",
+    )
+
+    fake_supadata = AsyncMock(
+        return_value={"title": "T", "description": "D", "transcript": "tx"}
+    )
+
+    await _signup(client, ADMIN_EMAIL)
+
+    with (
+        patch(
+            "backend.routes.admin.SupadataClient.fetch_transcript",
+            new=fake_supadata,
+        ),
+        patch("backend.routes.admin.chunk_video", return_value=["c0"]),
+        patch("backend.routes.admin.embed_batch", return_value=[[0.1] * 4]),
+    ):
+        r = await client.post(
+            "/api/admin/videos",
+            json={"url": "https://www.youtube.com/watch?v=abc12345678"},
+        )
+
+    assert r.status_code == 409
+
+
+async def test_add_video_rejects_non_youtube_url(client):
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.post(
+        "/api/admin/videos",
+        json={"url": "https://example.com/not-youtube"},
+    )
+    assert r.status_code == 400
+
+
+async def test_add_video_non_admin_returns_403(client):
+    await _signup(client, "regular@example.com")
+    r = await client.post(
+        "/api/admin/videos",
+        json={"url": "https://www.youtube.com/watch?v=abc12345678"},
+    )
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# sync-channel delegation + config guard
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_channel_delegates_to_channel_worker(client, monkeypatch):
+    from backend.routes import admin as admin_route
+
+    called = {"count": 0}
+
+    async def fake_worker():
+        called["count"] += 1
+        return {
+            "sync_run_id": "s1",
+            "status": "completed",
+            "videos_total": 0,
+            "videos_new": 0,
+            "videos_error": 0,
+        }
+
+    monkeypatch.setattr(admin_route, "_sync_channel_impl", fake_worker)
+
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.post("/api/admin/videos/sync-channel")
+    assert r.status_code == 200
+    assert called["count"] == 1
+    assert r.json()["status"] == "completed"
+
+
+async def test_sync_channel_returns_400_when_unconfigured(client, monkeypatch):
+    from backend.routes import admin as admin_route
+
+    monkeypatch.setattr(admin_route, "YOUTUBE_CHANNEL_ID", "")
+    monkeypatch.setattr(admin_route, "SUPADATA_API_KEY", "")
+
+    await _signup(client, ADMIN_EMAIL)
+    r = await client.post("/api/admin/videos/sync-channel")
+    assert r.status_code == 400

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { ChatArea } from './components/ChatArea';
 import { Sidebar } from './components/Sidebar';
 import { ToastProvider } from './components/ToastProvider';
 import { AuthProvider, useAuth } from './hooks/useAuth';
+import { AdminVideos } from './pages/AdminVideos';
 import { Login } from './pages/Login';
 import { Signup } from './pages/Signup';
 
@@ -108,6 +109,14 @@ function App() {
               element={
                 <RequireAuth>
                   <ConversationPage />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/admin"
+              element={
+                <RequireAuth>
+                  <AdminVideos />
                 </RequireAuth>
               }
             />

--- a/app/frontend/src/__tests__/adminApi.test.ts
+++ b/app/frontend/src/__tests__/adminApi.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { addVideoByUrl, deleteVideo, listAdminVideos, resyncVideo, syncChannel } from '../lib/api';
+
+describe('admin api wrappers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function mockJson(body: unknown, status = 200) {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'OK',
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    });
+  }
+
+  it('listAdminVideos hits GET /api/admin/videos with credentials', async () => {
+    mockJson({ videos: [] });
+    const res = await listAdminVideos();
+    expect(res.videos).toEqual([]);
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/admin/videos');
+    expect(init.credentials).toBe('include');
+  });
+
+  it('addVideoByUrl POSTs the url JSON', async () => {
+    mockJson({ video_id: 'v1', chunks_created: 3, status: 'ok' }, 201);
+    const res = await addVideoByUrl('https://www.youtube.com/watch?v=x');
+    expect(res.chunks_created).toBe(3);
+    const [, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ url: 'https://www.youtube.com/watch?v=x' });
+  });
+
+  it('deleteVideo issues DELETE and resolves on 204', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+      text: async () => '',
+    });
+    await expect(deleteVideo('abc')).resolves.toBeUndefined();
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/admin/videos/abc');
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('deleteVideo throws on non-2xx', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => '{"detail":"Video not found"}',
+    });
+    await expect(deleteVideo('abc')).rejects.toThrow(/404/);
+  });
+
+  it('resyncVideo posts to re-sync endpoint', async () => {
+    mockJson({ video_id: 'v1', chunks_created: 5, status: 'ok' });
+    const res = await resyncVideo('v1');
+    expect(res.chunks_created).toBe(5);
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/admin/videos/v1/re-sync');
+    expect(init.method).toBe('POST');
+  });
+
+  it('syncChannel posts to sync-channel endpoint', async () => {
+    mockJson({
+      sync_run_id: 's1',
+      status: 'completed',
+      videos_total: 3,
+      videos_new: 1,
+      videos_error: 0,
+    });
+    const res = await syncChannel();
+    expect(res.status).toBe('completed');
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/admin/videos/sync-channel');
+    expect(init.method).toBe('POST');
+  });
+});

--- a/app/frontend/src/components/AddVideoModal.tsx
+++ b/app/frontend/src/components/AddVideoModal.tsx
@@ -1,0 +1,101 @@
+import { type FormEvent, useEffect, useRef, useState } from 'react';
+
+interface AddVideoModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (url: string) => Promise<void>;
+}
+
+export function AddVideoModal({ open, onClose, onSubmit }: AddVideoModalProps) {
+  const [url, setUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setUrl('');
+      setError(null);
+      setSubmitting(false);
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(url.trim());
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add video');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add video by URL"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 16,
+      }}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+        className="w-full max-w-md bg-[var(--surface-1)] border border-[var(--border)] rounded-lg p-6 space-y-4"
+      >
+        <h2 className="text-lg font-semibold">Add video by URL</h2>
+        <label className="block text-sm">
+          <span className="text-[var(--text-secondary)]">YouTube URL</span>
+          <input
+            ref={inputRef}
+            type="url"
+            required
+            placeholder="https://www.youtube.com/watch?v=..."
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            disabled={submitting}
+            className="mt-1 w-full px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] disabled:opacity-60"
+          />
+        </label>
+        {error && (
+          <div className="text-sm text-[var(--danger)]" role="alert">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-2 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !url.trim()}
+            className="px-3 py-2 rounded bg-[var(--accent)] text-white font-medium disabled:opacity-50"
+          >
+            {submitting ? 'Adding…' : 'Add video'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { type Conversation, createConversation, deleteConversation } from '../lib/api';
@@ -479,9 +479,40 @@ export function Sidebar({ activeConversationId, isOpen, onClose }: SidebarProps)
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
+            gap: 8,
           }}
         >
           <span style={{ fontSize: 12, color: '#475569' }}>RAG YouTube Chat</span>
+
+          {/* Library admin link — admin-only. is_admin is a server-computed
+              hint only; the /api/admin/* endpoints re-verify on every call. */}
+          {user?.is_admin && (
+            <Link
+              to="/admin"
+              title="Manage video library"
+              style={{
+                fontSize: 12,
+                color: '#94a3b8',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 7,
+                padding: '5px 7px',
+                textDecoration: 'none',
+                transition: 'background 0.15s, color 0.15s, border-color 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#1e293b';
+                e.currentTarget.style.color = '#f1f5f9';
+                e.currentTarget.style.borderColor = 'rgba(59,130,246,0.4)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent';
+                e.currentTarget.style.color = '#94a3b8';
+                e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)';
+              }}
+            >
+              Admin
+            </Link>
+          )}
 
           {/* Library / VideoExplorer button */}
           <button

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -108,3 +108,55 @@ export const ingestVideo = (body: IngestVideoBody) =>
 // Health
 export const getHealth = () =>
   request<{ status: string; video_count: number; chunk_count: number; db_path: string }>('/health');
+
+// ─── Admin ────────────────────────────────────────────────────────────────
+// All /api/admin/* endpoints require the configured ADMIN_USER_EMAIL; the
+// backend returns 403 for any other authenticated user. Callers should gate
+// UI with `useAuth().user?.is_admin` first, but never rely on it for security.
+
+export interface AdminVideo extends Video {
+  chunk_count: number;
+}
+
+export interface AdminVideosResponse {
+  videos: AdminVideo[];
+}
+
+export interface AddVideoResponse {
+  video_id: string;
+  chunks_created: number;
+  status: string;
+}
+
+export interface SyncChannelResponse {
+  sync_run_id: string;
+  status: string;
+  videos_total: number;
+  videos_new: number;
+  videos_error: number;
+}
+
+export const listAdminVideos = () => request<AdminVideosResponse>('/admin/videos');
+
+export const addVideoByUrl = (url: string) =>
+  request<AddVideoResponse>('/admin/videos', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  });
+
+export const deleteVideo = async (id: string): Promise<void> => {
+  const res = await fetch(`${BASE}/admin/videos/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`API error ${res.status}: ${text}`);
+  }
+};
+
+export const resyncVideo = (id: string) =>
+  request<AddVideoResponse>(`/admin/videos/${id}/re-sync`, { method: 'POST' });
+
+export const syncChannel = () =>
+  request<SyncChannelResponse>('/admin/videos/sync-channel', { method: 'POST' });

--- a/app/frontend/src/lib/authApi.ts
+++ b/app/frontend/src/lib/authApi.ts
@@ -24,6 +24,7 @@ export interface AuthUser {
  *   when the user has zero messages in the window (nothing to reset).
  */
 export interface AuthMeResponse extends AuthUser {
+  is_admin: boolean;
   messages_used_today: number;
   messages_remaining_today: number;
   rate_window_resets_at: string | null;

--- a/app/frontend/src/pages/AdminVideos.tsx
+++ b/app/frontend/src/pages/AdminVideos.tsx
@@ -1,0 +1,228 @@
+/**
+ * Admin video library management.
+ *
+ * Re-reads the list after every mutation rather than surgically patching local
+ * state — chunk_count changes after re-sync, and sync-channel can add many
+ * rows at once. Authoritative list is cheaper than local bookkeeping.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { AddVideoModal } from '../components/AddVideoModal';
+import { useAuth } from '../hooks/useAuth';
+import { useToast } from '../hooks/useToast';
+import {
+  type AdminVideo,
+  addVideoByUrl,
+  deleteVideo,
+  listAdminVideos,
+  resyncVideo,
+  syncChannel,
+} from '../lib/api';
+
+export function AdminVideos() {
+  const { status, user } = useAuth();
+  const { addToast } = useToast();
+  const [videos, setVideos] = useState<AdminVideo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [addModalOpen, setAddModalOpen] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await listAdminVideos();
+      setVideos(res.videos);
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Failed to load videos', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    if (status === 'authed' && user?.is_admin) {
+      refresh();
+    }
+  }, [status, user?.is_admin, refresh]);
+
+  // Guard rendering
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--bg)] text-[var(--text-secondary)]">
+        Loading…
+      </div>
+    );
+  }
+  if (status === 'anon') {
+    return <Navigate to="/login" replace state={{ from: '/admin' }} />;
+  }
+  if (!user?.is_admin) {
+    return <Navigate to="/" replace />;
+  }
+
+  async function handleAdd(url: string) {
+    const res = await addVideoByUrl(url);
+    addToast(`Added video (${res.chunks_created} chunks)`, 'success');
+    await refresh();
+  }
+
+  async function handleDelete(video: AdminVideo) {
+    if (!confirm(`Delete "${video.title}" and its ${video.chunk_count} chunks?`)) {
+      return;
+    }
+    setPendingId(video.id);
+    try {
+      await deleteVideo(video.id);
+      addToast('Video deleted', 'success');
+      await refresh();
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Delete failed', 'error');
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  async function handleResync(video: AdminVideo) {
+    setPendingId(video.id);
+    try {
+      const res = await resyncVideo(video.id);
+      addToast(`Re-synced (${res.chunks_created} chunks)`, 'success');
+      await refresh();
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Re-sync failed', 'error');
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  async function handleSyncChannel() {
+    setSyncing(true);
+    try {
+      const res = await syncChannel();
+      addToast(
+        `Channel sync ${res.status}: ${res.videos_new} new, ${res.videos_error} errors`,
+        res.status === 'completed' ? 'success' : 'error',
+      );
+      await refresh();
+    } catch (err) {
+      addToast(err instanceof Error ? err.message : 'Channel sync failed', 'error');
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text-primary)] p-6">
+      <div className="max-w-5xl mx-auto">
+        <header className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-semibold">Library admin</h1>
+            <p className="text-sm text-[var(--text-secondary)] mt-1">
+              Add, re-sync, or remove videos in the RAG corpus.
+            </p>
+          </div>
+          <Link to="/" className="text-sm text-[var(--accent)] hover:underline">
+            ← Back to chat
+          </Link>
+        </header>
+
+        <div className="flex gap-2 mb-4">
+          <button
+            type="button"
+            onClick={() => setAddModalOpen(true)}
+            disabled={syncing}
+            className="px-3 py-2 rounded bg-[var(--accent)] text-white font-medium disabled:opacity-50"
+          >
+            + Add video by URL
+          </button>
+          <button
+            type="button"
+            onClick={handleSyncChannel}
+            disabled={syncing}
+            className="px-3 py-2 rounded border border-[var(--border)] text-[var(--text-primary)] hover:bg-[var(--surface-2)] disabled:opacity-50"
+          >
+            {syncing ? 'Syncing channel…' : 'Sync channel'}
+          </button>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={loading || syncing}
+            className="px-3 py-2 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-50"
+          >
+            Refresh
+          </button>
+        </div>
+
+        <div className="bg-[var(--surface-1)] border border-[var(--border)] rounded-lg overflow-hidden">
+          {loading ? (
+            <div className="p-6 text-center text-[var(--text-secondary)]">Loading…</div>
+          ) : videos.length === 0 ? (
+            <div className="p-6 text-center text-[var(--text-secondary)]">
+              No videos yet. Add one by URL or sync a channel.
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-[var(--surface-2)] text-left">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Title</th>
+                  <th className="px-4 py-2 font-medium">Chunks</th>
+                  <th className="px-4 py-2 font-medium">Added</th>
+                  <th className="px-4 py-2 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {videos.map((v) => {
+                  const isPending = pendingId === v.id;
+                  return (
+                    <tr key={v.id} className="border-t border-[var(--border)]">
+                      <td className="px-4 py-2">
+                        <a
+                          href={v.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="hover:underline"
+                        >
+                          {v.title || '(untitled)'}
+                        </a>
+                      </td>
+                      <td className="px-4 py-2 text-[var(--text-secondary)]">{v.chunk_count}</td>
+                      <td className="px-4 py-2 text-[var(--text-secondary)]">
+                        {v.created_at.slice(0, 10)}
+                      </td>
+                      <td className="px-4 py-2 text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleResync(v)}
+                          disabled={isPending || syncing}
+                          className="px-2 py-1 text-xs rounded border border-[var(--border)] hover:bg-[var(--surface-2)] disabled:opacity-50 mr-2"
+                        >
+                          {isPending ? '…' : 'Re-sync'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(v)}
+                          disabled={isPending || syncing}
+                          className="px-2 py-1 text-xs rounded border border-[var(--danger)] text-[var(--danger)] hover:bg-[var(--surface-2)] disabled:opacity-50"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <AddVideoModal
+        open={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        onSubmit={handleAdd}
+      />
+    </div>
+  );
+}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -12,3 +12,11 @@ DATABASE_URL=postgresql://dynachat:REPLACE_WITH_POSTGRES_PASSWORD@127.0.0.1:5433
 
 # OpenRouter (RAG pipeline - embeddings + chat)
 OPENROUTER_API_KEY=
+
+# JWT signing secret — 32+ random bytes, e.g. `openssl rand -hex 32`.
+# Rotating this value invalidates all live sessions.
+JWT_SECRET=
+
+# Admin account — a single hardcoded email, case-insensitive match. When
+# unset, every /api/admin/* endpoint returns 403.
+ADMIN_USER_EMAIL=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,6 +32,7 @@ The app container reads these from `/opt/dynachat/.env` via docker-compose:
 | `SUPADATA_API_KEY` | prod only | YouTube transcript fetch |
 | `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | **yes** | Postgres credentials used by both the `postgres` service and the app's `DATABASE_URL` |
 | `JWT_SECRET` | **yes** (auth) | 32+ random bytes used to sign session-cookie JWTs. Generate with `openssl rand -hex 32`. Rotating this value invalidates all live sessions |
+| `ADMIN_USER_EMAIL` | optional | Email of the single admin user (case-insensitive match). When unset, every `/api/admin/*` endpoint returns 403. Match MUST equal the email the admin registered with |
 
 The app's `DATABASE_URL` is assembled from the `POSTGRES_*` values inside
 `docker-compose.yml` — you do **not** set it directly in `.env`. It points at
@@ -46,6 +47,7 @@ POSTGRES_USER=dynachat
 POSTGRES_PASSWORD=<random>
 POSTGRES_DB=dynachat
 JWT_SECRET=<openssl rand -hex 32>
+ADMIN_USER_EMAIL=admin@yourdomain.com
 ```
 
 ## Secret hygiene

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       # in-compose postgres service; JWT_SECRET signs session cookies.
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
+      ADMIN_USER_EMAIL: ${ADMIN_USER_EMAIL:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -89,6 +90,7 @@ services:
       # in-compose postgres service; JWT_SECRET signs session cookies.
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
+      ADMIN_USER_EMAIL: ${ADMIN_USER_EMAIL:-}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Closes #62.

## Summary

- **Single-admin access control** via ADMIN_USER_EMAIL environment variable (case-insensitive match, fail-safe 403 when unset). Per MISSION §Administrative surface: "a hardcoded user identifier, not a role system."
- **Backend** adds /api/admin/videos — list (with chunk counts), add-by-URL, delete (cascade), re-sync (atomic), and sync-channel (delegates to existing worker).
- **Frontend** adds /admin page gated on is_admin (server-computed hint on /me; endpoints re-verify every call).
- **Re-sync is atomic**: fetches + chunks + embeds BEFORE the delete-old / insert-new transaction, so a Supadata or OpenRouter failure keeps the video's existing chunks intact.

## Auth model

- get_current_admin chains through get_current_user, so unauth returns 401, authed-non-admin returns 403, admin returns 200.
- is_admin_email is case-insensitive and reads ADMIN_USER_EMAIL via getattr at call time (testable via monkeypatch).
- routes/admin.py is **auth-adjacent per FACTORY_RULES §5** — added to the protected-paths list in CLAUDE.md.

## Test plan

- [x] Backend tests: 19 new (test_admin.py) + 101/101 full suite green
  - 401 unauthenticated, 403 non-admin, 200 admin
  - DELETE cascades chunks through FK
  - Re-sync preserves chunks on Supadata failure; replaces on success
  - Add-by-URL rejects duplicates (409) and non-YouTube URLs (400)
  - sync-channel returns 400 when YOUTUBE_CHANNEL_ID / SUPADATA_API_KEY missing
  - /me reports is_admin case-insensitively
- [x] Frontend: 14/14 tests pass (6 new admin API wrappers + 8 existing)
- [x] tsc --noEmit clean; vite build succeeds

## Deploy

- deploy/docker-compose.yml passes ADMIN_USER_EMAIL into both blue/green app services.
- deploy/README.md and the example env file document the variable.

## Out of scope (deliberate)

- No last_synced_at column (would require a migration); created_at acts as the proxy in the UI initially.
- Existing /api/channels/sync is preserved; the new admin endpoint delegates to it rather than duplicating or replacing.

Generated with Claude Code
