### PR TITLE
fix(channels): add force param to backfill timestamps on existing videos (#112)

### DIFF
--- a/app/backend/routes/channels.py
+++ b/app/backend/routes/channels.py
@@ -58,7 +58,7 @@ class SyncRunsResponse(BaseModel):
 
 
 @router.post("/channels/sync", response_model=SyncResponse)
-async def sync_channel(limit: int | None = None) -> SyncResponse:
+async def sync_channel(limit: int | None = None, force: bool = False) -> SyncResponse:
     """
     Enumerate videos from the configured YouTube channel via Supadata,
     ingest any new videos (idempotent by youtube_video_id), and record a
@@ -68,6 +68,13 @@ async def sync_channel(limit: int | None = None) -> SyncResponse:
         limit: Max number of videos to process. Omit for full channel.
                Supadata returns videos newest-first, so limit=20 processes
                the 20 most recent videos.
+        force: When True, re-process videos that are already in the DB —
+               chunks are re-fetched, re-embedded, and atomically replaced
+               via replace_chunks_for_video. Used to backfill timestamp +
+               snippet data onto videos ingested before PR #100 landed
+               the timestamped-chunk pipeline (see issue #112). Default
+               False preserves the idempotent skip behaviour that the
+               scheduled sync relies on.
 
     This is a synchronous, sequential operation — all videos are processed
     before the HTTP response is returned. The caller (e.g. systemd timer)
@@ -144,7 +151,7 @@ async def sync_channel(limit: int | None = None) -> SyncResponse:
         )
 
         existing = await repo.get_video_by_youtube_id(youtube_video_id)
-        if existing is not None:
+        if existing is not None and not force:
             logger.info("Video %s already ingested, skipping", youtube_video_id)
             videos_new += 1
             await repo.update_sync_video_status(
@@ -192,29 +199,35 @@ async def sync_channel(limit: int | None = None) -> SyncResponse:
             supadata_data.get("description") or f"Synced from channel {YOUTUBE_CHANNEL_ID}"
         )
 
-        # Ingest through chunk → embed → store pipeline
-        try:
-            video_record = await repo.create_video(
-                title=title,
-                description=description,
-                url=youtube_url,
-                transcript=transcript,
-            )
-        except Exception as exc:
-            logger.error(
-                "Failed to create video record for %s: %s",
-                youtube_video_id,
-                exc,
-            )
-            videos_error += 1
-            await repo.update_sync_video_status(
-                video_id=sync_video_record["id"],
-                status="error",
-                error_message=f"Video creation failed: {exc}",
-            )
-            continue
+        # Ingest through chunk → embed → store pipeline.
+        # When force=True and the video already exists, reuse its row and
+        # replace its chunks in a single transaction below; otherwise create
+        # a new video record.
+        if existing is not None:
+            video_id = existing["id"]
+        else:
+            try:
+                video_record = await repo.create_video(
+                    title=title,
+                    description=description,
+                    url=youtube_url,
+                    transcript=transcript,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to create video record for %s: %s",
+                    youtube_video_id,
+                    exc,
+                )
+                videos_error += 1
+                await repo.update_sync_video_status(
+                    video_id=sync_video_record["id"],
+                    status="error",
+                    error_message=f"Video creation failed: {exc}",
+                )
+                continue
 
-        video_id = video_record["id"]
+            video_id = video_record["id"]
 
         # Chunk the transcript
         if video_segments:
@@ -261,18 +274,39 @@ async def sync_channel(limit: int | None = None) -> SyncResponse:
             )
             continue
 
-        # Store chunks with timestamp data
+        # Store chunks with timestamp data. For re-processed (force=True)
+        # videos, replace_chunks_for_video atomically deletes old chunks and
+        # inserts the new ones inside one transaction — so a crash mid-replace
+        # can't leave the video with a half-old / half-new chunk set.
         try:
-            for idx, (chunk, embedding) in enumerate(zip(chunk_dicts, embeddings, strict=False)):
-                await repo.create_chunk(
-                    video_id=video_id,
-                    content=chunk["content"],
-                    embedding=embedding,
-                    chunk_index=idx,
-                    start_seconds=chunk["start_seconds"],
-                    end_seconds=chunk["end_seconds"],
-                    snippet=chunk["snippet"],
-                )
+            if existing is not None:
+                chunks_for_replace = [
+                    {
+                        "content": chunk["content"],
+                        "embedding": embedding,
+                        "chunk_index": idx,
+                        "start_seconds": chunk["start_seconds"],
+                        "end_seconds": chunk["end_seconds"],
+                        "snippet": chunk["snippet"],
+                    }
+                    for idx, (chunk, embedding) in enumerate(
+                        zip(chunk_dicts, embeddings, strict=False)
+                    )
+                ]
+                await repo.replace_chunks_for_video(video_id, chunks_for_replace)
+            else:
+                for idx, (chunk, embedding) in enumerate(
+                    zip(chunk_dicts, embeddings, strict=False)
+                ):
+                    await repo.create_chunk(
+                        video_id=video_id,
+                        content=chunk["content"],
+                        embedding=embedding,
+                        chunk_index=idx,
+                        start_seconds=chunk["start_seconds"],
+                        end_seconds=chunk["end_seconds"],
+                        snippet=chunk["snippet"],
+                    )
         except Exception as exc:
             logger.error(
                 "Failed to store chunks for video %s: %s",
@@ -293,7 +327,8 @@ async def sync_channel(limit: int | None = None) -> SyncResponse:
             status="ingested",
         )
         logger.info(
-            "Ingested video %s (%s): %d chunks",
+            "%s video %s (%s): %d chunks",
+            "Re-synced" if existing is not None else "Ingested",
             youtube_video_id,
             title,
             len(chunk_dicts),

--- a/app/backend/tests/test_chunk_timestamps.py
+++ b/app/backend/tests/test_chunk_timestamps.py
@@ -4,13 +4,22 @@ Regression tests for issue #89 — all chunks have start_seconds=0.0.
 Verifies that the from-url ingest path, admin _fetch_chunks_and_embeddings,
 and channel sync all pass real timestamp fields to create_chunk rather than
 leaving them at the default 0.0.
+
+Also covers issue #112: the /api/channels/sync?force=true backfill path,
+which replaces chunks on videos ingested before the #89 fix landed.
 """
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+os.environ.setdefault("SUPADATA_API_KEY", "test-supadata-key")
+os.environ.setdefault("YOUTUBE_CHANNEL_ID", "UC_testchannel")
 
 from backend.auth.dependencies import get_current_user
 from backend.main import app
@@ -174,3 +183,209 @@ async def test_ingest_from_url_fallback_stores_timestamps_when_no_segments():
     assert "end_seconds" in call_kwargs
     assert "snippet" in call_kwargs
     assert call_kwargs["end_seconds"] == 40.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: channel sync ?force=true replaces chunks on existing videos (#112)
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_sync_force_replaces_chunks_on_existing_video():
+    """force=true must refresh chunks on a video that already exists in the DB.
+
+    The 20 videos in prod were ingested before PR #100 wired timestamped
+    segments through the sync pipeline — they have start_seconds=0.0 and
+    empty snippets. Without a force flag, sync_channel skips existing videos,
+    so there is no way to backfill them. This test locks in the backfill
+    path: existing video → replace_chunks_for_video with real timestamps,
+    create_chunk not called, create_video not called.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    fake_helper = AsyncMock(
+        return_value={
+            "youtube_video_id": "existing1",
+            "title": "Existing Video",
+            "description": "desc",
+            "transcript": "Intro. Main. Outro.",
+            "segments": [
+                {"start": 0.0, "end": 30.0, "text": "Intro."},
+                {"start": 30.0, "end": 90.0, "text": "Main."},
+            ],
+        }
+    )
+
+    chunk_dicts = [
+        {"content": "Intro.", "start_seconds": 0.0, "end_seconds": 30.0, "snippet": "Intro."},
+        {"content": "Main.", "start_seconds": 30.0, "end_seconds": 90.0, "snippet": "Main."},
+    ]
+
+    existing_video = {
+        "id": "existing-video-uuid",
+        "title": "Existing Video (stale)",
+        "description": "stale",
+        "url": "https://www.youtube.com/watch?v=existing1",
+        "transcript": "stale transcript",
+    }
+
+    class MockChannelVideosResult:
+        def __init__(self, ids: list[str]):
+            self.video_ids = ids
+            self.short_ids: list[str] = []
+            self.live_ids: list[str] = []
+
+    with (
+        patch("backend.routes.channels.fetch_video_for_ingest", new=fake_helper),
+        patch(
+            "backend.routes.channels.chunk_video_timestamped",
+            return_value=(chunk_dicts, False),
+        ),
+        patch(
+            "backend.routes.channels.embed_batch",
+            return_value=[[0.1] * 3, [0.2] * 3],
+        ),
+        patch(
+            "backend.routes.channels.repo.get_video_by_youtube_id",
+            new_callable=AsyncMock,
+            return_value=existing_video,
+        ),
+        patch(
+            "backend.routes.channels.repo.create_sync_run",
+            new_callable=AsyncMock,
+            return_value={"id": "run-1"},
+        ),
+        patch(
+            "backend.routes.channels.repo.create_sync_video",
+            new_callable=AsyncMock,
+            return_value={"id": "sv-1"},
+        ),
+        patch(
+            "backend.routes.channels.repo.update_sync_video_status",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.routes.channels.repo.update_sync_run",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.routes.channels.repo.create_video",
+            new_callable=AsyncMock,
+        ) as mock_create_video,
+        patch(
+            "backend.routes.channels.repo.create_chunk",
+            new_callable=AsyncMock,
+        ) as mock_create_chunk,
+        patch(
+            "backend.routes.channels.repo.replace_chunks_for_video",
+            new_callable=AsyncMock,
+        ) as mock_replace_chunks,
+        patch("backend.services.supadata._get_client") as mock_get_client,
+        patch("backend.rag.retriever.invalidate_cache"),
+    ):
+        mock_client = AsyncMock()
+        mock_client.youtube.channel.videos = (
+            lambda *args, **kwargs: MockChannelVideosResult(["existing1"])
+        )
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post("/api/channels/sync?force=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["videos_total"] == 1
+    assert data["videos_new"] == 1
+    assert data["videos_error"] == 0
+
+    # The re-sync path must NOT create a new video row — reusing the existing one.
+    mock_create_video.assert_not_called()
+    # And must NOT go through the per-chunk insert path.
+    mock_create_chunk.assert_not_called()
+    # It MUST atomically replace chunks on the existing video id.
+    mock_replace_chunks.assert_awaited_once()
+    call = mock_replace_chunks.await_args
+    assert call.args[0] == "existing-video-uuid"
+    replaced = call.args[1]
+    assert len(replaced) == 2
+    # Real timestamps — the whole point of the backfill.
+    assert replaced[0]["start_seconds"] == 0.0
+    assert replaced[0]["end_seconds"] == 30.0
+    assert replaced[0]["snippet"] == "Intro."
+    assert replaced[1]["start_seconds"] == 30.0
+    assert replaced[1]["end_seconds"] == 90.0
+    assert replaced[1]["snippet"] == "Main."
+    # chunk_index is required by replace_chunks_for_video.
+    assert replaced[0]["chunk_index"] == 0
+    assert replaced[1]["chunk_index"] == 1
+
+
+async def test_channel_sync_without_force_still_skips_existing_video():
+    """Default (force=false) must preserve the idempotent skip behaviour.
+
+    The scheduled sync relies on this: re-running the sync must not re-ingest
+    every previously-seen video. Only an explicit force=true triggers replace.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    existing_video = {
+        "id": "existing-video-uuid",
+        "title": "Already in DB",
+        "description": "desc",
+        "url": "https://www.youtube.com/watch?v=existing1",
+        "transcript": "old",
+    }
+
+    class MockChannelVideosResult:
+        def __init__(self, ids: list[str]):
+            self.video_ids = ids
+            self.short_ids: list[str] = []
+            self.live_ids: list[str] = []
+
+    with (
+        patch(
+            "backend.routes.channels.repo.get_video_by_youtube_id",
+            new_callable=AsyncMock,
+            return_value=existing_video,
+        ),
+        patch(
+            "backend.routes.channels.repo.create_sync_run",
+            new_callable=AsyncMock,
+            return_value={"id": "run-1"},
+        ),
+        patch(
+            "backend.routes.channels.repo.create_sync_video",
+            new_callable=AsyncMock,
+            return_value={"id": "sv-1"},
+        ),
+        patch(
+            "backend.routes.channels.repo.update_sync_video_status",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.routes.channels.repo.update_sync_run",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.routes.channels.fetch_video_for_ingest", new_callable=AsyncMock
+        ) as mock_fetch,
+        patch(
+            "backend.routes.channels.repo.replace_chunks_for_video",
+            new_callable=AsyncMock,
+        ) as mock_replace_chunks,
+        patch("backend.services.supadata._get_client") as mock_get_client,
+        patch("backend.rag.retriever.invalidate_cache"),
+    ):
+        mock_client = AsyncMock()
+        mock_client.youtube.channel.videos = (
+            lambda *args, **kwargs: MockChannelVideosResult(["existing1"])
+        )
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            # No force param — defaults to false.
+            response = await ac.post("/api/channels/sync")
+
+    assert response.status_code == 200
+    # Existing video is skipped — no fetch, no replace.
+    mock_fetch.assert_not_called()
+    mock_replace_chunks.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #112 — production citations all show \`0:00\` and empty snippets.

**Root cause:** PR #100 (which fixed #89) correctly wired Supadata segment timestamps through all three ingest paths, so _new_ chunks carry real \`start_seconds\`/\`end_seconds\`/\`snippet\`. But \`sync_channel\` skips any video whose \`youtube_video_id\` is already in the DB, and the 20 videos in prod were ingested before PR #100 merged. They're stuck with zero timestamps and empty snippets, and there's no way to refresh them via the channel-sync pipeline.

## Changes

- \`app/backend/routes/channels.py\`
  - New \`force: bool = False\` query param on \`POST /api/channels/sync\`.
  - When \`force=true\` and a video already exists, the loop now re-fetches segments via \`fetch_video_for_ingest\`, re-chunks via \`chunk_video_timestamped\`, re-embeds, and atomically replaces chunks via \`replace_chunks_for_video\`. The video row itself (title, description, transcript text) is reused so conversation sources pointing at \`video_id\` stay valid.
  - Default \`force=false\` preserves the idempotent skip behaviour the scheduled sync relies on.
- \`app/backend/tests/test_chunk_timestamps.py\`
  - \`test_channel_sync_force_replaces_chunks_on_existing_video\` — locks in the backfill path: existing video → \`replace_chunks_for_video\` called with real timestamps, \`create_video\` and \`create_chunk\` both not called.
  - \`test_channel_sync_without_force_still_skips_existing_video\` — guards against regressing the idempotent default: no fetch, no replace when \`force\` is absent.

## Scope

Per #112, \`admin.py\` is off-limits for the factory. This PR only touches \`channels.py\` + tests. The admin add-video path is unaffected by the data problem (PR #100 already wired real timestamps there); this PR only addresses the backfill path for channel-synced videos.

## Backfill procedure (post-deploy)

\`\`\`
POST /api/channels/sync?force=true
\`\`\`

Re-processes every video in the configured channel, replacing stale chunks with new ones that carry Supadata-derived timestamps and snippets.

## Test plan

- [x] \`cd app/backend && uv run pytest tests/test_chunk_timestamps.py\` — 4/4 pass (+2 new regression tests)
- [x] \`cd app/backend && uv run pytest\` — 158/158 pass, 0 regressions
- [x] \`uv run mypy routes/channels.py tests/test_chunk_timestamps.py\` — clean
- [x] \`uv run ruff check routes/channels.py tests/test_chunk_timestamps.py\` — clean
- [ ] Manual: deploy, hit \`POST /api/channels/sync?force=true\`, verify \`sync_runs\` shows \`videos_new=20\`, then open \`GET /api/conversations/{id}\` and confirm \`sources[].start_seconds > 0\` and \`sources[].snippet != \"\"\` on at least one source

🤖 Generated with [Claude Code](https://claude.com/claude-code)