### PR TITLE
feat: Stream tool-call progress as SSE status events during silent tool-round wait

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -96,6 +96,29 @@ ToolExecutor = Callable[[str, str], Awaitable[str]]
 """(tool_name, raw_arguments_json) -> tool result string (role: tool content)."""
 
 
+def _extract_tool_subject(tool_name: str, tool_args_raw: str) -> str:
+    """Extract a human-readable subject from tool arguments for status events.
+
+    For search tools, returns the query string.
+    For transcript tool, returns the video_id.
+    Returns '' for unknown tools.
+
+    Uses regex extraction rather than JSON parsing to handle the case where
+    model streaming causes argument fragments to be duplicated/accumulated,
+    resulting in invalid JSON that would fail json.loads().
+    """
+    import re
+
+    search_tools = {"search_videos", "keyword_search_videos", "semantic_search_videos"}
+    if tool_name in search_tools:
+        m = re.search(r'"query"\s*:\s*"([^"]*)"', tool_args_raw)
+        return m.group(1) if m else ""
+    if tool_name == "get_video_transcript":
+        m = re.search(r'"video_id"\s*:\s*"([^"]*)"', tool_args_raw)
+        return m.group(1) if m else ""
+    return ""
+
+
 async def stream_chat(
     messages: list[dict],
     tools: list[dict] | None = None,
@@ -239,12 +262,20 @@ async def stream_chat(
                     )
                 )
                 for tc in ordered:
+                    tool_name = tc["function"]["name"]
+                    tool_args_raw = tc["function"]["arguments"]
+                    subject = _extract_tool_subject(tool_name, tool_args_raw)
                     # Tool execution (embedding + DB queries) can take a few
                     # seconds per call. Emit a keepalive right before we
                     # await it so browsers/proxies don't idle-timeout the
                     # socket while the coroutine is suspended.
                     yield ": keepalive\n\n"
                     last_heartbeat_at = time.monotonic()
+                    # Signal tool-call start so frontend can show progress.
+                    yield (
+                        f"event: status\n"
+                        f"data: {json.dumps({'type': 'tool_call_start', 'tool': tool_name, 'subject': subject})}\n\n"
+                    )
                     if tool_calls_made >= max_tool_calls:
                         payload = (
                             f"Error: per-turn tool call cap ({max_tool_calls}) reached. "
@@ -252,13 +283,16 @@ async def stream_chat(
                         )
                     else:
                         try:
-                            payload = await tool_executor(
-                                tc["function"]["name"], tc["function"]["arguments"]
-                            )
+                            payload = await tool_executor(tool_name, tool_args_raw)
                         except Exception as exc:
                             logger.warning("tool executor raised: %s", exc)
                             payload = f"Error: tool execution failed: {exc}"
                     tool_calls_made += 1
+                    # Signal tool-call done so frontend can update/clear progress.
+                    yield (
+                        f"event: status\n"
+                        f"data: {json.dumps({'type': 'tool_call_done', 'tool': tool_name})}\n\n"
+                    )
                     full_messages.append(
                         cast(
                             ChatCompletionMessageParam,

--- a/app/backend/tests/test_sse_status_events.py
+++ b/app/backend/tests/test_sse_status_events.py
@@ -1,0 +1,310 @@
+"""
+Tests for SSE status events emitted by `stream_chat` during tool-call rounds.
+
+Issue: Users see a loading spinner with no progress signal during 60-120s
+tool-call rounds, leading them to assume the app is broken and bounce.
+
+Solution: Emit `event: status\ndata: {...}\n\n` before each tool_executor await
+(tool_call_start) and after each completion (tool_call_done). Frontend shows
+an ephemeral "🔍 Searching: query…" indicator while tool calls are in flight.
+
+These tests verify:
+1. tool_call_start event appears before tool execution result
+2. tool_call_done event appears after tool execution
+3. status events do NOT end up in `_extract_text_from_sse` output
+4. payload shape: type, tool keys present; subject present for search tools
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+
+class _FakeDeltaChunk:
+    """Mimics a single chunk in OpenRouter's streaming response."""
+
+    def __init__(
+        self,
+        content: str | None = None,
+        tool_calls: list[Any] | None = None,
+        finish_reason: str | None = None,
+    ) -> None:
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+        self.choices = [choice]
+
+
+class _FakeToolCallDelta:
+    """A tool_call fragment as OpenRouter streams it."""
+
+    def __init__(
+        self,
+        index: int,
+        call_id: str | None = None,
+        name: str | None = None,
+        arguments: str | None = None,
+    ) -> None:
+        self.index = index
+        self.id = call_id
+        self.type = "function" if call_id else None
+        self.function = SimpleNamespace(name=name, arguments=arguments)
+
+
+class _FakeStream:
+    """Async iterator over pre-scripted chunks."""
+
+    def __init__(self, chunks: list[_FakeDeltaChunk]):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class TestSseStatusEventsDuringToolCalls:
+    async def _collect(self, tool_exec_slow: bool = False):
+        """Drive `stream_chat` through one tool-call round and collect emitted SSE chunks."""
+        from backend.llm.openrouter import stream_chat
+
+        # Round 1: model streams a search_videos tool call.
+        round1_chunks = [
+            _FakeDeltaChunk(
+                tool_calls=[_FakeToolCallDelta(0, call_id="call_1", name="search_videos")]
+            ),
+        ]
+        for i in range(6):
+            round1_chunks.append(
+                _FakeDeltaChunk(tool_calls=[_FakeToolCallDelta(0, arguments='{"query": "Cole agent approach", "top_k": 5}')])
+            )
+        round1_chunks.append(_FakeDeltaChunk(finish_reason="tool_calls"))
+
+        # Round 2: final content + stop.
+        round2_chunks = [
+            _FakeDeltaChunk(content="Here's what I found: "),
+            _FakeDeltaChunk(content="the approach works."),
+            _FakeDeltaChunk(finish_reason="stop"),
+        ]
+
+        streams = [
+            _FakeStream(round1_chunks),
+            _FakeStream(round2_chunks),
+        ]
+        create_mock = AsyncMock(side_effect=streams)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+        )
+
+        async def tool_executor(name: str, raw_args: str) -> str:
+            if tool_exec_slow:
+                await asyncio.sleep(0.05)
+            # Return a realistic chunk list for a search result.
+            return (
+                '[{"chunk_id":"c1","video_id":"v1","video_title":"Cole on Agentic AI",'
+                '"start_seconds":42,"snippet":"Cole builds agents that plan and delegate"}]'
+            )
+
+        emitted: list[str] = []
+        with (
+            patch("backend.llm.openrouter._get_async_client", return_value=fake_client),
+            patch(
+                "backend.llm.openrouter.build_system_prompt",
+                new=AsyncMock(return_value=[{"type": "text", "text": "system"}]),
+            ),
+        ):
+            async for chunk in stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "search_videos"}}],
+                tool_executor=tool_executor,
+                max_tool_calls=3,
+            ):
+                emitted.append(chunk)
+        return emitted
+
+    async def test_tool_call_start_status_event_emitted_before_tool_execution(self) -> None:
+        """The backend must emit `event: status` with `tool_call_start` BEFORE
+        awaiting tool_executor — the frontend needs time to display the indicator
+        before the 60-120s wait begins."""
+        emitted = await self._collect(tool_exec_slow=False)
+
+        # Find the tool_call_start status event.
+        start_idx = next(
+            (
+                i
+                for i, c in enumerate(emitted)
+                if c.startswith("event: status\n") and 'tool_call_start' in c
+            ),
+            -1,
+        )
+        assert start_idx >= 0, f"expected tool_call_start status event; got {emitted!r}"
+
+        # The tool_call_done event (emitted after tool execution) must come AFTER
+        # tool_call_start in the SSE stream. This proves tool_call_start was emitted
+        # before tool_executor awaited.
+        done_idx = next(
+            (
+                i
+                for i, c in enumerate(emitted)
+                if c.startswith("event: status\n") and 'tool_call_done' in c
+            ),
+            -1,
+        )
+        assert done_idx >= 0, f"expected tool_call_done status event; got {emitted!r}"
+        assert start_idx < done_idx, (
+            f"tool_call_start (index {start_idx}) must appear BEFORE tool_call_done (index {done_idx})"
+        )
+
+    async def test_tool_call_done_status_event_emitted_after_tool_execution(self) -> None:
+        """After tool_executor completes, the backend must emit `event: status`
+        with `tool_call_done`. The presence of the event in the stream proves
+        tool execution completed and the done signal was sent."""
+        emitted = await self._collect(tool_exec_slow=False)
+
+        # Find the tool_call_done status event.
+        done_idx = next(
+            (
+                i
+                for i, c in enumerate(emitted)
+                if c.startswith("event: status\n") and 'tool_call_done' in c
+            ),
+            -1,
+        )
+        assert done_idx >= 0, f"expected tool_call_done status event; got {emitted!r}"
+
+        # The event must appear before any final round content tokens arrive.
+        first_content_idx = next(
+            (i for i, c in enumerate(emitted) if c.startswith('data: "')),
+            -1,
+        )
+        assert first_content_idx >= 0, f"expected final content token; got {emitted!r}"
+        assert done_idx < first_content_idx, (
+            f"tool_call_done (index {done_idx}) must appear before content (index {first_content_idx})"
+        )
+
+    async def test_status_events_do_not_appear_in_extracted_text(self) -> None:
+        """`_extract_text_from_sse` must skip status events since they use the
+        `event:` prefix, not `data:`. This test ensures status events never
+        leak into persisted assistant text."""
+        from backend.routes.messages import _extract_text_from_sse
+
+        chunks = [
+            ": keepalive\n\n",
+            "event: status\ndata: {\"type\": \"tool_call_start\", \"tool\": \"search_videos\", \"subject\": \"Cole agent approach\"}\n\n",
+            'data: "Hello"\n\n',
+            "event: status\ndata: {\"type\": \"tool_call_done\", \"tool\": \"search_videos\"}\n\n",
+            'data: " world"\n\n',
+            "data: [DONE]\n\n",
+        ]
+        text = _extract_text_from_sse(chunks)
+        # Status events are silently skipped (event: prefix != data: prefix).
+        assert text == "Hello world", (
+            f"status events leaked into extracted text: {text!r}"
+        )
+        # Confirm no 'tool_call_start/done' strings leak through.
+        assert "tool_call" not in text
+
+    async def test_status_event_payload_shape_for_search_tool(self) -> None:
+        """For search_videos, the status payload must include:
+        - type: 'tool_call_start' or 'tool_call_done'
+        - tool: 'search_videos'
+        - subject: the query string extracted from tool args"""
+        import json
+
+        emitted = await self._collect(tool_exec_slow=False)
+
+        # Collect all status event payloads.
+        status_payloads = []
+        for chunk in emitted:
+            if chunk.startswith("event: status\n"):
+                # Extract the data line.
+                for line in chunk.split("\n"):
+                    if line.startswith("data: "):
+                        payload = json.loads(line[6:])
+                        status_payloads.append(payload)
+                        break
+
+        assert len(status_payloads) == 2, f"expected 2 status events; got {len(status_payloads)}"
+
+        # First: tool_call_start with subject.
+        start_payload = status_payloads[0]
+        assert start_payload["type"] == "tool_call_start", f"expected tool_call_start; got {start_payload}"
+        assert start_payload["tool"] == "search_videos"
+        assert "subject" in start_payload, f"search tool must have subject; got {start_payload}"
+        assert "Cole agent" in start_payload["subject"], f"subject should contain query; got {start_payload}"
+
+        # Second: tool_call_done (no subject required).
+        done_payload = status_payloads[1]
+        assert done_payload["type"] == "tool_call_done"
+        assert done_payload["tool"] == "search_videos"
+
+    async def test_status_event_payload_shape_for_get_video_transcript(self) -> None:
+        """For get_video_transcript, subject should be the video_id."""
+        import json
+
+        from backend.llm.openrouter import stream_chat
+
+        # Single round: get_video_transcript tool call.
+        round1_chunks = [
+            _FakeDeltaChunk(
+                tool_calls=[_FakeToolCallDelta(0, call_id="call_1", name="get_video_transcript")]
+            ),
+        ]
+        for i in range(4):
+            round1_chunks.append(
+                _FakeDeltaChunk(
+                    tool_calls=[_FakeToolCallDelta(0, arguments='{"video_id": "dQw4w9WgXcQ"}')]
+                )
+            )
+        round1_chunks.append(_FakeDeltaChunk(finish_reason="tool_calls"))
+        round2_chunks = [
+            _FakeDeltaChunk(content="The video covers "),
+            _FakeDeltaChunk(content="important topics."),
+            _FakeDeltaChunk(finish_reason="stop"),
+        ]
+
+        streams = [_FakeStream(round1_chunks), _FakeStream(round2_chunks)]
+        create_mock = AsyncMock(side_effect=streams)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+        )
+
+        async def tool_executor(name: str, raw_args: str) -> str:
+            return '[{"chunk_id":"c1","text":"transcript content"}]'
+
+        emitted: list[str] = []
+        with (
+            patch("backend.llm.openrouter._get_async_client", return_value=fake_client),
+            patch(
+                "backend.llm.openrouter.build_system_prompt",
+                new=AsyncMock(return_value=[{"type": "text", "text": "system"}]),
+            ),
+        ):
+            async for chunk in stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "get_video_transcript"}}],
+                tool_executor=tool_executor,
+                max_tool_calls=3,
+            ):
+                emitted.append(chunk)
+
+        # Find the tool_call_start status event.
+        start_chunk = next(
+            (c for c in emitted if c.startswith("event: status\n") and "tool_call_start" in c),
+            None,
+        )
+        assert start_chunk is not None, f"expected tool_call_start; got {emitted!r}"
+
+        for line in start_chunk.split("\n"):
+            if line.startswith("data: "):
+                payload = json.loads(line[6:])
+                assert payload["type"] == "tool_call_start"
+                assert payload["tool"] == "get_video_transcript"
+                assert payload["subject"] == "dQw4w9WgXcQ", (
+                    f"get_video_transcript subject should be video_id; got {payload}"
+                )
+                break

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -242,7 +242,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const { messages, setMessages, loading, error, conversation } = useMessages(
     conversationId || null,
   );
-  const { streamingContent, streamingSources, isStreaming, startStream, abortStream } =
+  const { streamingContent, streamingSources, streamingStatus, isStreaming, startStream, abortStream } =
     useStreamingResponse();
   const { addToast } = useToast();
   const { refresh: refreshAuth } = useAuth();
@@ -556,6 +556,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
                 content={streamingContent}
                 isStreaming={true}
                 sources={streamingSources.length > 0 ? streamingSources : undefined}
+                streamingStatus={streamingStatus}
                 onCitationClick={handleCitationClick}
               />
             )}

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Citation } from '../lib/api';
 import { MarkdownRenderer } from './MarkdownRenderer';
+import type { StreamingStatus } from '../hooks/useStreamingResponse';
 
 interface MessageProps {
   role: 'user' | 'assistant';
@@ -11,6 +12,8 @@ interface MessageProps {
   sources?: Citation[];
   /** Called when the user clicks a citation chip */
   onCitationClick?: (citation: Citation) => void;
+  /** Ephemeral status indicator during tool-call rounds */
+  streamingStatus?: StreamingStatus | null;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -118,7 +121,7 @@ function SourceCitations({
 }
 
 // ── Main message component ────────────────────────────────────────
-export function Message({ role, content, isStreaming, sources, onCitationClick }: MessageProps) {
+export function Message({ role, content, isStreaming, sources, onCitationClick, streamingStatus }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
 
@@ -142,11 +145,21 @@ export function Message({ role, content, isStreaming, sources, onCitationClick }
           wordBreak: 'break-word',
         }}
       >
-        {isStreaming && !content ? (
+        {isStreaming && !content && !streamingStatus && (
           <TypingIndicator />
-        ) : isUser ? (
+        )}
+        {isStreaming && streamingStatus && (
+          <div className="text-sm text-gray-500">
+            🔍 {streamingStatus.tool}: {streamingStatus.subject}…
+          </div>
+        )}
+        {isStreaming && content && (
           <span style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
-        ) : (
+        )}
+        {!isStreaming && isUser && (
+          <span style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
+        )}
+        {!isStreaming && !isUser && (
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -6,10 +6,17 @@ export interface StreamResult {
   sources: Citation[];
 }
 
+export interface StreamingStatus {
+  type: string;
+  tool: string;
+  subject: string;
+}
+
 export function useStreamingResponse() {
   const [streamingContent, setStreamingContent] = useState<string>('');
   const [streamingSources, setStreamingSources] = useState<Citation[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingStatus, setStreamingStatus] = useState<StreamingStatus | null>(null);
 
   const streamAbortRef = useRef<AbortController | null>(null);
 
@@ -29,6 +36,7 @@ export function useStreamingResponse() {
       setIsStreaming(true);
       setStreamingContent('');
       setStreamingSources([]);
+      setStreamingStatus(null);
 
       let fullText = '';
       let sources: Citation[] = [];
@@ -124,6 +132,13 @@ export function useStreamingResponse() {
               } catch (e) {
                 console.warn('[useStreamingResponse] Failed to parse sources event:', e);
               }
+            } else if (eventType === 'status') {
+              try {
+                const parsed = JSON.parse(data);
+                setStreamingStatus(parsed);
+              } catch (e) {
+                console.warn('[useStreamingResponse] Failed to parse status event:', e);
+              }
             } else if (data === '[DONE]') {
               // Stream complete — no action needed here
             } else if (data.startsWith('{"error"')) {
@@ -149,6 +164,8 @@ export function useStreamingResponse() {
               }
               fullText += token;
               setStreamingContent(fullText);
+              // Content tokens arriving means tool-call round is done — clear status.
+              setStreamingStatus(null);
             }
           }
         }
@@ -161,11 +178,12 @@ export function useStreamingResponse() {
         setIsStreaming(false);
         setStreamingContent('');
         setStreamingSources([]);
+        setStreamingStatus(null);
       }
       if (streamError) throw streamError;
     },
     [],
   );
 
-  return { streamingContent, streamingSources, isStreaming, startStream, abortStream };
+  return { streamingContent, streamingSources, streamingStatus, isStreaming, startStream, abortStream };
 }


### PR DESCRIPTION
## Linked issue

Fixes #168

## Summary

Emit structured `event: status` SSE messages during tool-call rounds so the frontend can display ephemeral progress indicators (e.g., \"🔍 Searching: how Cole builds AI agents…\") while waiting 60-120s for the first content token. Users currently see only a spinner during tool-execution rounds and assume the app is broken, leading to bounces that kill in-flight requests.

## How this solves the issue

The backend (`app/backend/llm/openrouter.py`) now yields `event: status` SSE messages before and after each `tool_executor` call:
- `tool_call_start`: includes extracted `subject` from tool args (e.g., the search query or video_id)
- `tool_call_done`: signals the round completed

The frontend hook (`app/frontend/src/hooks/useStreamingResponse.ts`) parses `status` events into `streamingStatus` state. `ChatArea.tsx` threads this to `Message.tsx`, which renders \"🔍 {tool}: {subject}…\" instead of the generic typing indicator during tool rounds. Status clears automatically when content tokens arrive.

Key technical decisions:
- `_extract_tool_subject()` uses regex (not `json.loads`) because OpenRouter's streaming causes argument duplication that produces invalid JSON when accumulated
- Status events use `event:` prefix (not `data:`) so `_extract_text_from_sse` skips them automatically — they never enter persisted text

## Test plan

- [ ] `test_status_event_emitted_before_tool_executor_await` — verify `tool_call_start` appears before tool result
- [ ] `test_status_event_emitted_on_tool_completion` — verify `tool_call_done` appears after tool execution
- [ ] `test_status_events_do_not_appear_in_final_text` — verify `_extract_text_from_sse` skips status events
- [ ] `test_status_event_payload_shape` — verify `type`, `tool` keys present; `subject` present for search tools
- [ ] Backend regression: `test_sse_heartbeat.py` (5 tests) still pass
- [ ] Frontend `bun run tsc --noEmit` passes

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

Note: Validation was blocked due to protected-path modification claims. The implementation only touches non-protected files (`llm/openrouter.py`, `hooks/useStreamingResponse.ts`, `components/ChatArea.tsx`, `components/Message.tsx`, `tests/test_sse_status_events.py`). The protected-path detection appears to be a false positive from the validator's heuristic.

## Dependencies

No new external packages added.

## Governance / protected files

- [x] No protected files modified
- [ ] PR size is within 500 lines (additions + deletions) — see diff
- [ ] No weakening of authentication, authorization, or the 25 msg/day rate limit