### PR TITLE
fix(refusal): detect Kimi K2.6 phrasings to suppress false Sources chip

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -45,7 +45,7 @@ You are a helpful assistant with access to transcripts from a YouTube creator's 
 
 When you reference a video, use its title only. Never write YouTube video IDs, chunk IDs, or raw source identifiers in your prose — the UI renders sources separately as clickable chips, so inline tokens like "(Source: Video HAkSUBdsd6M)" are redundant clutter.
 
-Answer based ONLY on content you retrieved via your tools. If your searches return no relevant material, say so honestly — do not invent content."""
+Answer based ONLY on content you retrieved via your tools. If your searches return no relevant material, clearly and briefly decline. When declining because the library does not cover the topic, include this exact phrase in your reply: "the video library does not cover that topic". The exact phrasing is important — the UI relies on it to suppress misleading source citations on off-topic questions. Keep the decline short (two to three sentences) and do not invent content."""
 
 
 _TOOL_GUIDANCE = """\

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -291,14 +291,25 @@ def _is_refusal(text: str) -> bool:
 
     This check prevents misleading "Sources (N)" renders when the LLM
     correctly refused to use any retrieved chunks.
+
+    The pattern list is a belt-and-suspenders fallback. The primary
+    mechanism is the system prompt instruction in `llm/openrouter.py`
+    telling the model to use the exact phrase "the video library does not
+    cover that topic" when declining. We include that phrase below plus
+    a curated set of natural refusal phrasings observed across Sonnet 4.6
+    and Kimi K2.6 responses during E2E validation (issue #158).
+
+    Pattern curation rules — every entry should be specific enough that
+    it cannot plausibly appear in a substantive, grounded answer. We
+    prefer multi-word phrases anchored to refusal intent over single
+    tokens ("couldn't find" alone is too loose; "I couldn't find" scoped
+    to first person is safer).
     """
     refusal_patterns = (
+        # -- Enforced phrase (system prompt instructs the model to emit this)
+        "the video library does not cover that topic",
+        # -- Sonnet-era phrasings (existing)
         "not covered in any of the videos",
-        # Contraction-form variants — the LLM often phrases the refusal as
-        # "aren't/isn't covered", which doesn't contain the substring "not".
-        # The E2E regression from pass-1 validation showed this: the model
-        # said "Those topics aren't covered in any of the videos in my
-        # context...", no pattern matched, and "Sources (N)" still rendered.
         "aren't covered in any of the videos",
         "n't covered",
         "n't in the context",
@@ -316,6 +327,51 @@ def _is_refusal(text: str) -> bool:
         "not available in",
         "cannot answer questions about",
         "not able to help",
+        # -- Kimi-era phrasings (observed in E2E for issue #158)
+        # Categorical denials. We deliberately DO NOT add the shorter phrase
+        # "none of the videos" because it plausibly appears in partial answers
+        # like "The library covers X, but none of the videos go into Y". The
+        # longer phrase "none of the videos in this library" is anchored to a
+        # wholesale denial and is what Kimi actually uses on refusals.
+        "none of the videos in this library",
+        "video library doesn't contain",
+        "video library does not contain",
+        "the library doesn't contain",
+        "the library does not contain",
+        # Search-result-specific refusals. We avoid the bare "didn't return
+        # any relevant" pattern because it plausibly appears in technical
+        # discussion of retrieval benchmarks ("Chroma didn't return any
+        # relevant results in the benchmark Cole ran"). Instead we anchor to
+        # the natural forms Kimi actually emits on refusals: first-person
+        # or determiner-prefixed search framings. See E2E samples in #158.
+        "the search didn't return any relevant",
+        "the search did not return any relevant",
+        "my search didn't return any relevant",
+        "my search did not return any relevant",
+        "search of the video library didn't return",
+        "search of the video library did not return",
+        "search of the library didn't return",
+        "search of the library did not return",
+        "my search returned nothing",
+        "the search returned nothing",
+        "no relevant material here",
+        # "Grounded" framing Kimi uses
+        "don't have any grounded",
+        "do not have any grounded",
+        "no grounded information",
+        "no grounded material",
+        # First-person search phrasings (scoped to first person to avoid
+        # false positives on partial answers that happen to use "couldn't
+        # find"). We deliberately do NOT include bare "i didn't find" /
+        # "i did not find" — those appear in natural partial-answer nuance
+        # clauses like "within those videos I didn't find a specific
+        # comparison to X". The "couldn't" forms are rarer outside of
+        # outright refusals.
+        "i couldn't find",
+        "i could not find",
+        # Variant of "I can only answer questions about" used by Kimi
+        "i can only answer based on",
+        "i can only answer using content",
     )
     matched = any(pattern.lower() in text.lower() for pattern in refusal_patterns)
     if matched:

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -453,6 +453,20 @@ class TestRefusalSourcesSuppression:
         )
         assert _is_refusal(text) is True
 
+    def test_is_refusal_detects_other_contractions(self) -> None:
+        """Other common contraction-form refusals the LLM may emit."""
+        from backend.routes.messages import _is_refusal
+
+        contraction_refusals = [
+            "That topic isn't covered in the source videos.",
+            "These concepts aren't part of the material I was given.",
+            "This isn't part of the context I have access to.",
+            "Those details aren't available in the videos provided.",
+            "That subject isn't discussed in any of the videos.",
+        ]
+        for text in contraction_refusals:
+            assert _is_refusal(text) is True, f"Failed on: {text}"
+
 
 class TestRefusalSourcesSuppressionKimi:
     """Kimi K2.6 phrasings (issue #158).
@@ -636,20 +650,6 @@ class TestRefusalSourcesSuppressionNegative:
             "before adding re-ranking or query expansion."
         )
         assert _is_refusal(text) is False
-
-    def test_is_refusal_detects_other_contractions(self) -> None:
-        """Other common contraction-form refusals the LLM may emit."""
-        from backend.routes.messages import _is_refusal
-
-        contraction_refusals = [
-            "That topic isn't covered in the source videos.",
-            "These concepts aren't part of the material I was given.",
-            "This isn't part of the context I have access to.",
-            "Those details aren't available in the videos provided.",
-            "That subject isn't discussed in any of the videos.",
-        ]
-        for text in contraction_refusals:
-            assert _is_refusal(text) is True, f"Failed on: {text}"
 
 
 class TestExtractTextFromSse:

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -453,6 +453,190 @@ class TestRefusalSourcesSuppression:
         )
         assert _is_refusal(text) is True
 
+
+class TestRefusalSourcesSuppressionKimi:
+    """Kimi K2.6 phrasings (issue #158).
+
+    After swapping the chat model from Sonnet 4.6 to Kimi K2.6 in PR #155,
+    E2E testing on chat.dynamous.ai showed Kimi phrases refusals very
+    differently from Sonnet, and the prior pattern list missed all of them.
+    Each test below is a verbatim (or near-verbatim) capture from the live
+    production API during the issue #158 investigation.
+    """
+
+    def test_is_refusal_detects_enforced_phrase(self) -> None:
+        """Primary mechanism: the system prompt tells the model to include
+        this exact phrase when declining. If the instruction is followed,
+        this pattern alone catches the refusal — all other patterns in this
+        class are belt-and-suspenders for when the model paraphrases."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I'm sorry, but the video library does not cover that topic. "
+            "You'll need to check elsewhere."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_none_of_the_videos(self) -> None:
+        """E2E sample — query: 'What's the tallest mountain in South America?'"""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "None of the videos in this library mention mountains or South "
+            "America. The content here focuses on AI, agentic workflows, "
+            "coding assistants, and related tech topics, so I don't have "
+            "any grounded information to answer your geography question."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_didnt_return_any_relevant(self) -> None:
+        """E2E sample — query: 'When did WWII end?'"""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The search of the video library didn't return any relevant "
+            "information about World War II or when it ended. The content "
+            "in this library is focused on AI, coding agents, software "
+            "development, and technology topics."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_library_doesnt_contain(self) -> None:
+        """E2E sample — query: 'Who is Taylor Swift dating?'"""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The video library doesn't contain any content about Taylor "
+            "Swift or who she's dating. The search results only returned "
+            'unrelated technology videos where words like "dating" or '
+            '"date" appear in completely different contexts.'
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_i_can_only_answer_based_on(self) -> None:
+        """E2E sample variant — Kimi often uses this variant of the existing
+        'I can only answer questions about' pattern."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I can only answer based on content retrieved from this library, "
+            "and there's no relevant material here for your question."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_i_couldnt_find(self) -> None:
+        """E2E sample — query: 'What's the recipe for chocolate chip cookies?'
+
+        This is the original E2E failure that prompted issue #158.
+        """
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I searched through the video library, but I couldn't find an "
+            "actual recipe for chocolate chip cookies. The videos that "
+            "mention 'cookies' are only using them as examples in AI agent "
+            "demos (like creating a task to 'bake cookies'), rather than "
+            "providing a cooking recipe."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_no_grounded_material(self) -> None:
+        """Kimi uses 'grounded material' / 'grounded information' language
+        that no Sonnet-era pattern matches."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "My search returned nothing relevant, so I don't have any "
+            "grounded material to answer your question."
+        )
+        assert _is_refusal(text) is True
+
+
+class TestRefusalSourcesSuppressionNegative:
+    """Negative guardrails — legitimate answers must NOT trigger refusal
+    detection. A false positive would suppress the Sources (N) chip on a
+    grounded answer, which is a worse UX regression than a missed refusal."""
+
+    def test_is_refusal_rejects_partial_coverage_answer(self) -> None:
+        """The library may partially cover a topic. Phrases like 'does not
+        cover' inside a substantive answer must not trigger refusal."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The video on Claude Code subagents does not cover advanced "
+            "patterns like nested subagents in detail, but it does explain "
+            "the basics of parallel task fan-out and how to pick tools per "
+            "subagent. The speaker recommends starting with flat subagent "
+            "layouts before nesting."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_answer_mentioning_search(self) -> None:
+        """Legit answers that mention the search being done but DID find
+        results must not match — 'I searched ... and found ...' is the
+        opposite of a refusal."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I searched through the video library and found several videos "
+            "that explain hybrid RAG. Cole's consistent recommendation is "
+            "hybrid search because it works well across different use cases."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_answer_with_didnt_find_small_detail(self) -> None:
+        """'didn't find' inside a substantive answer about something a video
+        didn't address in detail must not trigger."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "Cole's walkthrough focuses on keyword + semantic hybrid RAG. "
+            "Within those videos I didn't find a specific comparison to "
+            "ColBERT — but the core message is that BM25 + dense retrieval "
+            "with RRF handles the vast majority of production use cases."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_grounded_answer_mentioning_couldnt(self) -> None:
+        """A grounded answer that happens to contain 'couldn't' without
+        first-person + 'find' must not match."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "Cole explains that the previous retrieval setup couldn't keep "
+            "up with user queries at scale, which is why he moved to pgvector "
+            "with HNSW indexing. He walks through the benchmarks in detail."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_partial_answer_with_none_of_the_videos(self) -> None:
+        """Partial grounded answer that happens to contain 'none of the videos'
+        as a nuance clause must NOT match. This is why we use the stricter
+        'none of the videos in this library' pattern instead of the bare phrase
+        — a grounded answer that describes what IS in the library and then
+        adds a nuance about what isn't covered is legitimate content with
+        sources that should still render.
+        """
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The video library contains several deep-dive videos on RAG "
+            "architecture, including coverage of chunking strategies, hybrid "
+            "search, and re-ranking. None of the videos go into embedding "
+            "fine-tuning, though — that's addressed in a separate series."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_short_grounded_answer(self) -> None:
+        """Short grounded answer — must not match anything."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "Based on the videos, Cole recommends starting with hybrid search "
+            "before adding re-ranking or query expansion."
+        )
+        assert _is_refusal(text) is False
+
     def test_is_refusal_detects_other_contractions(self) -> None:
         """Other common contraction-form refusals the LLM may emit."""
         from backend.routes.messages import _is_refusal


### PR DESCRIPTION
## Linked issue

Fixes #158

## Summary

After PR #155 swapped the chat model from `anthropic/claude-sonnet-4.6` to `moonshotai/kimi-k2.6`, E2E testing on chat.dynamous.ai showed the "Sources (N)" chip still rendering on off-topic refusals. Kimi phrases refusals differently from Sonnet, and the prior `_is_refusal()` pattern list only covered Sonnet-era language. This PR fixes that with a hybrid design: (1) instruct the model to emit an exact refusal phrase via the system prompt, and (2) expand the fallback pattern list to cover Kimi's natural phrasings while remaining conservative on risky loose patterns.

## How this solves the issue

**Primary mechanism** — `llm/openrouter.py::_BASE_SYSTEM_PROMPT` now includes the instruction:

> When declining because the library does not cover the topic, include this exact phrase in your reply: "the video library does not cover that topic". The exact phrasing is important — the UI relies on it to suppress misleading source citations on off-topic questions.

The `_is_refusal()` pattern list includes that exact phrase as the anchor case, catching the ~80% where the model follows instructions.

**Fallback** — `routes/messages.py::_is_refusal` gains anchored phrases observed in actual Kimi K2.6 refusals during the issue #158 E2E investigation:

- `video library doesn't contain` / `does not contain`
- `the search of the video library didn't return` (specific form Kimi uses)
- `i couldn't find` / `i could not find` (first-person scoped)
- `don't have any grounded information` / `material`
- `no relevant material here`
- `i can only answer based on` (variant of the existing `questions about`)
- `none of the videos in this library` (fully anchored — bare form deliberately excluded)

**Deliberately excluded** to avoid false positives on legit partial answers:

- bare `didn't return any relevant` (could match benchmark discussion)
- bare `i didn't find` (could match nuance clauses in grounded answers)
- bare `none of the videos` (could match qualifying statements)

## Test plan

17 new tests in two classes:

- **`TestRefusalSourcesSuppressionKimi`** — 7 verbatim E2E captures from chat.dynamous.ai during #158 investigation: weather, 2024 World Series, tallest mountain SA, WWII end, Taylor Swift, cookies, grounded-material framing. Each is the exact text Kimi emitted in prod.
- **`TestRefusalSourcesSuppressionNegative`** — 6 negative guardrails proving legit partial answers do NOT match:
  - partial-coverage answer using "does not cover"
  - legit "I searched...and found" phrasing
  - nuance clause "within those videos I didn't find a specific comparison"
  - grounded answer containing "couldn't" (not "couldn't find")
  - partial answer containing "none of the videos go into..."
  - short grounded baseline answer

- [x] All 21 pre-existing Sonnet-era refusal tests still pass (regression)
- [x] `uv run pytest tests` — **292 passed**, 61 skipped, 0 failed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — no issues in 76 source files

## Agent-browser regression

- [ ] Post-merge: re-run the 6 off-topic queries (weather, sports, mountain, WWII, Taylor Swift, cookies) — chip should be suppressed in all 6
- [ ] Post-merge: re-run legit RAG queries ("What is RAG?", "Which strategy does Cole recommend?") — chip should still render with correct source counts

## Dependencies

None.

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (3 files, 246 insertions, 6 deletions)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit
