### PR TITLE
fix(auth): dedup concurrent /api/auth/me requests

### DIFF
--- a/app/frontend/src/__tests__/authApi.test.ts
+++ b/app/frontend/src/__tests__/authApi.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { me } from '../lib/authApi';
+
+describe('me() dedup', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function deferredJson(body: unknown, status = 200) {
+    let resolveFn!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      await gate;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: 'OK',
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      };
+    });
+    return { release: resolveFn };
+  }
+
+  it('coalesces concurrent callers into a single fetch (regression for issue #115)', async () => {
+    const { release } = deferredJson({
+      id: 'u1',
+      email: 'a@b.com',
+      is_admin: false,
+      messages_used_today: 0,
+      messages_remaining_today: 25,
+      rate_window_resets_at: null,
+    });
+
+    const callers = [me(), me(), me(), me(), me(), me(), me()];
+
+    // Every caller shares the same promise while the fetch is in flight.
+    expect(callers.every((p) => p === callers[0])).toBe(true);
+
+    release();
+    await Promise.all(callers);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after the previous call settles', async () => {
+    const first = deferredJson({
+      id: 'u1',
+      email: 'a@b.com',
+      is_admin: false,
+      messages_used_today: 0,
+      messages_remaining_today: 25,
+      rate_window_resets_at: null,
+    });
+    first.release();
+    await me();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const second = deferredJson({
+      id: 'u1',
+      email: 'a@b.com',
+      is_admin: false,
+      messages_used_today: 1,
+      messages_remaining_today: 24,
+      rate_window_resets_at: null,
+    });
+    second.release();
+    await me();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/frontend/src/lib/authApi.ts
+++ b/app/frontend/src/lib/authApi.ts
@@ -111,4 +111,17 @@ export const login = (email: string, password: string) =>
 
 export const logout = () => authRequest<void>('/logout', { method: 'POST' });
 
-export const me = () => authRequest<AuthMeResponse>('/me', { method: 'GET' });
+// In-flight `me()` promise. Multiple concurrent callers (e.g. an AuthProvider
+// that re-renders during mount, or a component that calls refresh() before
+// the first fetch has settled) share the same request instead of fanning out.
+// Cleared on settle so the next mount-cycle or post-login refresh gets a fresh
+// hit. Regression guard for issue #115 — seven /api/auth/me calls on signup.
+let _meInFlight: Promise<AuthMeResponse> | null = null;
+
+export const me = (): Promise<AuthMeResponse> => {
+  if (_meInFlight) return _meInFlight;
+  _meInFlight = authRequest<AuthMeResponse>('/me', { method: 'GET' }).finally(() => {
+    _meInFlight = null;
+  });
+  return _meInFlight;
+};


### PR DESCRIPTION
## Linked issue

Fixes #115

## Summary

Seven `GET /api/auth/me` requests were firing within ~150ms on a fresh signup
page load, each returning 401. The `useAuth` hook's `refresh()` has a stable
useCallback reference and a single `useEffect([refresh])`, so in principle
this should be one mount-time fetch. In practice, any environment that
double-invokes effects (React StrictMode in dev, HMR, error boundaries) or
any path that calls `refresh()` concurrently with the mount-time fetch
(components that re-trigger during hydration) fans out multiple
`/api/auth/me` hits.

Rather than try to guess at the exact trigger (which I can't reproduce in the
prod build from the repo), this PR moves the guarantee into the API layer:
a single in-flight promise is shared across concurrent `me()` callers. The
promise is cleared on settle so the next explicit `refresh()` still hits the
server.

## How this solves the issue

`me()` is now backed by a module-level promise cache. When a fetch is in
flight, subsequent calls return the same promise instead of spawning new
requests. The cache is cleared in `.finally()` so post-settle callers hit
the network again — which matters for the post-login `refresh()` that needs
the authoritative rate-limit counter.

## Test plan

- [x] `npx vitest run src/__tests__/authApi.test.ts` — 2 new tests
  (concurrent callers coalesce to 1 fetch; sequential callers each hit)
- [x] Full frontend suite: 91 passed
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/__tests__/authApi.test.ts src/lib/authApi.ts` clean
- [ ] Manual: open `/signup` in a fresh tab with devtools open; confirm
  exactly 1 `/api/auth/me` request (validator will cover this)

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask
  question → streaming response → citations → citation modal)

## Dependencies

No new dependencies.

## Governance / protected files

- [x] No protected files modified — touches `app/frontend/src/lib/authApi.ts`
  and adds `app/frontend/src/__tests__/authApi.test.ts` only
- [x] PR size under 500 lines (91 additions, 1 deletion)
- [x] No weakening of authentication, authorization, or the 25 msg/day limit
