### PR TITLE
fix(llm): use tool_choice=none on cap-reached round (real fix for empty responses)

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -157,13 +157,18 @@ async def stream_chat(
     try:
         while True:
             round_num += 1
-            # Once the per-turn cap has been reached, stop declaring tools on
-            # subsequent completions so the model can't keep burning round-trips
-            # on tool calls that will all be capped. The final round answers
-            # using whatever context the already-executed tools returned.
+            # Once the per-turn cap has been reached, force the model to
+            # compose a final answer instead of calling more tools. We must
+            # NOT strip `tools` from the request: the conversation history
+            # already contains tool_use/tool_result blocks, and Anthropic's
+            # API (via OpenRouter) returns finish_reason=stop with zero
+            # content tokens when it sees tool-use context but no declared
+            # tools. Instead, keep tools declared and set tool_choice="none"
+            # — that tells the model tools exist but may not be called, so
+            # it answers using the context it already has.
             kwargs = dict(base_kwargs)
             if tools_active and tool_calls_made >= max_tool_calls:
-                kwargs.pop("tools", None)
+                kwargs["tool_choice"] = "none"
             stream = await client.chat.completions.create(messages=full_messages, **kwargs)
             assistant_text_parts: list[str] = []
             round_content_deltas = 0

--- a/app/backend/tests/test_stream_chat_max_tokens.py
+++ b/app/backend/tests/test_stream_chat_max_tokens.py
@@ -94,6 +94,107 @@ class TestMaxTokensPassedToOpenRouter:
         )
 
 
+class _FakeToolCallDelta:
+    def __init__(
+        self,
+        index: int,
+        call_id: str | None = None,
+        name: str | None = None,
+        arguments: str | None = None,
+    ) -> None:
+        self.index = index
+        self.id = call_id
+        self.type = "function" if call_id else None
+        self.function = SimpleNamespace(name=name, arguments=arguments)
+
+
+class TestToolChoiceNoneOnCapReached:
+    """Regression for the prod bug where broad queries returned empty
+    responses after hitting the tool-call cap.
+
+    Root cause (verified via prod diagnostic logs): when tool_calls_made
+    reaches max_tool_calls, the original code stripped `tools` from the
+    next request. Anthropic via OpenRouter then saw conversation history
+    full of tool_use/tool_result blocks but no declared tools, and
+    returned finish_reason=stop with zero content tokens. Fix: keep
+    tools declared but set tool_choice=\"none\" to forbid further tool
+    calls while still giving the model a valid tool context — it then
+    composes a final answer from the retrieved chunks it already has.
+    """
+
+    async def test_tools_still_declared_on_cap_reached_round(self) -> None:
+        from backend.llm.openrouter import stream_chat
+
+        # Round 1: model makes a tool call (hitting cap of 1).
+        # Round 2 (final): model must compose answer using tool_choice=none.
+        round1 = _FakeStream(
+            [
+                _FakeDeltaChunk(
+                    tool_calls=[_FakeToolCallDelta(0, call_id="c1", name="search_videos")]
+                ),
+                _FakeDeltaChunk(tool_calls=[_FakeToolCallDelta(0, arguments='{"query":"x"}')]),
+                _FakeDeltaChunk(finish_reason="tool_calls"),
+            ]
+        )
+        round2 = _FakeStream(
+            [
+                _FakeDeltaChunk(content="Final answer"),
+                _FakeDeltaChunk(finish_reason="stop"),
+            ]
+        )
+        create_mock = AsyncMock(side_effect=[round1, round2])
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+        )
+
+        async def exec_tool(name: str, raw_args: str) -> str:
+            return "tool result payload"
+
+        with (
+            patch("backend.llm.openrouter._get_async_client", return_value=fake_client),
+            patch(
+                "backend.llm.openrouter.build_system_prompt",
+                new=AsyncMock(return_value=[{"type": "text", "text": "sys"}]),
+            ),
+        ):
+            async for _ in stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "search_videos"}}],
+                tool_executor=exec_tool,
+                max_tool_calls=1,
+            ):
+                pass
+
+        assert create_mock.call_count == 2
+        # Final-round kwargs must (a) still carry `tools`, (b) set
+        # tool_choice="none" to forbid further calls. Stripping tools was
+        # the original bug.
+        _, final_kwargs = create_mock.call_args_list[1]
+        assert "tools" in final_kwargs, (
+            "`tools` must remain declared on the cap-reached final round; "
+            "Anthropic returns empty content when tool history exists but "
+            "no tools are declared"
+        )
+        assert final_kwargs.get("tool_choice") == "none", (
+            "tool_choice must be 'none' on the cap-reached round so the "
+            f"model composes an answer; got {final_kwargs.get('tool_choice')!r}"
+        )
+
+    async def test_no_tool_choice_on_pre_cap_rounds(self) -> None:
+        """Rounds below the cap must not set tool_choice — default
+        'auto' must be used so the model can decide whether to call tools
+        or answer directly."""
+        stream = _FakeStream([_FakeDeltaChunk(content="ok", finish_reason="stop")])
+        create_mock = AsyncMock(return_value=stream)
+
+        await _run_stream_chat(create_mock)
+
+        _, kwargs = create_mock.call_args_list[0]
+        assert "tool_choice" not in kwargs, (
+            f"pre-cap round must not set tool_choice; got {kwargs.get('tool_choice')!r}"
+        )
+
+
 class TestEmptyFinalContentWarning:
     async def test_warning_logged_when_final_round_emits_zero_content(self, caplog) -> None:
         """The silent-empty-response prod bug must leave a fingerprint in


### PR DESCRIPTION
## Why

Follow-up to #165. The diagnostic logging from that PR reproduced the bug in prod, but max_tokens turned out not to be the root cause.

Prod log from re-running \"How does Cole recommend building AI agents?\" after #165 deployed:

\`\`\`
round=1 finish_reason=tool_calls  content_deltas=0  tool_calls_pending=2  tool_calls_made=0
round=2 finish_reason=tool_calls  content_deltas=0  tool_calls_pending=2  tool_calls_made=2
round=3 finish_reason=tool_calls  content_deltas=0  tool_calls_pending=2  tool_calls_made=4
round=4 finish_reason=stop        content_deltas=0  tool_calls_pending=0  tool_calls_made=6
WARNING stream_chat final round emitted zero content tokens
\`\`\`

Sonnet makes parallel tool calls (2 per round), so broad queries hit `LLM_TOOLS_MAX_PER_TURN=6` in exactly 3 rounds. Round 4 was the intended compose-the-answer round — but the old code stripped `tools` from the request when `tool_calls_made >= max_tool_calls`. Anthropic via OpenRouter then sees conversation history full of tool_use/tool_result blocks but no declared tools, and silently returns `finish_reason=stop` with zero content tokens.

## Fix

Keep `tools` declared on the cap-reached round and set `tool_choice=\"none\"` instead. That explicitly tells the model tools exist but may not be called, so it composes a grounded answer from the tool results already in context — which is the intended behavior of that round.

The prior concern (infinite tool loop if `tool_choice=\"auto\"` stayed) is addressed: `tool_choice=\"none\"` makes tool use impossible for that round.

## Test plan

- [x] \`uv run pytest tests\` — 303 passed, 61 skipped
- [x] \`uv run ruff check .\` / format — clean
- [x] \`uv run mypy .\` — no issues
- [x] New regression tests:
  - \`test_tools_still_declared_on_cap_reached_round\` — final-round kwargs carry both \`tools\` and \`tool_choice=\"none\"\`
  - \`test_no_tool_choice_on_pre_cap_rounds\` — pre-cap rounds leave tool_choice unset (default auto)
- [ ] Post-merge: re-run \"How does Cole recommend building AI agents?\" via curl, expect content_deltas > 0 on round 4 and a real user-visible answer

## Risk

Low. \`tool_choice=\"none\"\` is a standard OpenAI-compat parameter supported by Anthropic via OpenRouter. Only affects the cap-reached round; pre-cap rounds are unchanged.