### PR TITLE
fix: stop LLM from leaking YouTube IDs inline in prose

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -50,7 +50,7 @@ def _get_async_client() -> AsyncOpenAI:
 SYSTEM_PROMPT_TEMPLATE = """\
 You are a helpful assistant with access to transcripts from a YouTube creator's video library.
 Answer the user's question based ONLY on the provided video context. If the answer isn't in the context, say so honestly.
-Always cite which video(s) your answer draws from.
+When you reference a video, use its title only. Never write YouTube video IDs, chunk IDs, or other raw source identifiers in your response — the UI renders sources separately as clickable chips, so inline tokens like "(Source: Video HAkSUBdsd6M)" or "(Video 60G93MXT4DI)" are redundant clutter. Your prose should read naturally, as if the source list below were invisible.
 
 Context:
 {context}"""

--- a/app/backend/tests/test_system_prompt.py
+++ b/app/backend/tests/test_system_prompt.py
@@ -1,0 +1,29 @@
+"""
+Pin the RAG system prompt's "no raw IDs in prose" rule (issue #93).
+
+The LLM was emitting `(Source: Video <11-char-id>)` inline in responses;
+source chips already render that info below the message. We added an
+explicit instruction to suppress it — if someone rewrites the prompt and
+drops the rule, these tests fail so the regression is caught in CI.
+"""
+
+from __future__ import annotations
+
+from backend.llm.openrouter import SYSTEM_PROMPT_TEMPLATE, build_system_prompt
+
+
+class TestSystemPromptForbidsRawIds:
+    def test_template_forbids_raw_ids(self) -> None:
+        assert "video IDs" in SYSTEM_PROMPT_TEMPLATE or "video id" in SYSTEM_PROMPT_TEMPLATE.lower()
+        assert "title only" in SYSTEM_PROMPT_TEMPLATE.lower()
+
+    def test_built_prompt_contains_rule(self) -> None:
+        prompt = build_system_prompt(context="[Source: Some Video at 00:10]\nSome transcript.")
+        lowered = prompt.lower()
+        assert "never write youtube video ids" in lowered
+        assert "title only" in lowered
+
+    def test_built_prompt_still_injects_context(self) -> None:
+        ctx = "[Source: Claude Code Walkthrough at 01:23]\nHello world."
+        prompt = build_system_prompt(context=ctx)
+        assert ctx in prompt


### PR DESCRIPTION
Fixes #93.

## Problem

The assistant was emitting raw 11-char YouTube video IDs in its response text, e.g.

> The creator covers this on their channel (Source: Video HAkSUBdsd6M).

The UI already renders sources as clickable chips below the message, so inline IDs are both ugly and redundant.

## Fix

Added an explicit rule to the RAG system prompt in `app/backend/llm/openrouter.py`:

> When you reference a video, use its title only. Never write YouTube video IDs, chunk IDs, or other raw source identifiers in your response…

The context block already feeds titles to the model via `[Source: <video_title> at <mm:ss>]` (see `_format_context` in `routes/messages.py`), so the model has everything it needs to cite naturally.

Pinned the rule with a unit test (`test_system_prompt.py`) so any future rewrite of the prompt that drops this guardrail fails CI.

## Validation (VPS)

- ruff: clean
- mypy: 66 source files, no issues
- pytest: 148 passed, 61 skipped (incl. 3 new tests in `test_system_prompt.py`)
- tsc: clean
- biome: 1 pre-existing error in `ChatInput.test.tsx` (from main, unrelated to this PR)
- vitest: 62 passed

## Scope

Backend-only prompt tweak + one test file. No protected files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)