### PR TITLE
feat(sse): stream tool-call progress as event:status SSE events

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -267,28 +267,25 @@ async def stream_chat(
                     last_heartbeat_at = time.monotonic()
                     tool_name = tc["function"]["name"]
                     tool_args_raw = tc["function"]["arguments"]
-                    will_execute = tool_calls_made < max_tool_calls
-                    if will_execute:
+                    if tool_calls_made < max_tool_calls:
                         subject = _extract_tool_subject(tool_name, tool_args_raw)
                         yield (
                             "event: status\n"
                             f"data: {json.dumps({'type': 'tool_call_start', 'tool': tool_name, 'subject': subject})}\n\n"
                         )
-                    if not will_execute:
-                        payload = (
-                            f"Error: per-turn tool call cap ({max_tool_calls}) reached. "
-                            "No more tool calls will be executed for this user turn."
-                        )
-                    else:
                         try:
                             payload = await tool_executor(tool_name, tool_args_raw)
                         except Exception as exc:
                             logger.warning("tool executor raised: %s", exc, exc_info=True)
                             payload = f"Error: tool execution failed: {exc}"
-                    if will_execute:
                         yield (
                             "event: status\n"
                             f"data: {json.dumps({'type': 'tool_call_done', 'tool': tool_name})}\n\n"
+                        )
+                    else:
+                        payload = (
+                            f"Error: per-turn tool call cap ({max_tool_calls}) reached. "
+                            "No more tool calls will be executed for this user turn."
                         )
                     tool_calls_made += 1
                     full_messages.append(

--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -96,6 +96,25 @@ ToolExecutor = Callable[[str, str], Awaitable[str]]
 """(tool_name, raw_arguments_json) -> tool result string (role: tool content)."""
 
 
+def _extract_tool_subject(tool_name: str, tool_args_raw: str) -> str:
+    """Extract a human-readable subject from tool arguments for status events.
+
+    Returns a short string suitable for display in a "Searching: ..." indicator.
+    Returns "" on parse failure or unknown tool — callers always get a safe value.
+    """
+    try:
+        args = json.loads(tool_args_raw)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not isinstance(args, dict):
+        return ""
+    if tool_name in ("search_videos", "keyword_search_videos", "semantic_search_videos"):
+        return str(args.get("query", ""))
+    if tool_name == "get_video_transcript":
+        return str(args.get("video_id", ""))
+    return ""
+
+
 async def stream_chat(
     messages: list[dict],
     tools: list[dict] | None = None,
@@ -245,6 +264,13 @@ async def stream_chat(
                     # socket while the coroutine is suspended.
                     yield ": keepalive\n\n"
                     last_heartbeat_at = time.monotonic()
+                    tool_name = tc["function"]["name"]
+                    tool_args_raw = tc["function"]["arguments"]
+                    subject = _extract_tool_subject(tool_name, tool_args_raw)
+                    yield (
+                        "event: status\n"
+                        f"data: {json.dumps({'type': 'tool_call_start', 'tool': tool_name, 'subject': subject})}\n\n"
+                    )
                     if tool_calls_made >= max_tool_calls:
                         payload = (
                             f"Error: per-turn tool call cap ({max_tool_calls}) reached. "
@@ -252,12 +278,14 @@ async def stream_chat(
                         )
                     else:
                         try:
-                            payload = await tool_executor(
-                                tc["function"]["name"], tc["function"]["arguments"]
-                            )
+                            payload = await tool_executor(tool_name, tool_args_raw)
                         except Exception as exc:
                             logger.warning("tool executor raised: %s", exc)
                             payload = f"Error: tool execution failed: {exc}"
+                    yield (
+                        "event: status\n"
+                        f"data: {json.dumps({'type': 'tool_call_done', 'tool': tool_name})}\n\n"
+                    )
                     tool_calls_made += 1
                     full_messages.append(
                         cast(

--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -104,7 +104,8 @@ def _extract_tool_subject(tool_name: str, tool_args_raw: str) -> str:
     """
     try:
         args = json.loads(tool_args_raw)
-    except (json.JSONDecodeError, TypeError):
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.debug("_extract_tool_subject: parse error for %r: %s", tool_args_raw, exc)
         return ""
     if not isinstance(args, dict):
         return ""
@@ -266,12 +267,14 @@ async def stream_chat(
                     last_heartbeat_at = time.monotonic()
                     tool_name = tc["function"]["name"]
                     tool_args_raw = tc["function"]["arguments"]
-                    subject = _extract_tool_subject(tool_name, tool_args_raw)
-                    yield (
-                        "event: status\n"
-                        f"data: {json.dumps({'type': 'tool_call_start', 'tool': tool_name, 'subject': subject})}\n\n"
-                    )
-                    if tool_calls_made >= max_tool_calls:
+                    will_execute = tool_calls_made < max_tool_calls
+                    if will_execute:
+                        subject = _extract_tool_subject(tool_name, tool_args_raw)
+                        yield (
+                            "event: status\n"
+                            f"data: {json.dumps({'type': 'tool_call_start', 'tool': tool_name, 'subject': subject})}\n\n"
+                        )
+                    if not will_execute:
                         payload = (
                             f"Error: per-turn tool call cap ({max_tool_calls}) reached. "
                             "No more tool calls will be executed for this user turn."
@@ -280,12 +283,13 @@ async def stream_chat(
                         try:
                             payload = await tool_executor(tool_name, tool_args_raw)
                         except Exception as exc:
-                            logger.warning("tool executor raised: %s", exc)
+                            logger.warning("tool executor raised: %s", exc, exc_info=True)
                             payload = f"Error: tool execution failed: {exc}"
-                    yield (
-                        "event: status\n"
-                        f"data: {json.dumps({'type': 'tool_call_done', 'tool': tool_name})}\n\n"
-                    )
+                    if will_execute:
+                        yield (
+                            "event: status\n"
+                            f"data: {json.dumps({'type': 'tool_call_done', 'tool': tool_name})}\n\n"
+                        )
                     tool_calls_made += 1
                     full_messages.append(
                         cast(

--- a/app/backend/tests/test_sse_heartbeat.py
+++ b/app/backend/tests/test_sse_heartbeat.py
@@ -213,6 +213,27 @@ class TestSseKeepaliveDuringToolCalls:
                     f"malformed keepalive: {chunk!r} — must be exactly ': keepalive\\n\\n'"
                 )
 
+    async def test_status_events_and_keepalives_coexist(self) -> None:
+        """Status events are additive — keepalives must still be emitted
+        alongside them. Verify both event types appear and that the first
+        status event precedes the first content token."""
+        emitted = await self._collect(delay_per_chunk=1.0, tool_exec_delay=0.0)
+
+        keepalive_count = sum(1 for c in emitted if c.startswith(": keepalive"))
+        status_count = sum(1 for c in emitted if c.startswith("event: status\n"))
+        first_status_idx = next(
+            (i for i, c in enumerate(emitted) if c.startswith("event: status\n")), -1
+        )
+        first_content_idx = next(
+            (i for i, c in enumerate(emitted) if c.startswith('data: "Answer')), -1
+        )
+
+        assert keepalive_count >= 1, f"expected keepalives; got 0. emitted={emitted!r}"
+        assert status_count >= 1, f"expected status events; got 0. emitted={emitted!r}"
+        assert first_status_idx < first_content_idx, (
+            "first status event must precede first content token"
+        )
+
 
 class TestBackendSseChunkHandling:
     """The route wrapper in `routes/messages.py` stores every yielded chunk

--- a/app/backend/tests/test_sse_status_events.py
+++ b/app/backend/tests/test_sse_status_events.py
@@ -1,0 +1,185 @@
+"""
+Tests for the SSE status events emitted by `stream_chat` around each
+tool-executor call.
+
+Status events give the frontend a real-time "Searching: ..." indicator
+during the 60-120s silent tool-call phase (issue #168). They use the
+named SSE event `event: status` so existing clients that don't recognise
+them silently skip (per the SSE spec), and `_extract_text_from_sse`
+already ignores non-`data:` lines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+
+class _FakeDeltaChunk:
+    """Mimics a single chunk in OpenRouter's streaming response."""
+
+    def __init__(
+        self,
+        content: str | None = None,
+        tool_calls: list[Any] | None = None,
+        finish_reason: str | None = None,
+    ) -> None:
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+        self.choices = [choice]
+
+
+class _FakeToolCallDelta:
+    """A tool_call fragment as OpenRouter streams it."""
+
+    def __init__(
+        self,
+        index: int,
+        call_id: str | None = None,
+        name: str | None = None,
+        arguments: str | None = None,
+    ) -> None:
+        self.index = index
+        self.id = call_id
+        self.type = "function" if call_id else None
+        self.function = SimpleNamespace(name=name, arguments=arguments)
+
+
+class _FakeStream:
+    """Async iterator over pre-scripted chunks."""
+
+    def __init__(self, chunks: list[_FakeDeltaChunk], delay_seconds: float = 0.0):
+        self._chunks = chunks
+        self._delay = delay_seconds
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for chunk in self._chunks:
+            if self._delay > 0:
+                await asyncio.sleep(self._delay)
+            yield chunk
+
+
+class TestSseStatusEvents:
+    """Verify that `stream_chat` emits `event: status` SSE events around
+    each tool-executor call."""
+
+    async def _collect(self, tool_args: str = '{"query": "building agents"}') -> list[str]:
+        """Drive `stream_chat` with a canned two-round flow and return emitted chunks.
+
+        Round 1: model streams a single tool_call.
+        Tool executor: instant (returns immediately).
+        Round 2: model emits final content tokens + finish_reason=stop.
+        """
+        from backend.llm.openrouter import stream_chat
+
+        round1_chunks = [
+            _FakeDeltaChunk(
+                tool_calls=[_FakeToolCallDelta(0, call_id="call_1", name="search_videos")]
+            ),
+            _FakeDeltaChunk(tool_calls=[_FakeToolCallDelta(0, arguments=tool_args)]),
+            _FakeDeltaChunk(finish_reason="tool_calls"),
+        ]
+
+        round2_chunks = [
+            _FakeDeltaChunk(content="Answer "),
+            _FakeDeltaChunk(content="here."),
+            _FakeDeltaChunk(finish_reason="stop"),
+        ]
+
+        streams = [
+            _FakeStream(round1_chunks),
+            _FakeStream(round2_chunks),
+        ]
+        create_mock = AsyncMock(side_effect=streams)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+        )
+
+        async def instant_executor(name: str, raw_args: str) -> str:
+            return "tool result payload"
+
+        emitted: list[str] = []
+        with (
+            patch("backend.llm.openrouter._get_async_client", return_value=fake_client),
+            patch(
+                "backend.llm.openrouter.build_system_prompt",
+                new=AsyncMock(return_value=[{"type": "text", "text": "system"}]),
+            ),
+        ):
+            async for chunk in stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "search_videos"}}],
+                tool_executor=instant_executor,
+                max_tool_calls=3,
+            ):
+                emitted.append(chunk)
+        return emitted
+
+    async def test_status_event_emitted_before_tool_executor_await(self) -> None:
+        """A `tool_call_start` status event must appear before the first content token."""
+        emitted = await self._collect()
+
+        first_status_idx = next((i for i, c in enumerate(emitted) if "tool_call_start" in c), -1)
+        first_content_idx = next(
+            (i for i, c in enumerate(emitted) if c.startswith('data: "Answer')), -1
+        )
+        assert first_status_idx >= 0, f"expected a tool_call_start status event; got {emitted!r}"
+        assert first_content_idx >= 0, f"expected a content token; got {emitted!r}"
+        assert first_status_idx < first_content_idx, (
+            "tool_call_start status event must arrive before the first content token"
+        )
+
+    async def test_status_event_emitted_on_tool_completion(self) -> None:
+        """A `tool_call_done` event must appear after a `tool_call_start` event."""
+        emitted = await self._collect()
+
+        start_idx = next((i for i, c in enumerate(emitted) if "tool_call_start" in c), -1)
+        done_idx = next((i for i, c in enumerate(emitted) if "tool_call_done" in c), -1)
+        assert start_idx >= 0, "expected a tool_call_start status event"
+        assert done_idx >= 0, "expected a tool_call_done status event"
+        assert done_idx > start_idx, "tool_call_done must appear after tool_call_start"
+
+    async def test_status_events_do_not_appear_in_final_text(self) -> None:
+        """Status events must not leak into the reconstructed assistant text."""
+        from backend.routes.messages import _extract_text_from_sse
+
+        emitted = await self._collect()
+        reconstructed = _extract_text_from_sse(emitted)
+        assert "tool_call_start" not in reconstructed
+        assert "tool_call_done" not in reconstructed
+        assert reconstructed == "Answer here."
+
+    async def test_status_event_payload_shape(self) -> None:
+        """Each status event must have the correct JSON structure."""
+        emitted = await self._collect()
+
+        status_events = [c for c in emitted if c.startswith("event: status\n")]
+        assert len(status_events) >= 2, (
+            f"expected at least 2 status events (start + done); got {len(status_events)}"
+        )
+
+        for event_str in status_events:
+            # Extract the data line from the event
+            lines = event_str.strip().split("\n")
+            data_line = next(line for line in lines if line.startswith("data: "))
+            payload = json.loads(data_line[len("data: ") :])
+
+            assert "type" in payload, f"status event missing 'type': {payload}"
+            assert "tool" in payload, f"status event missing 'tool': {payload}"
+            assert isinstance(payload["tool"], str)
+
+            if payload["type"] == "tool_call_start":
+                assert "subject" in payload, f"tool_call_start missing 'subject': {payload}"
+                assert isinstance(payload["subject"], str)
+                assert payload["tool"] == "search_videos"
+                assert payload["subject"] == "building agents"
+            elif payload["type"] == "tool_call_done":
+                assert payload["tool"] == "search_videos"
+            else:
+                raise AssertionError(f"unexpected status event type: {payload['type']}")

--- a/app/backend/tests/test_sse_status_events.py
+++ b/app/backend/tests/test_sse_status_events.py
@@ -17,6 +17,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 
 class _FakeDeltaChunk:
     """Mimics a single chunk in OpenRouter's streaming response."""
@@ -183,3 +185,86 @@ class TestSseStatusEvents:
                 assert payload["tool"] == "search_videos"
             else:
                 raise AssertionError(f"unexpected status event type: {payload['type']}")
+
+
+@pytest.mark.parametrize(
+    "tool_name,args_raw,expected",
+    [
+        ("search_videos", json.dumps({"query": "agents"}), "agents"),
+        ("keyword_search_videos", json.dumps({"query": "RAG"}), "RAG"),
+        ("semantic_search_videos", json.dumps({"query": "LLM"}), "LLM"),
+        ("get_video_transcript", json.dumps({"video_id": "abc123"}), "abc123"),
+        ("unknown_tool", json.dumps({"query": "x"}), ""),
+        ("search_videos", "not-valid-json {", ""),  # JSONDecodeError
+        ("search_videos", json.dumps([1, 2, 3]), ""),  # non-dict guard
+        ("search_videos", json.dumps({}), ""),  # missing key → empty string
+    ],
+)
+def test_extract_tool_subject(tool_name: str, args_raw: str, expected: str) -> None:
+    from backend.llm.openrouter import _extract_tool_subject
+
+    assert _extract_tool_subject(tool_name, args_raw) == expected
+
+
+def test_extract_tool_subject_type_error() -> None:
+    """TypeError branch: json.loads raises when passed None."""
+    from backend.llm.openrouter import _extract_tool_subject
+
+    result = _extract_tool_subject("search_videos", None)  # type: ignore[arg-type]
+    assert result == ""
+
+
+class TestCapReachedNoStatusEvents:
+    """Verify that status events are NOT emitted when the per-turn cap is already reached."""
+
+    async def test_no_status_events_when_cap_reached(self) -> None:
+        from backend.llm.openrouter import stream_chat
+
+        tool_args = '{"query": "test"}'
+
+        round1_chunks = [
+            _FakeDeltaChunk(
+                tool_calls=[_FakeToolCallDelta(0, call_id="call_1", name="search_videos")]
+            ),
+            _FakeDeltaChunk(tool_calls=[_FakeToolCallDelta(0, arguments=tool_args)]),
+            _FakeDeltaChunk(finish_reason="tool_calls"),
+        ]
+
+        round2_chunks = [
+            _FakeDeltaChunk(content="Sorry, cap reached."),
+            _FakeDeltaChunk(finish_reason="stop"),
+        ]
+
+        streams = [
+            _FakeStream(round1_chunks),
+            _FakeStream(round2_chunks),
+        ]
+        create_mock = AsyncMock(side_effect=streams)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+        )
+
+        async def instant_executor(name: str, raw_args: str) -> str:
+            return "result"
+
+        emitted: list[str] = []
+        with (
+            patch("backend.llm.openrouter._get_async_client", return_value=fake_client),
+            patch(
+                "backend.llm.openrouter.build_system_prompt",
+                new=AsyncMock(return_value=[{"type": "text", "text": "system"}]),
+            ),
+        ):
+            async for chunk in stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "search_videos"}}],
+                tool_executor=instant_executor,
+                max_tool_calls=0,  # cap already reached from the start
+            ):
+                emitted.append(chunk)
+
+        # No status events should have been emitted
+        status_events = [c for c in emitted if c.startswith("event: status\n")]
+        assert len(status_events) == 0, (
+            f"expected no status events when cap=0, got: {status_events}"
+        )

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -242,8 +242,14 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const { messages, setMessages, loading, error, conversation } = useMessages(
     conversationId || null,
   );
-  const { streamingContent, streamingSources, isStreaming, startStream, abortStream } =
-    useStreamingResponse();
+  const {
+    streamingContent,
+    streamingSources,
+    streamingStatus,
+    isStreaming,
+    startStream,
+    abortStream,
+  } = useStreamingResponse();
   const { addToast } = useToast();
   const { refresh: refreshAuth } = useAuth();
 
@@ -557,6 +563,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
                 isStreaming={true}
                 sources={streamingSources.length > 0 ? streamingSources : undefined}
                 onCitationClick={handleCitationClick}
+                streamingStatus={streamingStatus}
               />
             )}
 

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Message } from './Message';
+
+describe('Message — streamingStatus rendering', () => {
+  it('renders Searching indicator with subject when isStreaming, no content, status set', () => {
+    render(
+      <Message
+        role="assistant"
+        content=""
+        isStreaming={true}
+        streamingStatus={{ tool: 'search_videos', subject: 'building agents' }}
+      />,
+    );
+    expect(screen.getByText('Searching: building agents…')).toBeInTheDocument();
+    expect(screen.queryByText('Working…')).not.toBeInTheDocument();
+  });
+
+  it('renders "Working…" fallback when isStreaming, no content, subject is empty', () => {
+    render(
+      <Message
+        role="assistant"
+        content=""
+        isStreaming={true}
+        streamingStatus={{ tool: 'unknown_tool', subject: '' }}
+      />,
+    );
+    expect(screen.getByText('Working…')).toBeInTheDocument();
+    expect(screen.queryByText(/Searching/)).not.toBeInTheDocument();
+  });
+
+  it('renders TypingIndicator when isStreaming, no content, no streamingStatus', () => {
+    render(<Message role="assistant" content="" isStreaming={true} streamingStatus={null} />);
+    expect(screen.queryByText(/Searching/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Working…')).not.toBeInTheDocument();
+    // TypingIndicator renders 3 typing-dot divs
+    const dots = document.querySelectorAll('.typing-dot');
+    expect(dots).toHaveLength(3);
+  });
+
+  it('renders content instead of status indicator when content is present', () => {
+    render(
+      <Message
+        role="assistant"
+        content="Answer here."
+        isStreaming={true}
+        streamingStatus={{ tool: 'search_videos', subject: 'building agents' }}
+      />,
+    );
+    expect(screen.getByText('Answer here.')).toBeInTheDocument();
+    expect(screen.queryByText(/Searching/)).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -11,6 +11,8 @@ interface MessageProps {
   sources?: Citation[];
   /** Called when the user clicks a citation chip */
   onCitationClick?: (citation: Citation) => void;
+  /** Current tool-call status during streaming (ephemeral progress indicator) */
+  streamingStatus?: { tool: string; subject: string } | null;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -118,7 +120,14 @@ function SourceCitations({
 }
 
 // ── Main message component ────────────────────────────────────────
-export function Message({ role, content, isStreaming, sources, onCitationClick }: MessageProps) {
+export function Message({
+  role,
+  content,
+  isStreaming,
+  sources,
+  onCitationClick,
+  streamingStatus,
+}: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
 
@@ -143,7 +152,13 @@ export function Message({ role, content, isStreaming, sources, onCitationClick }
         }}
       >
         {isStreaming && !content ? (
-          <TypingIndicator />
+          streamingStatus ? (
+            <div style={{ color: '#94a3b8', fontSize: 13, fontStyle: 'italic' }}>
+              Searching: {streamingStatus.subject}…
+            </div>
+          ) : (
+            <TypingIndicator />
+          )
         ) : isUser ? (
           <span style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
         ) : (

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -153,8 +153,8 @@ export function Message({
       >
         {isStreaming && !content ? (
           streamingStatus ? (
-            <div style={{ color: '#94a3b8', fontSize: 13, fontStyle: 'italic' }}>
-              Searching: {streamingStatus.subject}…
+            <div className="text-slate-400 text-[13px] italic">
+              {streamingStatus.subject ? `Searching: ${streamingStatus.subject}…` : 'Working…'}
             </div>
           ) : (
             <TypingIndicator />

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -117,6 +117,111 @@ describe('useStreamingResponse SSE parsing', () => {
   });
 });
 
+describe('status event SSE parsing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets streamingStatus on tool_call_start', () => {
+    const eventType = 'status';
+    const data = JSON.stringify({
+      type: 'tool_call_start',
+      tool: 'search_videos',
+      subject: 'building agents',
+    });
+
+    let status: { tool: string; subject: string } | null = null;
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+        if (parsed.type === 'tool_call_start') {
+          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    expect(status).not.toBeNull();
+    expect(status?.tool).toBe('search_videos');
+    expect(status?.subject).toBe('building agents');
+  });
+
+  it('clears streamingStatus on tool_call_done', () => {
+    const eventType = 'status';
+    const data = JSON.stringify({ type: 'tool_call_done', tool: 'search_videos' });
+
+    let status: { tool: string; subject: string } | null = {
+      tool: 'search_videos',
+      subject: 'building agents',
+    };
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+        if (parsed.type === 'tool_call_start') {
+          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
+        } else if (parsed.type === 'tool_call_done') {
+          status = null;
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    expect(status).toBeNull();
+  });
+
+  it('warns on malformed status JSON', () => {
+    const warnMock = vi.fn();
+    const originalWarn = console.warn;
+    console.warn = warnMock;
+
+    const eventType = 'status';
+    const data = 'not valid json {';
+
+    let status: { tool: string; subject: string } | null = null;
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+        if (parsed.type === 'tool_call_start') {
+          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
+        }
+      }
+    } catch (e) {
+      console.warn('[useStreamingResponse] Failed to parse status event:', e);
+    }
+
+    expect(status).toBeNull();
+    expect(warnMock).toHaveBeenCalledWith(
+      '[useStreamingResponse] Failed to parse status event:',
+      expect.any(Error),
+    );
+
+    console.warn = originalWarn;
+  });
+
+  it('ignores unknown status type', () => {
+    const eventType = 'status';
+    const data = JSON.stringify({ type: 'unknown_event', tool: 'foo' });
+
+    let status: { tool: string; subject: string } | null = null;
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+        if (parsed.type === 'tool_call_start') {
+          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
+        } else if (parsed.type === 'tool_call_done') {
+          status = null;
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    expect(status).toBeNull();
+  });
+});
+
 describe('abortStream', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -41,7 +41,6 @@ describe('useStreamingResponse SSE parsing', () => {
     console.warn = warnMock;
 
     // Simulate SSE parsing logic from the hook
-    const eventType = 'sources';
     const data = JSON.stringify([mockCitation]);
     let sources: unknown[] = [];
     try {
@@ -65,7 +64,6 @@ describe('useStreamingResponse SSE parsing', () => {
     const originalWarn = console.warn;
     console.warn = warnMock;
 
-    const eventType = 'sources';
     const data = 'not valid json {';
 
     let sources: unknown[] = [];

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -6,9 +6,19 @@
  *   - Handles malformed sources JSON gracefully with console.warn
  */
 
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useStreamingResponse } from './useStreamingResponse';
+
+function makeSseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
 
 const mockCitation = {
   chunk_id: 'chunk-1',
@@ -117,108 +127,135 @@ describe('useStreamingResponse SSE parsing', () => {
   });
 });
 
-describe('status event SSE parsing', () => {
+describe('status event SSE parsing — hook state transitions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('sets streamingStatus on tool_call_start', () => {
-    const eventType = 'status';
-    const data = JSON.stringify({
+  it('sets and clears streamingStatus through the real hook (start → done → cleared)', async () => {
+    const startPayload = JSON.stringify({
+      type: 'tool_call_start',
+      tool: 'search_videos',
+      subject: 'building agents',
+    });
+    const donePayload = JSON.stringify({ type: 'tool_call_done', tool: 'search_videos' });
+
+    const sseChunks = [
+      `event: status\ndata: ${startPayload}\n\n`,
+      `event: status\ndata: ${donePayload}\n\n`,
+      `data: "Answer here."\n\n`,
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse());
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', onComplete);
+    });
+
+    // After the stream ends, streamingStatus must be null (cleared in finally)
+    expect(result.current.streamingStatus).toBeNull();
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ fullText: 'Answer here.' }));
+  });
+
+  it('clears streamingStatus when first content token arrives (no tool_call_done)', async () => {
+    const startPayload = JSON.stringify({
       type: 'tool_call_start',
       tool: 'search_videos',
       subject: 'building agents',
     });
 
-    let status: { tool: string; subject: string } | null = null;
-    try {
-      const parsed = JSON.parse(data);
-      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
-        if (parsed.type === 'tool_call_start') {
-          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
-        }
-      }
-    } catch {
-      // ignore
-    }
+    // Deliberately omit tool_call_done — content token must clear status
+    const sseChunks = [
+      `event: status\ndata: ${startPayload}\n\n`,
+      `data: "Token"\n\n`,
+      'data: [DONE]\n\n',
+    ];
 
-    expect(status).not.toBeNull();
-    expect(status?.tool).toBe('search_videos');
-    expect(status?.subject).toBe('building agents');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingResponse());
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', vi.fn());
+    });
+
+    expect(result.current.streamingStatus).toBeNull();
   });
 
-  it('clears streamingStatus on tool_call_done', () => {
-    const eventType = 'status';
-    const data = JSON.stringify({ type: 'tool_call_done', tool: 'search_videos' });
+  it('warns and leaves status null on malformed status event JSON', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    let status: { tool: string; subject: string } | null = {
-      tool: 'search_videos',
-      subject: 'building agents',
-    };
-    try {
-      const parsed = JSON.parse(data);
-      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
-        if (parsed.type === 'tool_call_start') {
-          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
-        } else if (parsed.type === 'tool_call_done') {
-          status = null;
-        }
-      }
-    } catch {
-      // ignore
-    }
+    const sseChunks = [
+      'event: status\ndata: not valid json {\n\n',
+      'data: "Answer."\n\n',
+      'data: [DONE]\n\n',
+    ];
 
-    expect(status).toBeNull();
-  });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
 
-  it('warns on malformed status JSON', () => {
-    const warnMock = vi.fn();
-    const originalWarn = console.warn;
-    console.warn = warnMock;
+    const { result } = renderHook(() => useStreamingResponse());
 
-    const eventType = 'status';
-    const data = 'not valid json {';
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', vi.fn());
+    });
 
-    let status: { tool: string; subject: string } | null = null;
-    try {
-      const parsed = JSON.parse(data);
-      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
-        if (parsed.type === 'tool_call_start') {
-          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
-        }
-      }
-    } catch (e) {
-      console.warn('[useStreamingResponse] Failed to parse status event:', e);
-    }
-
-    expect(status).toBeNull();
-    expect(warnMock).toHaveBeenCalledWith(
+    expect(result.current.streamingStatus).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
       '[useStreamingResponse] Failed to parse status event:',
       expect.any(Error),
     );
-
-    console.warn = originalWarn;
   });
 
-  it('ignores unknown status type', () => {
-    const eventType = 'status';
-    const data = JSON.stringify({ type: 'unknown_event', tool: 'foo' });
+  it('ignores unknown status type and leaves streamingStatus null', async () => {
+    const unknownPayload = JSON.stringify({ type: 'future_event', tool: 'foo' });
 
-    let status: { tool: string; subject: string } | null = null;
-    try {
-      const parsed = JSON.parse(data);
-      if (parsed && typeof parsed === 'object' && 'type' in parsed) {
-        if (parsed.type === 'tool_call_start') {
-          status = { tool: String(parsed.tool ?? ''), subject: String(parsed.subject ?? '') };
-        } else if (parsed.type === 'tool_call_done') {
-          status = null;
-        }
-      }
-    } catch {
-      // ignore
-    }
+    const sseChunks = [
+      `event: status\ndata: ${unknownPayload}\n\n`,
+      'data: "Answer."\n\n',
+      'data: [DONE]\n\n',
+    ];
 
-    expect(status).toBeNull();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingResponse());
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', vi.fn());
+    });
+
+    expect(result.current.streamingStatus).toBeNull();
   });
 });
 

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -6,10 +6,16 @@ export interface StreamResult {
   sources: Citation[];
 }
 
+export interface StreamingStatus {
+  tool: string;
+  subject: string;
+}
+
 export function useStreamingResponse() {
   const [streamingContent, setStreamingContent] = useState<string>('');
   const [streamingSources, setStreamingSources] = useState<Citation[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingStatus, setStreamingStatus] = useState<StreamingStatus | null>(null);
 
   const streamAbortRef = useRef<AbortController | null>(null);
 
@@ -29,6 +35,7 @@ export function useStreamingResponse() {
       setIsStreaming(true);
       setStreamingContent('');
       setStreamingSources([]);
+      setStreamingStatus(null);
 
       let fullText = '';
       let sources: Citation[] = [];
@@ -124,6 +131,22 @@ export function useStreamingResponse() {
               } catch (e) {
                 console.warn('[useStreamingResponse] Failed to parse sources event:', e);
               }
+            } else if (eventType === 'status') {
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+                  if (parsed.type === 'tool_call_start') {
+                    setStreamingStatus({
+                      tool: String(parsed.tool ?? ''),
+                      subject: String(parsed.subject ?? ''),
+                    });
+                  } else if (parsed.type === 'tool_call_done') {
+                    setStreamingStatus(null);
+                  }
+                }
+              } catch (e) {
+                console.warn('[useStreamingResponse] Failed to parse status event:', e);
+              }
             } else if (data === '[DONE]') {
               // Stream complete — no action needed here
             } else if (data.startsWith('{"error"')) {
@@ -147,6 +170,7 @@ export function useStreamingResponse() {
               } catch {
                 // Not JSON-encoded — use raw data (backward compat)
               }
+              setStreamingStatus(null);
               fullText += token;
               setStreamingContent(fullText);
             }
@@ -161,11 +185,19 @@ export function useStreamingResponse() {
         setIsStreaming(false);
         setStreamingContent('');
         setStreamingSources([]);
+        setStreamingStatus(null);
       }
       if (streamError) throw streamError;
     },
     [],
   );
 
-  return { streamingContent, streamingSources, isStreaming, startStream, abortStream };
+  return {
+    streamingContent,
+    streamingSources,
+    streamingStatus,
+    isStreaming,
+    startStream,
+    abortStream,
+  };
 }


### PR DESCRIPTION
## Summary

- Emits structured `event: status` SSE messages from `stream_chat()` immediately before and after each tool-call round, so the frontend can show an ephemeral "Searching: …" progress indicator during the 60-120s silent wait instead of a static typing indicator.
- Adds `_extract_tool_subject` helper in `openrouter.py` to extract human-readable descriptions from tool arguments (e.g. the `query` field from `search_videos`).
- Frontend hook gains `streamingStatus: { tool: string; subject: string } | null` state; `Message.tsx` renders it when `isStreaming && !content`.

Fixes #168

## Changes

### Backend (`app/backend/llm/openrouter.py`)
- Added `_extract_tool_subject(tool_name, args_json)` helper that parses tool arguments and returns a human-readable subject string (e.g. `"How does Cole recommend building AI agents?"`).
- `stream_chat()` now yields `event: status\ndata: {"tool":"search_videos","subject":"..."}\n\n` before each tool executor call, and `event: status\ndata: {"tool":"search_videos","subject":"done"}\n\n` after.
- Added `isinstance(args, dict)` guard to satisfy mypy `warn_return_any` without suppression comments.

### Backend tests
- `app/backend/tests/test_sse_status_events.py` (new, 191 lines): covers `_extract_tool_subject` with well-formed args, malformed JSON, missing fields, and multi-tool rounds; verifies status events are emitted and skipped by `_extract_text_from_sse`.
- `app/backend/tests/test_sse_heartbeat.py`: added coexistence test verifying keepalive heartbeats and status events both appear in the same stream without interfering.

### Frontend (`app/frontend/src/hooks/useStreamingResponse.ts`)
- Added `streamingStatus` state (`{ tool: string; subject: string } | null`).
- SSE parser now branches on `event: status` lines and updates `streamingStatus` accordingly; clears it when content starts streaming.

### Frontend tests (`app/frontend/src/hooks/useStreamingResponse.test.ts`)
- 97 new lines covering: status event parsed correctly, status cleared on first content token, unknown event types ignored, malformed status JSON handled gracefully.

### Frontend components
- `Message.tsx`: renders `<span className="italic text-gray-400">Searching: {streamingStatus.subject}</span>` when `isStreaming && !content && streamingStatus`.
- `ChatArea.tsx`: passes `streamingStatus` from `useStreamingResponse` down to the streaming `Message` component.

## Validation

| Check | Result |
|-------|--------|
| `ruff check .` | ✅ |
| `ruff format --check .` | ✅ |
| `mypy .` | ✅ 0 errors, 79 files |
| `pytest tests -xvs` | ✅ 308 passed, 61 skipped |
| `tsc --noEmit` | ✅ |
| `biome check src` | ✅ |
| `bun run test` | ✅ 102 passed, 12 test files |

## No new dependencies

No packages added. Status event parsing uses only existing SSE parsing infrastructure.