### PR TITLE
fix(alembic): correct 0004 down_revision unblocking production deploys

### DIFF
--- a/app/backend/alembic/versions/0004_add_channel_columns_to_videos.py
+++ b/app/backend/alembic/versions/0004_add_channel_columns_to_videos.py
@@ -1,7 +1,7 @@
 """Add channel_id and channel_title columns to videos.
 
 Revision ID: 0004
-Revises: 0003_add_sources_to_messages
+Revises: 0003
 Create Date: 2026-04-21
 
 """
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0004"
-down_revision: str | None = "0003_add_sources_to_messages"
+down_revision: str | None = "0003"
 branch_labels: str | None = None
 depends_on: str | None = None
 


### PR DESCRIPTION
## Problem

Production has been stuck on pre-#136 code since #136 merged on 2026-04-21 18:26 CDT. Every blue/green deploy cycle since then has failed with:

```
alembic ... KeyError: '0003_add_sources_to_messages'
ERROR:    Application startup failed. Exiting.
[...] app-green unhealthy (unhealthy) — aborting, keeping blue live
```

The `dynachat-app-blue` container has been running for 44+ hours — that's how long the blue/green rollback has been keeping users on the old code. Every PR merged since #136 — #137, #138, #146, #149, etc. — is **not live**.

## Root cause

Migration `0003_add_sources_to_messages.py`:
```python
revision: str = "0003"
```

Migration `0004_add_channel_columns_to_videos.py` (added in #136):
```python
down_revision: str | None = "0003_add_sources_to_messages"
```

Alembic looks up `"0003_add_sources_to_messages"` in its revision map and finds nothing — the actual revision ID of 0003 is just `"0003"`. The filename and the `revision` string are different, and the downrev must match the `revision` string, not the filename.

## Fix

One-line change in `0004_add_channel_columns_to_videos.py`:

```diff
- down_revision: str | None = "0003_add_sources_to_messages"
+ down_revision: str | None = "0003"
```

Also updated the docstring `Revises:` line for consistency.

## Verification

Locally:
```
$ python -c "from alembic.config import Config; from alembic.script import ScriptDirectory; ..."
Head: 0004
Revisions:
  0004 (down: 0003)
  0003 (down: 0002)
  0002 (down: 0001)
  0001 (down: None)
```

The chain resolves cleanly. No data migration needed — the DB is already at `0003`, so the next deploy will run `0004` forward as intended.

## Notes for reviewer

- Pure revision-ID string fix. No schema changes. No runtime code touched.
- Human-authored, not factory-produced.
- Needs to merge and deploy ASAP so the backlog of ~2 days of merged-but-undeployed changes can finally land.
- Once live: PRs #146 (tool-driven RAG) and #149 (tool-driven RAG fixes) will both be in production for the first time.

## Test plan

- [x] `alembic walk_revisions()` resolves 0001→0002→0003→0004 with head=0004
- [ ] Post-merge: watch `journalctl -u dynachat-deploy.service` on VPS — expect green to come up healthy and take over
- [ ] Post-merge: E2E smoke test of chat.dynamous.ai to confirm new tool-driven RAG path is live
