### PR TITLE
chore(services): migrate supadata SDK from deprecated youtube.transcript() to unified transcript()

### DIFF
--- a/app/backend/services/supadata.py
+++ b/app/backend/services/supadata.py
@@ -113,10 +113,9 @@ async def get_transcript(video_id: str, lang: str = "en") -> str | None:
             result = client.transcript(url=f"https://youtube.com/watch?v={video_id}", lang=lang)
             if not result:
                 return None
-            # Supadata SDK ≥1.x returns a `content` field instead of `text`.
-            # `content` is either a plain string (when the caller asked for
-            # text mode) or a list of TranscriptChunk(text, offset, duration,
-            # lang) segments. Normalize to a single string.
+            # `content` is either a plain string (text mode) or a list of
+            # TranscriptChunk(text, offset, duration, lang) segments.
+            # Normalize to a single string.
             content = getattr(result, "content", None)
             if content is None:
                 return None

--- a/app/backend/services/supadata.py
+++ b/app/backend/services/supadata.py
@@ -89,7 +89,7 @@ async def get_channel_video_ids(
             logger.error("Network error in get_channel_video_ids: %s", exc)
             raise SupadataError(error="network_error", message=str(exc), details="") from exc
 
-    raise RuntimeError("unreachable")
+    raise RuntimeError("unreachable")  # mypy needs this for return-type inference
 
 
 async def get_transcript(video_id: str, lang: str = "en") -> str | None:

--- a/app/backend/services/supadata.py
+++ b/app/backend/services/supadata.py
@@ -110,7 +110,7 @@ async def get_transcript(video_id: str, lang: str = "en") -> str | None:
 
     for attempt in range(3):
         try:
-            result = client.youtube.transcript(video_id=video_id, lang=lang)
+            result = client.transcript(url=f"https://youtube.com/watch?v={video_id}", lang=lang)
             if not result:
                 return None
             # Supadata SDK ≥1.x returns a `content` field instead of `text`.

--- a/app/backend/tests/test_channel_sync.py
+++ b/app/backend/tests/test_channel_sync.py
@@ -78,10 +78,31 @@ class MockChannelVideosResult:
 
 
 class MockTranscriptResult:
-    """Plain sync object returned by client.transcript()."""
+    """Plain sync object returned by client.transcript().
+
+    The `text` parameter feeds `.content` (matching the real SDK's field name)
+    — the name is a legacy holdover from the pre-migration API.
+    """
 
     def __init__(self, text="This is a sample transcript for the video."):
         self.content = text
+
+
+class MockTranscriptChunk:
+    """Mimics a TranscriptChunk segment returned by the Supadata SDK."""
+
+    def __init__(self, text: str, offset: float = 0.0, duration: float = 1.0, lang: str = "en"):
+        self.text = text
+        self.offset = offset
+        self.duration = duration
+        self.lang = lang
+
+
+class MockTranscriptResultList:
+    """Plain sync object whose .content is a list of TranscriptChunk segments."""
+
+    def __init__(self, chunks: list[MockTranscriptChunk] | None = None):
+        self.content = chunks or []
 
 
 class NoTranscriptResult:

--- a/app/backend/tests/test_channel_sync.py
+++ b/app/backend/tests/test_channel_sync.py
@@ -136,9 +136,7 @@ async def test_sync_channel_idempotent_skips_existing_videos():
         mock_client.youtube.channel.videos = make_mock_channel_videos(
             ["dQw4w9WgXcQ", "abc123def456"]
         )
-        mock_client.transcript = make_mock_transcript(
-            "This is a sample transcript for the video."
-        )
+        mock_client.transcript = make_mock_transcript("This is a sample transcript for the video.")
         mock_get_client.return_value = mock_client
 
         # Patch where names are bound in channels.py (import = local name)
@@ -164,9 +162,7 @@ async def test_sync_channel_returns_sync_run_id():
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = make_mock_channel_videos(["dQw4w9WgXcQ"])
-        mock_client.transcript = make_mock_transcript(
-            "This is a sample transcript for the video."
-        )
+        mock_client.transcript = make_mock_transcript("This is a sample transcript for the video.")
         mock_get_client.return_value = mock_client
 
         with (
@@ -241,9 +237,7 @@ async def test_sync_channel_429_triggers_backoff():
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = mock_channel_videos_with_retry
-        mock_client.transcript = make_mock_transcript(
-            "This is a sample transcript for the video."
-        )
+        mock_client.transcript = make_mock_transcript("This is a sample transcript for the video.")
         mock_get_client.return_value = mock_client
 
         with (

--- a/app/backend/tests/test_channel_sync.py
+++ b/app/backend/tests/test_channel_sync.py
@@ -78,17 +78,17 @@ class MockChannelVideosResult:
 
 
 class MockTranscriptResult:
-    """Plain sync object returned by client.youtube.transcript()."""
+    """Plain sync object returned by client.transcript()."""
 
     def __init__(self, text="This is a sample transcript for the video."):
-        self.text = text
+        self.content = text
 
 
 class NoTranscriptResult:
     """Plain sync object returned when no transcript is available."""
 
     def __init__(self):
-        self.text = None
+        self.content = None
 
 
 def make_mock_channel_videos(video_ids, short_ids=None, live_ids=None):
@@ -136,7 +136,7 @@ async def test_sync_channel_idempotent_skips_existing_videos():
         mock_client.youtube.channel.videos = make_mock_channel_videos(
             ["dQw4w9WgXcQ", "abc123def456"]
         )
-        mock_client.youtube.transcript = make_mock_transcript(
+        mock_client.transcript = make_mock_transcript(
             "This is a sample transcript for the video."
         )
         mock_get_client.return_value = mock_client
@@ -164,7 +164,7 @@ async def test_sync_channel_returns_sync_run_id():
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = make_mock_channel_videos(["dQw4w9WgXcQ"])
-        mock_client.youtube.transcript = make_mock_transcript(
+        mock_client.transcript = make_mock_transcript(
             "This is a sample transcript for the video."
         )
         mock_get_client.return_value = mock_client
@@ -209,7 +209,7 @@ async def test_sync_channel_no_transcript_creates_error_row():
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = make_mock_channel_videos(["noTranscriptVideo"])
-        mock_client.youtube.transcript = no_transcript_fn
+        mock_client.transcript = no_transcript_fn
         mock_get_client.return_value = mock_client
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -241,7 +241,7 @@ async def test_sync_channel_429_triggers_backoff():
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = mock_channel_videos_with_retry
-        mock_client.youtube.transcript = make_mock_transcript(
+        mock_client.transcript = make_mock_transcript(
             "This is a sample transcript for the video."
         )
         mock_get_client.return_value = mock_client
@@ -341,7 +341,7 @@ async def test_sync_channel_embedding_failure_updates_sync_video_status(
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = make_mock_channel_videos(["dQw4w9WgXcQ"])
-        mock_client.youtube.transcript = make_mock_transcript("Sample transcript.")
+        mock_client.transcript = make_mock_transcript("Sample transcript.")
         mock_get_client.return_value = mock_client
 
         with (
@@ -371,7 +371,7 @@ async def test_sync_channel_empty_chunks_videos_error_not_new(temp_db_schema, by
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = make_mock_channel_videos(["dQw4w9WgXcQ"])
-        mock_client.youtube.transcript = make_mock_transcript("Sample transcript.")
+        mock_client.transcript = make_mock_transcript("Sample transcript.")
         mock_get_client.return_value = mock_client
 
         with patch("backend.routes.channels.chunk_video", return_value=[]):
@@ -407,7 +407,7 @@ async def test_sync_channel_all_videos_error_status_failed(temp_db_schema, bypas
         mock_client.youtube.channel.videos = make_mock_channel_videos(
             ["video1", "video2", "video3"]
         )
-        mock_client.youtube.transcript = always_fail_transcript
+        mock_client.transcript = always_fail_transcript
         mock_get_client.return_value = mock_client
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -426,7 +426,7 @@ async def test_sync_channel_invalidate_cache_called(temp_db_schema, bypass_auth)
     with patch("backend.services.supadata._get_client") as mock_get_client:
         mock_client = AsyncMock()
         mock_client.youtube.channel.videos = make_mock_channel_videos(["dQw4w9WgXcQ"])
-        mock_client.youtube.transcript = make_mock_transcript("Sample transcript.")
+        mock_client.transcript = make_mock_transcript("Sample transcript.")
         mock_get_client.return_value = mock_client
 
         with (

--- a/app/backend/tests/test_services_supadata.py
+++ b/app/backend/tests/test_services_supadata.py
@@ -1,0 +1,323 @@
+"""
+Direct unit tests for backend.services.supadata.
+
+Tests get_transcript() normalization and error handling in isolation,
+independent of the Alembic-pending test_channel_sync.py skip.
+Uses unittest.mock.patch to replace _get_client().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from supadata import SupadataError
+
+from backend.services.supadata import get_transcript
+
+
+class MockTranscriptChunk:
+    """Mimics the TranscriptChunk segment returned by the Supadata SDK."""
+
+    def __init__(self, text: str, offset: float = 0.0, duration: float = 1.0, lang: str = "en"):
+        self.text = text
+        self.offset = offset
+        self.duration = duration
+        self.lang = lang
+
+
+class MockTranscriptResultString:
+    """Mock result where content is a plain string."""
+
+    def __init__(self, text: str):
+        self.content = text
+
+
+class MockTranscriptResultList:
+    """Mock result where content is a list of TranscriptChunk segments."""
+
+    def __init__(self, chunks: list[MockTranscriptChunk]):
+        self.content = chunks
+
+
+class MockTranscriptResultNone:
+    """Mock result where content is None (no transcript available)."""
+
+    def __init__(self):
+        self.content = None
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_transcript — string content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_returns_string_content():
+    """When SDK returns content as a plain string, it is returned as-is."""
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultString(
+        "Hello world, this is a transcript."
+    )
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result == "Hello world, this is a transcript."
+    mock_client.transcript.assert_called_once_with(
+        url="https://youtube.com/watch?v=dQw4w9WgXcQ", lang="en"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_empty_string_returns_none():
+    """When SDK returns an empty string content, get_transcript returns None."""
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultString("")
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_whitespace_only_string_returned_as_is():
+    """When SDK returns whitespace-only string, it is returned as-is (not stripped to None).
+
+    The string case does NOT strip whitespace — only the list-of-chunks path does.
+    This matches the existing normalization behavior in supadata.py.
+    """
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultString("   \n\t  ")
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result == "   \n\t  "  # returned as-is, not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_transcript — list of chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_handles_list_of_chunks():
+    """When SDK returns content as a list of TranscriptChunk, they are joined."""
+    chunks = [
+        MockTranscriptChunk("First segment."),
+        MockTranscriptChunk("Second segment."),
+        MockTranscriptChunk("Third segment."),
+    ]
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultList(chunks)
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result == "First segment. Second segment. Third segment."
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_list_chunks_empty_text_included_as_empty():
+    """Empty .text chunks produce double spaces when joined (not silently dropped).
+
+    The join uses " ".join(), so empty strings produce consecutive spaces.
+    This matches the actual normalization behavior in supadata.py.
+    """
+    chunks = [
+        MockTranscriptChunk("Valid segment."),
+        MockTranscriptChunk(""),  # empty, contributes to double space
+        MockTranscriptChunk("Another valid."),
+    ]
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultList(chunks)
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    # Note: double space because "" joins to "Valid segment.  Another valid."
+    assert result == "Valid segment.  Another valid."
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_list_chunks_all_empty_returns_none():
+    """When all chunks have empty .text, get_transcript returns None."""
+    chunks = [
+        MockTranscriptChunk(""),
+        MockTranscriptChunk("  "),
+    ]
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultList(chunks)
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_transcript — None / falsy content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_result_is_none_returns_none():
+    """When result itself is falsy (None), get_transcript returns None."""
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = None
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_content_is_none_returns_none():
+    """When result.content is None, get_transcript returns None."""
+    mock_client = MagicMock()
+    mock_client.transcript.return_value = MockTranscriptResultNone()
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_transcript — SDK errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_429_triggers_backoff_and_succeeds():
+    """Supadata 429 triggers exponential backoff retry and succeeds on second attempt."""
+    call_count = 0
+
+    def transcript_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            exc = SupadataError(error="rate_limited", message="Rate limit", details="")
+            exc.status = 429
+            raise exc
+        return MockTranscriptResultString("Retry succeeded.")
+
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = transcript_side_effect
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert call_count == 2
+    assert result == "Retry succeeded."
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_429_all_retries_exhausted_raises():
+    """After 3 consecutive 429s, SupadataError is raised."""
+
+    def always_429(*args, **kwargs):
+        exc = SupadataError(error="rate_limited", message="Rate limit", details="")
+        exc.status = 429
+        raise exc
+
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = always_429
+
+    with (
+        patch("backend.services.supadata._get_client", return_value=mock_client),
+        pytest.raises(SupadataError) as exc_info,
+    ):
+        await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert exc_info.value.status == 429
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_404_returns_none():
+    """Supadata 404 (video unavailable) returns None, not an exception."""
+
+    def not_found(*args, **kwargs):
+        exc = SupadataError(error="not_found", message="Transcript not found", details="")
+        exc.status = 404
+        raise exc
+
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = not_found
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_400_returns_none():
+    """Supadata 400 (bad request) returns None, not an exception."""
+
+    def bad_request(*args, **kwargs):
+        exc = SupadataError(error="bad_request", message="Bad request", details="")
+        exc.status = 400
+        raise exc
+
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = bad_request
+
+    with patch("backend.services.supadata._get_client", return_value=mock_client):
+        result = await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_other_error_raises():
+    """Supadata errors other than 429/404/400 are raised."""
+
+    def server_error(*args, **kwargs):
+        exc = SupadataError(error="server_error", message="Internal error", details="")
+        exc.status = 500
+        raise exc
+
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = server_error
+
+    with (
+        patch("backend.services.supadata._get_client", return_value=mock_client),
+        pytest.raises(SupadataError) as exc_info,
+    ):
+        await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert exc_info.value.status == 500
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_network_error_raises_wrapped():
+    """Network errors (TimeoutError, OSError) are wrapped in SupadataError."""
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = TimeoutError("connection timed out")
+
+    with (
+        patch("backend.services.supadata._get_client", return_value=mock_client),
+        pytest.raises(SupadataError) as exc_info,
+    ):
+        await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert "network_error" in exc_info.value.error
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_oserror_network_error_raises_wrapped():
+    """OSError (network refused) is wrapped in SupadataError with network_error tag."""
+    mock_client = MagicMock()
+    mock_client.transcript.side_effect = OSError("connection refused")
+
+    with (
+        patch("backend.services.supadata._get_client", return_value=mock_client),
+        pytest.raises(SupadataError) as exc_info,
+    ):
+        await get_transcript("dQw4w9WgXcQ", lang="en")
+
+    assert "network_error" in exc_info.value.error


### PR DESCRIPTION
<!--
This PR will be validated by the Dark Factory's independent validator.
Fill in every section. The validator reads this body + the diff + the test
results only — it does not see the coder's scratch notes or implementation
plan (the \"holdout principle\"). If you don't explain the change here, it
won't be considered.
-->

## Linked issue

Fixes #79

## Summary

Migrated the Supadata SDK usage in `backend/services/supadata.py` from the deprecated `client.youtube.transcript(video_id=..., lang=...)` API to the new unified `client.transcript(url=..., lang=...)` API. This eliminates deprecation warnings that were emitted on every transcript fetch (up to 20 per channel sync) and ensures compatibility with future SDK versions.

## How this solves the issue

The Supadata Python SDK v1.6.0 deprecated `client.youtube.transcript()` in favor of a unified `client.transcript()` API that works across platforms. The deprecated method emitted `DeprecationWarning` on every call, cluttering logs and risking future breakage. This change:

1. Updates `services/supadata.py:get_transcript()` to call `client.transcript(url=f"https://youtube.com/watch?v={video_id}", lang=lang)` instead of `client.youtube.transcript(video_id=video_id, lang=lang)`.
2. Updates all 8 mock patches in `tests/test_channel_sync.py` to mock `client.transcript` instead of `client.youtube.transcript`.
3. Updates `MockTranscriptResult` to expose a `.content` attribute matching the real SDK's return shape.

No behavior change — same normalization logic, same return shape.

## Test plan

- [ ] `uv run ruff check app/backend/services/supadata.py` — no errors
- [ ] `uv run ruff check app/backend/tests/test_channel_sync.py` — no errors
- [ ] `uv run pytest app/backend/tests/test_channel_sync.py -xvs --collect-only` — tests collect without import errors (tests are skip-marked pending Alembic rewrite, but file must be syntactically valid)
- [ ] `uv run mypy app/backend/services/supadata.py` — no new type errors

## Agent-browser regression

- [x] N/A — SDK migration with no user-facing behavior change. No UI, API contract, or streaming format changes. The validator should still run the full suite.

## Dependencies

<!-- No new dependencies. The supadata Python SDK v1.6.0 was already declared in pyproject.toml and pinned in uv.lock. -->

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (additions + deletions)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit