### PR TITLE
fix(refusal): persist sources=None on refusals so reload doesn't bring the chip back

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -45,7 +45,7 @@ You are a helpful assistant with access to transcripts from a YouTube creator's 
 
 When you reference a video, use its title only. Never write YouTube video IDs, chunk IDs, or raw source identifiers in your prose — the UI renders sources separately as clickable chips, so inline tokens like "(Source: Video HAkSUBdsd6M)" are redundant clutter.
 
-Answer based ONLY on content you retrieved via your tools. If your searches return no relevant material, say so honestly — do not invent content."""
+Answer based ONLY on content you retrieved via your tools. If your searches return no relevant material, clearly and briefly decline. When declining because the library does not cover the topic, include this exact phrase in your reply: "the video library does not cover that topic". The exact phrasing is important — the UI relies on it to suppress misleading source citations on off-topic questions. Keep the decline short (two to three sentences) and do not invent content."""
 
 
 _TOOL_GUIDANCE = """\

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -215,6 +215,22 @@ async def create_message(
             # can exit cleanly.
             assistant_text = _extract_text_from_sse(full_response)
             if assistant_text:
+                # Apply the same refusal detection used for the live SSE
+                # `event: sources` suppression so reloading the conversation
+                # later doesn't bring the misleading chip back. Prefer the
+                # final-round text when available — it's what the SSE path
+                # checks — and fall back to the full reconstructed text if
+                # the final_text buffer wasn't populated (e.g. pre-tool
+                # flow). If the message is a refusal we persist sources=None
+                # regardless of what the tool calls retrieved; the frontend
+                # renders the chip based on the stored field, so dropping
+                # it here keeps the reload UX consistent with the stream.
+                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
+                sources_to_persist: list[dict] | None = (
+                    None
+                    if not source_citations or _is_refusal(refusal_check_text)
+                    else source_citations
+                )
                 try:
                     await asyncio.shield(
                         repository.create_message(
@@ -222,7 +238,7 @@ async def create_message(
                             user_id=user_id,
                             role="assistant",
                             content=assistant_text,
-                            sources=source_citations if source_citations else None,
+                            sources=sources_to_persist,
                         )
                     )
                 except asyncio.CancelledError:

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -291,14 +291,25 @@ def _is_refusal(text: str) -> bool:
 
     This check prevents misleading "Sources (N)" renders when the LLM
     correctly refused to use any retrieved chunks.
+
+    The pattern list is a belt-and-suspenders fallback. The primary
+    mechanism is the system prompt instruction in `llm/openrouter.py`
+    telling the model to use the exact phrase "the video library does not
+    cover that topic" when declining. We include that phrase below plus
+    a curated set of natural refusal phrasings observed across Sonnet 4.6
+    and Kimi K2.6 responses during E2E validation (issue #158).
+
+    Pattern curation rules — every entry should be specific enough that
+    it cannot plausibly appear in a substantive, grounded answer. We
+    prefer multi-word phrases anchored to refusal intent over single
+    tokens ("couldn't find" alone is too loose; "I couldn't find" scoped
+    to first person is safer).
     """
     refusal_patterns = (
+        # -- Enforced phrase (system prompt instructs the model to emit this)
+        "the video library does not cover that topic",
+        # -- Sonnet-era phrasings (existing)
         "not covered in any of the videos",
-        # Contraction-form variants — the LLM often phrases the refusal as
-        # "aren't/isn't covered", which doesn't contain the substring "not".
-        # The E2E regression from pass-1 validation showed this: the model
-        # said "Those topics aren't covered in any of the videos in my
-        # context...", no pattern matched, and "Sources (N)" still rendered.
         "aren't covered in any of the videos",
         "n't covered",
         "n't in the context",
@@ -316,6 +327,51 @@ def _is_refusal(text: str) -> bool:
         "not available in",
         "cannot answer questions about",
         "not able to help",
+        # -- Kimi-era phrasings (observed in E2E for issue #158)
+        # Categorical denials. We deliberately DO NOT add the shorter phrase
+        # "none of the videos" because it plausibly appears in partial answers
+        # like "The library covers X, but none of the videos go into Y". The
+        # longer phrase "none of the videos in this library" is anchored to a
+        # wholesale denial and is what Kimi actually uses on refusals.
+        "none of the videos in this library",
+        "video library doesn't contain",
+        "video library does not contain",
+        "the library doesn't contain",
+        "the library does not contain",
+        # Search-result-specific refusals. We avoid the bare "didn't return
+        # any relevant" pattern because it plausibly appears in technical
+        # discussion of retrieval benchmarks ("Chroma didn't return any
+        # relevant results in the benchmark Cole ran"). Instead we anchor to
+        # the natural forms Kimi actually emits on refusals: first-person
+        # or determiner-prefixed search framings. See E2E samples in #158.
+        "the search didn't return any relevant",
+        "the search did not return any relevant",
+        "my search didn't return any relevant",
+        "my search did not return any relevant",
+        "search of the video library didn't return",
+        "search of the video library did not return",
+        "search of the library didn't return",
+        "search of the library did not return",
+        "my search returned nothing",
+        "the search returned nothing",
+        "no relevant material here",
+        # "Grounded" framing Kimi uses
+        "don't have any grounded",
+        "do not have any grounded",
+        "no grounded information",
+        "no grounded material",
+        # First-person search phrasings (scoped to first person to avoid
+        # false positives on partial answers that happen to use "couldn't
+        # find"). We deliberately do NOT include bare "i didn't find" /
+        # "i did not find" — those appear in natural partial-answer nuance
+        # clauses like "within those videos I didn't find a specific
+        # comparison to X". The "couldn't" forms are rarer outside of
+        # outright refusals.
+        "i couldn't find",
+        "i could not find",
+        # Variant of "I can only answer questions about" used by Kimi
+        "i can only answer based on",
+        "i can only answer using content",
     )
     matched = any(pattern.lower() in text.lower() for pattern in refusal_patterns)
     if matched:

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -721,6 +721,103 @@ class TestRefusalSourcesSuppressionIntegration:
     suppresses sources event → response contains [DONE] but no 'event: sources'.
     """
 
+    async def test_refusal_persists_sources_as_none(self) -> None:
+        """When LLM refuses, the assistant row persisted to the DB must have
+        ``sources=None`` — otherwise reloading the conversation would bring
+        the misleading 'Sources (N)' chip back, defeating the SSE-level
+        suppression. Belt-and-suspenders fix for issue #158."""
+        import json
+        from unittest.mock import AsyncMock, patch
+        from uuid import uuid4
+
+        from httpx import ASGITransport, AsyncClient
+
+        from backend.auth.tokens import encode_token
+        from backend.main import app
+
+        refusal_text = "Those topics are not covered in any of the videos."
+        refusal_chunk = f"data: {json.dumps(refusal_text)}\n\n"
+        done_chunk = "data: [DONE]\n\n"
+
+        source_citations = [
+            {
+                "chunk_id": "c1",
+                "video_id": "v1",
+                "video_title": "Test Video",
+                "video_url": "u",
+                "start_seconds": 10.0,
+                "end_seconds": 20.0,
+                "snippet": "Test snippet",
+            }
+        ]
+
+        async def mock_stream_chat(
+            messages, tools=None, tool_executor=None, max_tool_calls=0, final_text_out=None
+        ):
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "test"}))
+            yield refusal_chunk
+            if final_text_out is not None:
+                final_text_out.append(refusal_text)
+            yield done_chunk
+
+        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None):
+            return {"ok": True, "text": "context", "chunks": source_citations}
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        async def mock_get_user_by_id(user_id):
+            return {
+                "id": test_user_id,
+                "email": "test@example.com",
+                "password_hash": "hashed",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {
+                "id": test_conv_id,
+                "user_id": test_user_id,
+                "title": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+
+        async def mock_list_messages(conv_id, user_id):
+            return []
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                await client.post(
+                    f"/api/conversations/{test_conv_id}/messages",
+                    json={"content": "off-topic question"},
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        # Two create_message calls: user msg, then assistant msg in finally.
+        assert mock_create.call_count == 2, f"expected 2 calls, got {mock_create.call_count}"
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] is None, (
+            f"refusal should persist sources=None (reload-scenario protection); "
+            f"got {assistant_kwargs['sources']!r}"
+        )
+
     async def test_sources_event_suppressed_on_refusal(self) -> None:
         """When LLM refuses, the sources SSE event must not be emitted."""
         import json

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -453,6 +453,20 @@ class TestRefusalSourcesSuppression:
         )
         assert _is_refusal(text) is True
 
+    def test_is_refusal_detects_other_contractions(self) -> None:
+        """Other common contraction-form refusals the LLM may emit."""
+        from backend.routes.messages import _is_refusal
+
+        contraction_refusals = [
+            "That topic isn't covered in the source videos.",
+            "These concepts aren't part of the material I was given.",
+            "This isn't part of the context I have access to.",
+            "Those details aren't available in the videos provided.",
+            "That subject isn't discussed in any of the videos.",
+        ]
+        for text in contraction_refusals:
+            assert _is_refusal(text) is True, f"Failed on: {text}"
+
 
 class TestRefusalSourcesSuppressionKimi:
     """Kimi K2.6 phrasings (issue #158).
@@ -636,20 +650,6 @@ class TestRefusalSourcesSuppressionNegative:
             "before adding re-ranking or query expansion."
         )
         assert _is_refusal(text) is False
-
-    def test_is_refusal_detects_other_contractions(self) -> None:
-        """Other common contraction-form refusals the LLM may emit."""
-        from backend.routes.messages import _is_refusal
-
-        contraction_refusals = [
-            "That topic isn't covered in the source videos.",
-            "These concepts aren't part of the material I was given.",
-            "This isn't part of the context I have access to.",
-            "Those details aren't available in the videos provided.",
-            "That subject isn't discussed in any of the videos.",
-        ]
-        for text in contraction_refusals:
-            assert _is_refusal(text) is True, f"Failed on: {text}"
 
 
 class TestExtractTextFromSse:

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -453,6 +453,190 @@ class TestRefusalSourcesSuppression:
         )
         assert _is_refusal(text) is True
 
+
+class TestRefusalSourcesSuppressionKimi:
+    """Kimi K2.6 phrasings (issue #158).
+
+    After swapping the chat model from Sonnet 4.6 to Kimi K2.6 in PR #155,
+    E2E testing on chat.dynamous.ai showed Kimi phrases refusals very
+    differently from Sonnet, and the prior pattern list missed all of them.
+    Each test below is a verbatim (or near-verbatim) capture from the live
+    production API during the issue #158 investigation.
+    """
+
+    def test_is_refusal_detects_enforced_phrase(self) -> None:
+        """Primary mechanism: the system prompt tells the model to include
+        this exact phrase when declining. If the instruction is followed,
+        this pattern alone catches the refusal — all other patterns in this
+        class are belt-and-suspenders for when the model paraphrases."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I'm sorry, but the video library does not cover that topic. "
+            "You'll need to check elsewhere."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_none_of_the_videos(self) -> None:
+        """E2E sample — query: 'What's the tallest mountain in South America?'"""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "None of the videos in this library mention mountains or South "
+            "America. The content here focuses on AI, agentic workflows, "
+            "coding assistants, and related tech topics, so I don't have "
+            "any grounded information to answer your geography question."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_didnt_return_any_relevant(self) -> None:
+        """E2E sample — query: 'When did WWII end?'"""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The search of the video library didn't return any relevant "
+            "information about World War II or when it ended. The content "
+            "in this library is focused on AI, coding agents, software "
+            "development, and technology topics."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_library_doesnt_contain(self) -> None:
+        """E2E sample — query: 'Who is Taylor Swift dating?'"""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The video library doesn't contain any content about Taylor "
+            "Swift or who she's dating. The search results only returned "
+            'unrelated technology videos where words like "dating" or '
+            '"date" appear in completely different contexts.'
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_i_can_only_answer_based_on(self) -> None:
+        """E2E sample variant — Kimi often uses this variant of the existing
+        'I can only answer questions about' pattern."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I can only answer based on content retrieved from this library, "
+            "and there's no relevant material here for your question."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_i_couldnt_find(self) -> None:
+        """E2E sample — query: 'What's the recipe for chocolate chip cookies?'
+
+        This is the original E2E failure that prompted issue #158.
+        """
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I searched through the video library, but I couldn't find an "
+            "actual recipe for chocolate chip cookies. The videos that "
+            "mention 'cookies' are only using them as examples in AI agent "
+            "demos (like creating a task to 'bake cookies'), rather than "
+            "providing a cooking recipe."
+        )
+        assert _is_refusal(text) is True
+
+    def test_is_refusal_detects_no_grounded_material(self) -> None:
+        """Kimi uses 'grounded material' / 'grounded information' language
+        that no Sonnet-era pattern matches."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "My search returned nothing relevant, so I don't have any "
+            "grounded material to answer your question."
+        )
+        assert _is_refusal(text) is True
+
+
+class TestRefusalSourcesSuppressionNegative:
+    """Negative guardrails — legitimate answers must NOT trigger refusal
+    detection. A false positive would suppress the Sources (N) chip on a
+    grounded answer, which is a worse UX regression than a missed refusal."""
+
+    def test_is_refusal_rejects_partial_coverage_answer(self) -> None:
+        """The library may partially cover a topic. Phrases like 'does not
+        cover' inside a substantive answer must not trigger refusal."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The video on Claude Code subagents does not cover advanced "
+            "patterns like nested subagents in detail, but it does explain "
+            "the basics of parallel task fan-out and how to pick tools per "
+            "subagent. The speaker recommends starting with flat subagent "
+            "layouts before nesting."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_answer_mentioning_search(self) -> None:
+        """Legit answers that mention the search being done but DID find
+        results must not match — 'I searched ... and found ...' is the
+        opposite of a refusal."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "I searched through the video library and found several videos "
+            "that explain hybrid RAG. Cole's consistent recommendation is "
+            "hybrid search because it works well across different use cases."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_answer_with_didnt_find_small_detail(self) -> None:
+        """'didn't find' inside a substantive answer about something a video
+        didn't address in detail must not trigger."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "Cole's walkthrough focuses on keyword + semantic hybrid RAG. "
+            "Within those videos I didn't find a specific comparison to "
+            "ColBERT — but the core message is that BM25 + dense retrieval "
+            "with RRF handles the vast majority of production use cases."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_grounded_answer_mentioning_couldnt(self) -> None:
+        """A grounded answer that happens to contain 'couldn't' without
+        first-person + 'find' must not match."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "Cole explains that the previous retrieval setup couldn't keep "
+            "up with user queries at scale, which is why he moved to pgvector "
+            "with HNSW indexing. He walks through the benchmarks in detail."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_partial_answer_with_none_of_the_videos(self) -> None:
+        """Partial grounded answer that happens to contain 'none of the videos'
+        as a nuance clause must NOT match. This is why we use the stricter
+        'none of the videos in this library' pattern instead of the bare phrase
+        — a grounded answer that describes what IS in the library and then
+        adds a nuance about what isn't covered is legitimate content with
+        sources that should still render.
+        """
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "The video library contains several deep-dive videos on RAG "
+            "architecture, including coverage of chunking strategies, hybrid "
+            "search, and re-ranking. None of the videos go into embedding "
+            "fine-tuning, though — that's addressed in a separate series."
+        )
+        assert _is_refusal(text) is False
+
+    def test_is_refusal_rejects_short_grounded_answer(self) -> None:
+        """Short grounded answer — must not match anything."""
+        from backend.routes.messages import _is_refusal
+
+        text = (
+            "Based on the videos, Cole recommends starting with hybrid search "
+            "before adding re-ranking or query expansion."
+        )
+        assert _is_refusal(text) is False
+
     def test_is_refusal_detects_other_contractions(self) -> None:
         """Other common contraction-form refusals the LLM may emit."""
         from backend.routes.messages import _is_refusal


### PR DESCRIPTION
## Linked issue

Follow-up to #158 (PR #161 merged the live-stream fix).

## Summary

During post-merge E2E validation of #161, I reloaded one of the off-topic refusal conversations in the browser and saw **six "Sources (N)" chips still rendering** — one per refusal message. The live-stream SSE suppression was working, but the assistant row was being persisted with `sources=source_citations` regardless of the refusal check. On reload, the frontend reads `sources` from the DB record and renders the chip.

## How this solves the issue

Symmetric with the SSE-level suppression: run `_is_refusal` on the same `final_text_buf`-or-reconstructed text, and pass `sources=None` to `repository.create_message` when it matches.

```python
refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
sources_to_persist: list[dict] | None = (
    None
    if not source_citations or _is_refusal(refusal_check_text)
    else source_citations
)
await asyncio.shield(
    repository.create_message(
        ...
        sources=sources_to_persist,
    )
)
```

## Test plan

New test `test_refusal_persists_sources_as_none` drives the full ASGI route with a refusal-yielding mock stream and asserts the assistant `create_message` call was invoked with `sources=None`. Companion to the existing `test_sources_event_suppressed_on_refusal`.

- [x] `uv run pytest tests` — **293 passed**, 61 skipped, 0 failed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — no issues in 76 source files

## Agent-browser regression

- [ ] Post-merge: fire an off-topic query, then reload the conversation — chip should NOT render
- [ ] Post-merge: fire a legit RAG query, reload — chip should still render with correct count

## Note on existing data

This PR does not backfill — the 6 refusal rows in my test conversation `8ea1fec6` and any other pre-existing refusal messages will still have `sources` populated. A one-shot cleanup script could null them out, but the volume is trivial (we've only been running Kimi for a day) so I'll leave that as a manual follow-up if needed.

## Governance / protected files

- [x] No protected files modified
- [x] PR size well within cap (1 file changed in backend, 1 test file; ~115 lines total)
- [x] No auth/rate-limit changes
