### PR TITLE
fix: UI polish bundle (#113 #114 #116 #119 #125)

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from './components/ToastProvider';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { AdminVideos } from './pages/AdminVideos';
 import { Login } from './pages/Login';
+import { NotFound } from './pages/NotFound';
 import { Signup } from './pages/Signup';
 
 // ── Auth guard ───────────────────────────────────────────────────
@@ -125,6 +126,7 @@ function App() {
                 </RequireAuth>
               }
             />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </ToastProvider>
       </AuthProvider>

--- a/app/frontend/src/__tests__/VideoExplorer-admin-gate.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer-admin-gate.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VideoExplorer } from '../components/VideoExplorer';
+import * as api from '../lib/api';
+
+// Non-admin user: the "+ Add Video" button must not render. Split into its
+// own file because vi.mock is hoisted per-module and cannot be changed
+// between tests in the same file.
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'test-user',
+      email: 'user@test',
+      is_admin: false,
+      messages_used_today: 0,
+      messages_remaining_today: 100,
+      rate_window_resets_at: null,
+    },
+    status: 'authed',
+    refresh: vi.fn(),
+  }),
+}));
+
+describe('VideoExplorer admin gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(api, 'getVideos').mockResolvedValue([]);
+  });
+
+  it('hides the "+ Add Video" button for non-admin users', async () => {
+    render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+
+    // The modal header renders asynchronously after fetchVideos resolves.
+    await waitFor(() => {
+      expect(screen.getByText('Video Library')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('+ Add Video')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/VideoExplorer.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer.test.tsx
@@ -3,6 +3,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoExplorer } from '../components/VideoExplorer';
 import * as api from '../lib/api';
 
+// Default auth mock: admin user so the "+ Add Video" button renders. The
+// non-admin gate is covered by its own suite below that re-mocks useAuth.
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'test-admin',
+      email: 'admin@test',
+      is_admin: true,
+      messages_used_today: 0,
+      messages_remaining_today: 100,
+      rate_window_resets_at: null,
+    },
+    status: 'authed',
+    refresh: vi.fn(),
+  }),
+}));
+
 describe('VideoExplorer', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -204,6 +204,7 @@ function ConvItem({
             setEditing(true);
             setEditValue(conv.title);
           }}
+          aria-label="Rename conversation"
           title="Rename conversation"
           style={{
             position: 'absolute',
@@ -741,7 +742,7 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
             gap: 8,
           }}
         >
-          <span style={{ fontSize: 12, color: '#475569' }}>RAG YouTube Chat</span>
+          <span style={{ fontSize: 12, color: '#475569' }}>DynaChat</span>
 
           {/* Library admin link — admin-only. is_admin is a server-computed
               hint only; the /api/admin/* endpoints re-verify on every call. */}

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { type Video, getVideos, ingestVideo } from '../lib/api';
+import { useAuth } from '../hooks/useAuth';
 
 // ── Skeleton card ────────────────────────────────────────────────
 function SkeletonCard() {
@@ -87,6 +88,7 @@ const INGEST_FIELDS = [
 ] as const;
 
 export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
+  const { user } = useAuth();
   const [videos, setVideos] = useState<Video[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -204,13 +206,15 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
               <line x1="11" y1="3" x2="3" y2="11" />
             </svg>
           </button>
-          <button
-            onClick={() => setIngestOpen(true)}
-            className="px-3 py-1.5 bg-blue-500 border-none rounded-md text-white text-sm cursor-pointer"
-            title="Add new video"
-          >
-            + Add Video
-          </button>
+          {user?.is_admin && (
+            <button
+              onClick={() => setIngestOpen(true)}
+              className="px-3 py-1.5 bg-blue-500 border-none rounded-md text-white text-sm cursor-pointer"
+              title="Add new video"
+            >
+              + Add Video
+            </button>
+          )}
         </div>
 
         {/* Content */}

--- a/app/frontend/src/lib/authApi.ts
+++ b/app/frontend/src/lib/authApi.ts
@@ -47,6 +47,29 @@ export class AuthError extends Error {
   }
 }
 
+/**
+ * Normalize FastAPI's polymorphic `detail` field into a human-readable string.
+ *
+ * Handlers return `{"detail": "..."}` for most errors, but the default
+ * validation handler returns `{"detail": [{loc, msg, type}, ...]}`. Rendering
+ * the array via JS string coercion produces "[object Object]" in the UI.
+ */
+function formatDetail(detail: unknown): string | null {
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    const parts = detail
+      .map((d) => {
+        if (d && typeof d === 'object' && 'msg' in d && typeof (d as { msg: unknown }).msg === 'string') {
+          return (d as { msg: string }).msg;
+        }
+        return null;
+      })
+      .filter((p): p is string => p !== null);
+    return parts.length > 0 ? parts.join(', ') : null;
+  }
+  return null;
+}
+
 async function authRequest<T>(path: string, init: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     credentials: 'include',
@@ -61,8 +84,9 @@ async function authRequest<T>(path: string, init: RequestInit): Promise<T> {
       if (body?.error === 'signup_rate_limited' && typeof body?.message === 'string') {
         detail = body.message;
         if (body.scope === 'ip' || body.scope === 'global') scope = body.scope;
-      } else if (body?.detail) {
-        detail = body.detail;
+      } else {
+        const formatted = formatDetail(body?.detail);
+        if (formatted) detail = formatted;
       }
     } catch {
       // fall through with statusText

--- a/app/frontend/src/pages/NotFound.tsx
+++ b/app/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+
+export function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--bg)] text-[var(--text-primary)] p-4">
+      <div className="w-full max-w-sm bg-[var(--surface-1)] border border-[var(--border)] rounded-lg p-6 space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Page not found</h1>
+        <p className="text-sm text-[var(--text-secondary)]">
+          The page you're looking for doesn't exist.
+        </p>
+        <Link
+          to="/"
+          className="inline-block py-2 px-4 rounded bg-[var(--accent)] text-white font-medium no-underline"
+        >
+          Back to home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Out-of-factory human fix bundle for 5 easy issues, taking load off the dark-factory queue. Each fix is a separate commit so reviewers can scan one-by-one.

| # | Issue | Commit |
|---|---|---|
| #119 | Sidebar says "RAG YouTube Chat" while the rest of the app is DynaChat | `eeff2e9` |
| #125 | Rename pencil button's accessible name was "✏️" | `eeff2e9` |
| #116 | "+ Add Video" button visible to non-admin users | `fba855d` |
| #114 | Unknown routes rendered a blank black page | `1f22a70` |
| #113 | Signup validation errors rendered as `[object Object]` | `dd49abb` |

Also closes #117 and #127 outside this PR — both were already fixed in main (marked completed with comments pointing to the fix lines).

## Root causes (one line each)

- **#119**: Footer text in `Sidebar.tsx:744` was never migrated when the product was renamed.
- **#125**: Rename button had `title="Rename conversation"` but the visible content was the `✏️` emoji, and ARIA's accessible-name computation prefers contents over `title`. Added an `aria-label` which overrides both.
- **#116**: `VideoExplorer.tsx` rendered the "+ Add Video" button unconditionally. Gated on `user?.is_admin`. API already enforces 403 — this is just UI polish.
- **#114**: `App.tsx` had no `<Route path="*">`. Added a `NotFound` page. The "blank page while unauthenticated" sub-issue was already covered by `RequireAuth`.
- **#113**: `authApi.ts::authRequest` was assigning `body.detail` to a string field. FastAPI's default validation handler returns `detail` as an array of `{loc, msg, type}` objects, which gets coerced to `[object Object]` when rendered. Added a `formatDetail` helper that turns the array into `"msg1, msg2, ..."`.

## Test plan

- [x] `cd app/backend && uv run pytest` — 156 passed, 61 skipped (unrelated)
- [x] `cd app/frontend && bun run test` — 83 passed (includes new non-admin gate test)
- [x] `cd app/frontend && bun run build` — tsc + vite build clean

Manual verification left for reviewer / prod smoke:
- [ ] Log in as non-admin, open Video Library, confirm "+ Add Video" is hidden
- [ ] Navigate to `/nonsense-xyz`, confirm NotFound page renders with a back-to-home link
- [ ] Try a bad-format email on signup, confirm the error message is human-readable (not `[object Object]`)
- [ ] Sidebar footer now reads "DynaChat"
- [ ] Hover a conversation row, inspect the pencil button — its accessible name should be "Rename conversation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)