### PR TITLE
fix(sidebar): add user email display + logout button (#90)

### DIFF
--- a/app/frontend/src/components/Sidebar.test.tsx
+++ b/app/frontend/src/components/Sidebar.test.tsx
@@ -283,3 +283,59 @@ describe('Sidebar handleNewChat', () => {
     });
   });
 });
+
+describe('Sidebar logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    navigateMock.mockReset();
+  });
+
+  it('shows the user email and a Log out button when authed', async () => {
+    render(
+      <MemoryRouter>
+        <Sidebar activeConversationId={undefined} isOpen={true} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();
+  });
+
+  it('calls logout and navigates to /login when the button is clicked', async () => {
+    const logoutMock = vi.fn().mockResolvedValue(undefined);
+    const { useAuth } = await import('../hooks/useAuth');
+    vi.mocked(useAuth).mockReturnValue({
+      status: 'authed',
+      user: {
+        id: 'user-1',
+        email: 'test@example.com',
+        is_admin: false,
+        messages_used_today: 5,
+        messages_remaining_today: 20,
+        rate_window_resets_at: null,
+      } as never,
+      error: null,
+      signup: vi.fn(),
+      login: vi.fn(),
+      logout: logoutMock,
+      refresh: vi.fn(),
+    });
+
+    const onClose = vi.fn();
+    render(
+      <MemoryRouter>
+        <Sidebar activeConversationId={undefined} isOpen={true} onClose={onClose} />
+      </MemoryRouter>,
+    );
+
+    const logoutBtn = screen.getByRole('button', { name: /log out/i });
+    await act(async () => {
+      fireEvent.click(logoutBtn);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/login');
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -408,13 +408,14 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const { conversations, loading, refetch, rename, filteredConversations } =
     useConversations(debouncedQuery);
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(false);
   const [explorerOpen, setExplorerOpen] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
   const { addToast } = useToast();
 
   // Debounce search query — 250ms per issue #92
@@ -491,6 +492,18 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const handleSelect = (id: string) => {
     navigate(`/c/${id}`);
     onClose();
+  };
+
+  // ── Logout ──
+  const handleLogout = async () => {
+    setLoggingOut(true);
+    try {
+      await logout();
+      onClose();
+      navigate('/login');
+    } finally {
+      setLoggingOut(false);
+    }
   };
 
   // ── Rename ──
@@ -655,6 +668,66 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
             remaining={user.messages_remaining_today}
             resetsAt={user.rate_window_resets_at}
           />
+        )}
+
+        {/* ── User identity + logout row ── */}
+        {user && (
+          <div
+            style={{
+              padding: '8px 12px',
+              borderTop: '1px solid rgba(255,255,255,0.06)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+            }}
+          >
+            <span
+              title={user.email}
+              style={{
+                fontSize: 12,
+                color: '#94a3b8',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                flex: 1,
+                minWidth: 0,
+              }}
+            >
+              {user.email}
+            </span>
+            <button
+              onClick={handleLogout}
+              disabled={loggingOut}
+              title="Log out"
+              aria-label="Log out"
+              style={{
+                background: 'transparent',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 7,
+                color: '#94a3b8',
+                cursor: loggingOut ? 'not-allowed' : 'pointer',
+                padding: '5px 10px',
+                fontSize: 12,
+                opacity: loggingOut ? 0.6 : 1,
+                transition: 'background 0.15s, color 0.15s, border-color 0.15s',
+                flexShrink: 0,
+              }}
+              onMouseEnter={(e) => {
+                if (loggingOut) return;
+                e.currentTarget.style.background = '#1e293b';
+                e.currentTarget.style.color = '#f1f5f9';
+                e.currentTarget.style.borderColor = 'rgba(239,68,68,0.4)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent';
+                e.currentTarget.style.color = '#94a3b8';
+                e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)';
+              }}
+            >
+              {loggingOut ? 'Signing out…' : 'Log out'}
+            </button>
+          </div>
         )}
 
         {/* ── Sidebar footer: branding + library button ── */}


### PR DESCRIPTION
## Summary

Closes #90 — backend already exposes `POST /api/auth/logout` and `useAuth().logout()` has been wired to it since login shipped, but the UI never surfaced either the user identity or the control. Signed-in users could only log out by clearing cookies manually — a baseline account-hygiene gap and a blocker for switching accounts on shared machines.

## Changes

- **`Sidebar.tsx`** — new identity row above the existing branding footer: truncated email on the left (with `title` attr for overflow), "Log out" button on the right with red-tinted hover border. `handleLogout` calls `useAuth().logout()` (which POSTs to `/api/auth/logout` and clears client auth state), closes the sidebar, and navigates to `/login`. A `loggingOut` state prevents double-clicks and shows "Signing out…" during the in-flight call.
- **`Sidebar.test.tsx`** — 2 new tests: (1) the email + logout button render when authed, (2) clicking the button calls `logout()`, closes the sidebar, and navigates to `/login`.

Note: `useAuth`'s `doLogout` already swallows network errors in a `finally` block so the local state is cleared even if the server call fails — no redundant error handling added here.

## Validation (ran against this branch rebased onto main, on the Dark Factory VPS)

- [x] `bun run type-check` — clean
- [x] `bun run test` — 62/62 pass (9 test files; 6 in Sidebar including the 2 new logout tests)
- [x] `bun run build` — succeeds
- [x] `uv run ruff check .` — all checks pass
- [x] `uv run mypy .` — clean, 65 source files, no issues
- [x] `uv run pytest -q` — 145 passed, 61 skipped (matches baseline; no backend changes)
- [ ] Manual: verify email renders, click "Log out", confirm redirect to /login and that revisiting /c/... redirects back through login.

🤖 Manually implemented to help move the Dark Factory queue forward.