### PR TITLE
fix(sidebar): wire search input to /api/conversations/search (#92)

### DIFF
--- a/app/frontend/src/components/Sidebar.test.tsx
+++ b/app/frontend/src/components/Sidebar.test.tsx
@@ -26,7 +26,6 @@ vi.mock('../hooks/useConversations', () => ({
     error: null,
     refetch: vi.fn().mockResolvedValue(undefined),
     rename: vi.fn(),
-    search: vi.fn(),
     filteredConversations: [] as api.Conversation[],
   })),
 }));
@@ -79,7 +78,6 @@ describe('Sidebar handleNewChat', () => {
         error: null,
         refetch: vi.fn(),
         rename: vi.fn(),
-        search: vi.fn(),
         filteredConversations: [emptyConversation] as api.Conversation[],
       });
 
@@ -140,7 +138,6 @@ describe('Sidebar handleNewChat', () => {
         error: null,
         refetch: vi.fn().mockResolvedValue(undefined),
         rename: vi.fn(),
-        search: vi.fn(),
         filteredConversations: [nonEmptyConversation] as api.Conversation[],
       });
 
@@ -191,7 +188,6 @@ describe('Sidebar handleNewChat', () => {
         error: null,
         refetch: vi.fn().mockResolvedValue(undefined),
         rename: vi.fn(),
-        search: vi.fn(),
         filteredConversations: [] as api.Conversation[],
       });
 
@@ -250,7 +246,6 @@ describe('Sidebar handleNewChat', () => {
         error: null,
         refetch: vi.fn().mockResolvedValue(undefined),
         rename: vi.fn(),
-        search: vi.fn(),
         filteredConversations: [] as api.Conversation[],
       });
 

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -34,16 +34,48 @@ function SkeletonRow() {
   );
 }
 
+// ── Highlight matched substring in a title ──────────────────────
+function highlightMatch(title: string, query: string) {
+  const q = query.trim();
+  if (!q) return title;
+  const idx = title.toLowerCase().indexOf(q.toLowerCase());
+  if (idx === -1) return title;
+  return (
+    <>
+      {title.slice(0, idx)}
+      <mark
+        style={{
+          background: 'rgba(59,130,246,0.35)',
+          color: 'inherit',
+          padding: 0,
+          borderRadius: 2,
+        }}
+      >
+        {title.slice(idx, idx + q.length)}
+      </mark>
+      {title.slice(idx + q.length)}
+    </>
+  );
+}
+
 // ── Single conversation item ─────────────────────────────────────
 interface ConvItemProps {
   conv: Conversation;
   isActive: boolean;
+  searchQuery: string;
   onSelect: () => void;
   onDeleteRequest: (id: string) => void;
   onRename: (id: string, title: string) => void;
 }
 
-function ConvItem({ conv, isActive, onSelect, onDeleteRequest, onRename }: ConvItemProps) {
+function ConvItem({
+  conv,
+  isActive,
+  searchQuery,
+  onSelect,
+  onDeleteRequest,
+  onRename,
+}: ConvItemProps) {
   const [hovered, setHovered] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(conv.title);
@@ -133,7 +165,7 @@ function ConvItem({ conv, isActive, onSelect, onDeleteRequest, onRename }: ConvI
             paddingRight: hovered ? 56 : 0,
           }}
         >
-          {conv.title}
+          {highlightMatch(conv.title, searchQuery)}
         </div>
       )}
 
@@ -372,7 +404,10 @@ interface SidebarProps {
 
 export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRef }: SidebarProps) {
   const navigate = useNavigate();
-  const { conversations, loading, refetch, rename, filteredConversations } = useConversations();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const { conversations, loading, refetch, rename, filteredConversations } =
+    useConversations(debouncedQuery);
   const { user } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -380,13 +415,11 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(false);
   const [explorerOpen, setExplorerOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedQuery, setDebouncedQuery] = useState('');
   const { addToast } = useToast();
 
-  // Debounce search query
+  // Debounce search query — 250ms per issue #92
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 200);
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
@@ -551,7 +584,7 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               <SkeletonRow />
             </>
           ) : filteredConversations.length === 0 ? (
-            // Empty state
+            // Empty state — distinct copy when the user is searching
             <div
               style={{
                 padding: '40px 16px',
@@ -570,25 +603,35 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              <p style={{ margin: 0, fontSize: 13 }}>No conversations yet</p>
-              <button
-                onClick={handleNewChat}
-                style={{
-                  marginTop: 10,
-                  background: 'transparent',
-                  border: '1px solid rgba(59,130,246,0.4)',
-                  borderRadius: 8,
-                  color: '#3b82f6',
-                  cursor: 'pointer',
-                  fontSize: 13,
-                  padding: '7px 16px',
-                  transition: 'background 0.15s',
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(59,130,246,0.1)')}
-                onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
-              >
-                Start your first chat →
-              </button>
+              {debouncedQuery.trim() ? (
+                <p style={{ margin: 0, fontSize: 13 }}>
+                  No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
+                </p>
+              ) : (
+                <>
+                  <p style={{ margin: 0, fontSize: 13 }}>No conversations yet</p>
+                  <button
+                    onClick={handleNewChat}
+                    style={{
+                      marginTop: 10,
+                      background: 'transparent',
+                      border: '1px solid rgba(59,130,246,0.4)',
+                      borderRadius: 8,
+                      color: '#3b82f6',
+                      cursor: 'pointer',
+                      fontSize: 13,
+                      padding: '7px 16px',
+                      transition: 'background 0.15s',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.background = 'rgba(59,130,246,0.1)')
+                    }
+                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                  >
+                    Start your first chat →
+                  </button>
+                </>
+              )}
             </div>
           ) : (
             filteredConversations.map((conv) => (
@@ -596,6 +639,7 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
                 key={conv.id}
                 conv={conv}
                 isActive={conv.id === activeConversationId}
+                searchQuery={debouncedQuery}
                 onSelect={() => handleSelect(conv.id)}
                 onDeleteRequest={handleDeleteRequest}
                 onRename={handleRename}

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -42,35 +42,65 @@ describe('useConversations', () => {
   });
 
   describe('search', () => {
-    it('should filter conversations by title (case-insensitive)', async () => {
-      const conversations = [
+    it('calls searchConversations when query is non-empty', async () => {
+      const matches = [
         { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '' },
-        { id: '2', title: 'JavaScript Guide', created_at: '', updated_at: '' },
         { id: '3', title: 'python advanced', created_at: '', updated_at: '' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValueOnce(conversations as api.Conversation[]);
+      vi.spyOn(api, 'getConversations').mockResolvedValue([] as api.Conversation[]);
+      const spy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValueOnce(matches as api.Conversation[]);
 
-      const { result } = renderHook(() => useConversations());
-      await waitFor(() => expect(result.current.conversations).toHaveLength(3));
+      const { result } = renderHook(() => useConversations('python'));
 
-      result.current.search('python');
-      await waitFor(() => {
-        expect(result.current.filteredConversations).toHaveLength(2);
-      });
+      await waitFor(() => expect(spy).toHaveBeenCalledWith('python'));
+      await waitFor(() => expect(result.current.conversations).toHaveLength(2));
+      expect(result.current.filteredConversations).toHaveLength(2);
     });
 
-    it('should return all conversations when search is empty', async () => {
+    it('calls getConversations (not search) when query is empty', async () => {
       const conversations = [
         { id: '1', title: 'Chat A', created_at: '', updated_at: '' },
         { id: '2', title: 'Chat B', created_at: '', updated_at: '' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValueOnce(conversations as api.Conversation[]);
+      const getSpy = vi
+        .spyOn(api, 'getConversations')
+        .mockResolvedValue(conversations as api.Conversation[]);
+      const searchSpy = vi.spyOn(api, 'searchConversations');
 
-      const { result } = renderHook(() => useConversations());
+      const { result } = renderHook(() => useConversations(''));
+
       await waitFor(() => expect(result.current.conversations).toHaveLength(2));
+      expect(getSpy).toHaveBeenCalled();
+      expect(searchSpy).not.toHaveBeenCalled();
+    });
 
-      result.current.search('');
-      expect(result.current.filteredConversations).toHaveLength(2);
+    it('trims whitespace-only queries and falls back to full list', async () => {
+      vi.spyOn(api, 'getConversations').mockResolvedValue([
+        { id: '1', title: 'Chat A', created_at: '', updated_at: '' },
+      ] as api.Conversation[]);
+      const searchSpy = vi.spyOn(api, 'searchConversations');
+
+      renderHook(() => useConversations('   '));
+
+      await waitFor(() => expect(api.getConversations).toHaveBeenCalled());
+      expect(searchSpy).not.toHaveBeenCalled();
+    });
+
+    it('refetches when searchQuery prop changes', async () => {
+      vi.spyOn(api, 'getConversations').mockResolvedValue([] as api.Conversation[]);
+      const searchSpy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValue([] as api.Conversation[]);
+
+      const { rerender } = renderHook(({ q }: { q: string }) => useConversations(q), {
+        initialProps: { q: 'alpha' },
+      });
+      await waitFor(() => expect(searchSpy).toHaveBeenCalledWith('alpha'));
+
+      rerender({ q: 'beta' });
+      await waitFor(() => expect(searchSpy).toHaveBeenCalledWith('beta'));
     });
   });
 });

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,27 +1,40 @@
-import { useEffect, useState } from 'react';
-import { type Conversation, getConversations, renameConversation } from '../lib/api';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type Conversation,
+  getConversations,
+  renameConversation,
+  searchConversations,
+} from '../lib/api';
 
-export function useConversations() {
+export function useConversations(searchQuery?: string) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
+  // Per-fetch ID so a stale response can't overwrite fresher results
+  // when the user types faster than the network replies.
+  const fetchIdRef = useRef(0);
 
-  const fetchConversations = async () => {
+  const load = useCallback(async () => {
+    const trimmed = (searchQuery ?? '').trim();
+    const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = await getConversations();
-      setConversations(data);
+      const data = trimmed
+        ? await searchConversations(trimmed)
+        : await getConversations();
+      if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load conversations');
+      if (myId === fetchIdRef.current) {
+        setError(e instanceof Error ? e.message : 'Failed to load conversations');
+      }
     } finally {
-      setLoading(false);
+      if (myId === fetchIdRef.current) setLoading(false);
     }
-  };
+  }, [searchQuery]);
 
   useEffect(() => {
-    fetchConversations();
-  }, []);
+    load();
+  }, [load]);
 
   const rename = async (id: string, title: string): Promise<{ ok: boolean; error?: string }> => {
     const prevConversations = conversations;
@@ -36,19 +49,12 @@ export function useConversations() {
     }
   };
 
-  const search = (q: string) => setSearchQuery(q);
-
-  const filtered = searchQuery
-    ? conversations.filter((c) => c.title.toLowerCase().includes(searchQuery.toLowerCase()))
-    : conversations;
-
   return {
     conversations,
     loading,
     error,
-    refetch: fetchConversations,
+    refetch: load,
     rename,
-    search,
-    filteredConversations: filtered,
+    filteredConversations: conversations,
   };
 }

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -19,9 +19,7 @@ export function useConversations(searchQuery?: string) {
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = trimmed
-        ? await searchConversations(trimmed)
-        : await getConversations();
+      const data = trimmed ? await searchConversations(trimmed) : await getConversations();
       if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
       if (myId === fetchIdRef.current) {

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -86,6 +86,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 // Conversations
 export const getConversations = () => request<Conversation[]>('/conversations');
+export const searchConversations = (q: string) =>
+  request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
 export const createConversation = () =>
   request<Conversation>('/conversations', { method: 'POST', body: '{}' });
 export const getConversation = (id: string) =>


### PR DESCRIPTION
## Summary

Closes #92 — the sidebar "Search conversations…" input was accepting text but never filtering the list. The frontend was computing a debounced query but never passing it anywhere; the `useConversations` hook ran a client-side filter against its own internal state that nothing ever updated. Meanwhile the backend's `GET /api/conversations/search?q=...` endpoint has been sitting unused.

## Changes

- **`lib/api.ts`** — new `searchConversations(q)` helper that GETs the server endpoint.
- **`hooks/useConversations.ts`** — now accepts an optional `searchQuery` arg. When non-empty (trimmed), calls `searchConversations`; otherwise falls back to the full list. A per-fetch ID ref guards against stale responses overwriting fresher ones when the user types faster than the network replies. Client-side filter + unused `search()` method removed.
- **`components/Sidebar.tsx`** — bumped debounce to 250ms (per the issue), passes `debouncedQuery` into the hook, and highlights the matched substring in conversation titles. Empty-state copy now distinguishes "No matches for X" from "No conversations yet" so a fruitless search doesn't show the "Start your first chat" CTA.
- **Tests** — rewrote the `search` describe in `useConversations.test.ts` to cover the server-side contract (non-empty triggers search, empty/whitespace falls back to getConversations, re-renders refetch with new query). Dropped the stale `search: vi.fn()` from Sidebar mocks to match the new hook return shape.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun run test` — 49/49 pass (6 in useConversations, 7 in Sidebar)
- [x] `bun run build` — succeeds
- [ ] Manual: type into sidebar search, confirm list filters within ~250ms; confirm empty query restores the full list; confirm matched text is highlighted; confirm no-match query shows the "No matches for X" state.

🤖 Manually implemented by @coleam00's operator to unblock the Dark Factory queue (resolves #92).