### PR TITLE
fix(auth): invalidate session cookie on logout (#111)

### DIFF
--- a/app/backend/routes/auth.py
+++ b/app/backend/routes/auth.py
@@ -77,6 +77,24 @@ def _set_session_cookie(response: Response, user_id: str) -> None:
     )
 
 
+def _clear_session_cookie(response: Response) -> None:
+    """Invalidate the session cookie on the client.
+
+    Browsers only honour a `Set-Cookie` deletion directive when every
+    attribute matches the original cookie — Secure, SameSite, HttpOnly, Path.
+    Omitting any of them leaves the original cookie intact and the user stays
+    authenticated until the JWT's own expiry (see issue #111). This helper is
+    intentionally symmetric with `_set_session_cookie` so the two can't drift.
+    """
+    response.delete_cookie(
+        key=COOKIE_NAME,
+        path="/",
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+
+
 def _user_to_response(user: dict[str, Any]) -> UserResponse:
     return UserResponse(id=str(user["id"]), email=str(user["email"]))
 
@@ -163,10 +181,16 @@ async def login(body: LoginRequest, response: Response) -> UserResponse:
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
-async def logout(response: Response) -> Response:
-    """Clear the session cookie. Always 204 — idempotent."""
-    response.delete_cookie(key=COOKIE_NAME, path="/")
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+async def logout() -> Response:
+    """Clear the session cookie. Always 204 — idempotent.
+
+    Builds the response directly so the deletion Set-Cookie header lands on
+    the wire; relying on the FastAPI-injected `response` object drops headers
+    when we return a new `Response(...)`.
+    """
+    response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    _clear_session_cookie(response)
+    return response
 
 
 @router.get("/me", response_model=MeResponse)

--- a/app/backend/tests/test_auth.py
+++ b/app/backend/tests/test_auth.py
@@ -197,12 +197,38 @@ async def test_logout_clears_cookie_and_blocks_me(client):
     )
     r_logout = await client.post("/api/auth/logout")
     assert r_logout.status_code == 204
-    # Clear client-side cookies as the browser would after Set-Cookie with
-    # max-age=0 / deletion. httpx's ASGI transport doesn't automatically honour
-    # the delete-cookie response, so drop them manually to match browser state.
-    client.cookies.clear()
+    # No manual cookies.clear() — the Set-Cookie deletion directive must
+    # actually take effect in the client jar (regression test for #111).
     r_me = await client.get("/api/auth/me")
     assert r_me.status_code == 401
+
+
+async def test_logout_set_cookie_header_has_matching_attributes(client):
+    """Regression test for #111.
+
+    The logout handler must emit a Set-Cookie directive whose attributes match
+    the ones used when the cookie was minted (Secure, HttpOnly, SameSite=Lax,
+    Path=/). Browsers only honour a deletion when every attribute matches; if
+    any are missing the original cookie survives and the JWT remains valid
+    until its server-side expiry.
+    """
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "frank@example.com", "password": "password123"},
+    )
+    r_logout = await client.post("/api/auth/logout")
+    assert r_logout.status_code == 204
+
+    set_cookie = r_logout.headers.get("set-cookie", "")
+    assert "session=" in set_cookie
+    # Attributes are case-insensitive per RFC 6265.
+    lowered = set_cookie.lower()
+    assert "path=/" in lowered
+    assert "httponly" in lowered
+    assert "secure" in lowered
+    assert "samesite=lax" in lowered
+    # Either max-age=0 or an expiry in the past signals deletion.
+    assert "max-age=0" in lowered or "expires=" in lowered
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #111 — logout did not actually invalidate the session cookie in the browser, so the user remained authenticated until the JWT's own server-side expiry.

**Root cause:** `logout` called `response.delete_cookie(key=COOKIE_NAME, path="/")` which emits `Set-Cookie: session=; Path=/; Max-Age=0; Expires=...` **without** the `Secure`, `HttpOnly`, or `SameSite=Lax` attributes that were on the original cookie. Per RFC 6265 and every major browser's implementation, a deletion directive must match all attributes of the original cookie; otherwise it's treated as a separate cookie and the original survives.

## Changes

- `app/backend/routes/auth.py`
  - New `_clear_session_cookie` helper, symmetric with `_set_session_cookie`, so the set and delete paths can't drift.
  - `logout` now builds the `Response` directly instead of mutating the FastAPI-injected `response` and returning a fresh `Response(...)` (which drops the Set-Cookie header).
- `app/backend/tests/test_auth.py`
  - Removed the `client.cookies.clear()` workaround from `test_logout_clears_cookie_and_blocks_me` — it was masking this exact bug.
  - New `test_logout_set_cookie_header_has_matching_attributes` asserts the Set-Cookie header carries `Secure`, `HttpOnly`, `SameSite=Lax`, `Path=/`, and a deletion marker.

## Test plan

- [x] `cd app/backend && uv run pytest tests/test_auth.py` — 14/14 pass (was 13, +1 regression test)
- [x] `cd app/backend && uv run pytest` — 157/157 pass, 0 new failures
- [ ] Manual check: log in, hit `/api/auth/logout`, confirm the Set-Cookie response header in DevTools contains `Secure; HttpOnly; SameSite=Lax`
- [ ] Manual check: after logout, `/api/auth/me` returns 401 without clearing cookies manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)