### PR TITLE
feat(admin): add debounced title search to video library

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -318,6 +318,25 @@ async def list_videos_admin() -> list[dict]:
     return [dict(r) for r in rows]
 
 
+async def search_videos_admin(q: str, limit: int = 20) -> list[dict]:
+    """Videos with chunk_count where title/description/channel_title contains substring (case-insensitive)."""
+    pattern = f"%{q}%"
+    async with _acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT v.id, v.title, v.description, v.url, v.created_at, v.channel_id, v.channel_title,
+                   (SELECT COUNT(*) FROM chunks c WHERE c.video_id = v.id) AS chunk_count
+            FROM videos v
+            WHERE v.title ILIKE $1 OR v.description ILIKE $1 OR v.channel_title ILIKE $1
+            ORDER BY v.created_at DESC
+            LIMIT $2
+            """,
+            pattern,
+            limit,
+        )
+    return [dict(r) for r in rows]
+
+
 async def delete_video_cascade(video_id: str) -> bool:
     """Delete a video and its chunks (FK ON DELETE CASCADE). Returns False if not found."""
     async with _acquire() as conn:

--- a/app/backend/routes/admin.py
+++ b/app/backend/routes/admin.py
@@ -209,6 +209,30 @@ async def add_video(body: AddVideoRequest) -> AddVideoResponse:
     return AddVideoResponse(video_id=video_id, chunks_created=len(chunks), status="ok")
 
 
+@router.get("/videos/search", response_model=AdminVideosResponse)
+async def search_videos_admin(q: str) -> AdminVideosResponse:
+    """Title-contains search for the admin video library.
+
+    Must be declared BEFORE /admin/videos/{video_id} or FastAPI routes
+    "search" to the path-parameter handler and returns 404.
+    """
+    rows = await repo.search_videos_admin(q)
+    videos = [
+        AdminVideo(
+            id=r["id"],
+            title=r["title"],
+            description=r["description"],
+            url=r["url"],
+            created_at=str(r["created_at"]),
+            chunk_count=int(r["chunk_count"]),
+            channel_id=r.get("channel_id"),
+            channel_title=r.get("channel_title"),
+        )
+        for r in rows
+    ]
+    return AdminVideosResponse(videos=videos)
+
+
 @router.delete("/videos/{video_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_video(video_id: str) -> None:
     """Delete a video and cascade its chunks. 404 if not found."""

--- a/app/backend/tests/test_search_conversations.py
+++ b/app/backend/tests/test_search_conversations.py
@@ -22,7 +22,9 @@ pytestmark = pytest.mark.skip(
 
 from backend.db.repository import (  # noqa: E402
     create_conversation,
+    create_video,
     search_conversations_by_title,
+    search_videos_admin,
 )
 
 
@@ -82,3 +84,101 @@ async def test_search_conversations_no_matches():
 
     results = await search_conversations_by_title(user_id, "javascript")
     assert results == []
+
+
+async def test_search_videos_admin_case_insensitive():
+    """Search should be case-insensitive using ILIKE."""
+    await create_video(
+        title="Docker Tutorial",
+        description="Learn Docker",
+        url="https://youtube.com/watch?v=docker1",
+        transcript="docker docker docker",
+        channel_id="ch1",
+        channel_title="DevOps Channel",
+    )
+    await create_video(
+        title="Kubernetes Guide",
+        description="Learn Kubernetes",
+        url="https://youtube.com/watch?v=k8s1",
+        transcript="k8s k8s k8s",
+        channel_id="ch2",
+        channel_title="Cloud Channel",
+    )
+    await create_video(
+        title="docker advanced",
+        description="Advanced Docker topics",
+        url="https://youtube.com/watch?v=docker2",
+        transcript="advanced docker",
+        channel_id="ch1",
+        channel_title="DevOps Channel",
+    )
+
+    results = await search_videos_admin("docker")
+    titles = {r["title"] for r in results}
+    assert titles == {"Docker Tutorial", "docker advanced"}
+
+    results = await search_videos_admin("DOCKER")
+    titles = {r["title"] for r in results}
+    assert titles == {"Docker Tutorial", "docker advanced"}
+
+
+async def test_search_videos_admin_empty_query():
+    """Empty query should return results (pattern would be %%)."""
+    await create_video(
+        title="Test Video",
+        description="A test",
+        url="https://youtube.com/watch?v=test1",
+        transcript="test test test",
+    )
+
+    results = await search_videos_admin("")
+    assert isinstance(results, list)
+
+
+async def test_search_videos_admin_limit():
+    """Search should respect the limit parameter."""
+    for i in range(5):
+        await create_video(
+            title=f"Video {i}",
+            description="Desc",
+            url=f"https://youtube.com/watch?v=v{i}",
+            transcript="transcript",
+        )
+
+    results = await search_videos_admin("Video", limit=3)
+    assert len(results) == 3
+
+
+async def test_search_videos_admin_no_matches():
+    """Search should return empty list when no matches."""
+    await create_video(
+        title="Python Tutorial",
+        description="Learn Python",
+        url="https://youtube.com/watch?v=py1",
+        transcript="python python",
+    )
+
+    results = await search_videos_admin("javascript")
+    assert results == []
+
+
+async def test_search_videos_admin_matches_description_and_channel_title():
+    """Search should match description and channel_title as well as title."""
+    await create_video(
+        title="Generic Title",
+        description="Rust Programming",
+        url="https://youtube.com/watch?v=rust1",
+        transcript="rust rust",
+        channel_id="ch1",
+        channel_title="Rust Channel",
+    )
+
+    # Match by description
+    results = await search_videos_admin("Rust Programming")
+    assert len(results) == 1
+    assert results[0]["title"] == "Generic Title"
+
+    # Match by channel_title
+    results = await search_videos_admin("Rust Channel")
+    assert len(results) == 1
+    assert results[0]["title"] == "Generic Title"

--- a/app/frontend/src/hooks/useAdminVideos.ts
+++ b/app/frontend/src/hooks/useAdminVideos.ts
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  type AdminVideo,
-  listAdminVideos,
-  searchAdminVideos,
-} from '../lib/api';
+import { type AdminVideo, listAdminVideos, searchAdminVideos } from '../lib/api';
 
 export function useAdminVideos(searchQuery?: string) {
   const [videos, setVideos] = useState<AdminVideo[]>([]);

--- a/app/frontend/src/hooks/useAdminVideos.ts
+++ b/app/frontend/src/hooks/useAdminVideos.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type AdminVideo,
+  listAdminVideos,
+  searchAdminVideos,
+} from '../lib/api';
+
+export function useAdminVideos(searchQuery?: string) {
+  const [videos, setVideos] = useState<AdminVideo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Per-fetch ID so a stale response can't overwrite fresher results
+  // when the user types faster than the network replies.
+  const fetchIdRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const trimmed = (searchQuery ?? '').trim();
+    const myId = ++fetchIdRef.current;
+    try {
+      setLoading(true);
+      const data = trimmed ? await searchAdminVideos(trimmed) : await listAdminVideos();
+      if (myId === fetchIdRef.current) setVideos(data.videos);
+    } catch (e) {
+      if (myId === fetchIdRef.current) {
+        setError(e instanceof Error ? e.message : 'Failed to load videos');
+      }
+    } finally {
+      if (myId === fetchIdRef.current) setLoading(false);
+    }
+  }, [searchQuery]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return {
+    videos,
+    loading,
+    error,
+    refetch: load,
+  };
+}

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -157,6 +157,9 @@ export interface SyncChannelResponse {
 
 export const listAdminVideos = () => request<AdminVideosResponse>('/admin/videos');
 
+export const searchAdminVideos = (q: string) =>
+  request<AdminVideosResponse>(`/admin/videos/search?q=${encodeURIComponent(q)}`);
+
 export const addVideoByUrl = (url: string) =>
   request<AddVideoResponse>('/admin/videos', {
     method: 'POST',

--- a/app/frontend/src/pages/AdminVideos.tsx
+++ b/app/frontend/src/pages/AdminVideos.tsx
@@ -9,16 +9,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { AddVideoModal } from '../components/AddVideoModal';
+import { useAdminVideos } from '../hooks/useAdminVideos';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
-import { useAdminVideos } from '../hooks/useAdminVideos';
-import {
-  type AdminVideo,
-  addVideoByUrl,
-  deleteVideo,
-  resyncVideo,
-  syncChannel,
-} from '../lib/api';
+import { type AdminVideo, addVideoByUrl, deleteVideo, resyncVideo, syncChannel } from '../lib/api';
 
 export function AdminVideos() {
   const { status, user } = useAuth();

--- a/app/frontend/src/pages/AdminVideos.tsx
+++ b/app/frontend/src/pages/AdminVideos.tsx
@@ -11,11 +11,11 @@ import { Link, Navigate } from 'react-router-dom';
 import { AddVideoModal } from '../components/AddVideoModal';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
+import { useAdminVideos } from '../hooks/useAdminVideos';
 import {
   type AdminVideo,
   addVideoByUrl,
   deleteVideo,
-  listAdminVideos,
   resyncVideo,
   syncChannel,
 } from '../lib/api';
@@ -23,29 +23,18 @@ import {
 export function AdminVideos() {
   const { status, user } = useAuth();
   const { addToast } = useToast();
-  const [videos, setVideos] = useState<AdminVideo[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const { videos, loading, refetch } = useAdminVideos(debouncedQuery);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [addModalOpen, setAddModalOpen] = useState(false);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await listAdminVideos();
-      setVideos(res.videos);
-    } catch (err) {
-      addToast(err instanceof Error ? err.message : 'Failed to load videos', 'error');
-    } finally {
-      setLoading(false);
-    }
-  }, [addToast]);
-
+  // Debounce search query — 250ms per issue #92 pattern
   useEffect(() => {
-    if (status === 'authed' && user?.is_admin) {
-      refresh();
-    }
-  }, [status, user?.is_admin, refresh]);
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
   // Guard rendering
   if (status === 'loading') {
@@ -65,7 +54,7 @@ export function AdminVideos() {
   async function handleAdd(url: string) {
     const res = await addVideoByUrl(url);
     addToast(`Added video (${res.chunks_created} chunks)`, 'success');
-    await refresh();
+    await refetch();
   }
 
   async function handleDelete(video: AdminVideo) {
@@ -76,7 +65,7 @@ export function AdminVideos() {
     try {
       await deleteVideo(video.id);
       addToast('Video deleted', 'success');
-      await refresh();
+      await refetch();
     } catch (err) {
       addToast(err instanceof Error ? err.message : 'Delete failed', 'error');
     } finally {
@@ -89,7 +78,7 @@ export function AdminVideos() {
     try {
       const res = await resyncVideo(video.id);
       addToast(`Re-synced (${res.chunks_created} chunks)`, 'success');
-      await refresh();
+      await refetch();
     } catch (err) {
       addToast(err instanceof Error ? err.message : 'Re-sync failed', 'error');
     } finally {
@@ -105,7 +94,7 @@ export function AdminVideos() {
         `Channel sync ${res.status}: ${res.videos_new} new, ${res.videos_error} errors`,
         res.status === 'completed' ? 'success' : 'error',
       );
-      await refresh();
+      await refetch();
     } catch (err) {
       addToast(err instanceof Error ? err.message : 'Channel sync failed', 'error');
     } finally {
@@ -147,7 +136,7 @@ export function AdminVideos() {
           </button>
           <button
             type="button"
-            onClick={refresh}
+            onClick={refetch}
             disabled={loading || syncing}
             className="px-3 py-2 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-50"
           >
@@ -155,12 +144,36 @@ export function AdminVideos() {
           </button>
         </div>
 
+        <div style={{ marginBottom: 12 }}>
+          <input
+            type="text"
+            placeholder="Search videos..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 13,
+              outline: 'none',
+              transition: 'border-color 0.15s',
+            }}
+            onFocus={(e) => (e.currentTarget.style.borderColor = '#3b82f6')}
+            onBlur={(e) => (e.currentTarget.style.borderColor = '#334155')}
+          />
+        </div>
+
         <div className="bg-[var(--surface-1)] border border-[var(--border)] rounded-lg overflow-hidden">
           {loading ? (
             <div className="p-6 text-center text-[var(--text-secondary)]">Loading…</div>
           ) : videos.length === 0 ? (
             <div className="p-6 text-center text-[var(--text-secondary)]">
-              No videos yet. Add one by URL or sync a channel.
+              {debouncedQuery.trim()
+                ? `No matches for "${debouncedQuery}"`
+                : 'No videos yet. Add one by URL or sync a channel.'}
             </div>
           ) : (
             <table className="w-full text-sm">


### PR DESCRIPTION
## Summary

Closes #178.

Adds a debounced title search to the admin video library (`/admin/videos`), mirroring the existing conversation-search pattern end-to-end.

## Changes

**Backend**
- `app/backend/db/repository.py` — `search_videos_admin(q, limit=20)` using `ILIKE` on `title`, `description`, `channel_title`
- `app/backend/routes/admin.py` — `GET /admin/videos/search` (declared **before** `/{video_id}` to avoid FastAPI path-parameter shadowing — see inline comment mirroring `conversations.py`)

**Frontend**
- `app/frontend/src/lib/api.ts` — `searchAdminVideos(q)` typed wrapper
- `app/frontend/src/hooks/useAdminVideos.ts` — debounced hook with `fetchIdRef` stale-response guard (mirrors `useConversations`)
- `app/frontend/src/pages/AdminVideos.tsx` — 250ms-debounced search input above table, no-matches empty state

**Tests**
- `app/backend/tests/test_search_conversations.py` — 5 cases: case-insensitive, empty query, limit, no matches, description/channel_title matching

## Notes

This PR was generated by the dark-factory `fix-github-issue` workflow. The `validate` node hung on a long Kimi K2.6 stream after a clean implement (passed inline backend import / Python syntax / `tsc --noEmit` checks), so the PR is being opened manually for review. Full CI / agent-browser regression will run on this PR.

## Test plan

- [ ] CI green (ruff, mypy, pytest, tsc, biome, vitest)
- [ ] Manually verify `GET /admin/videos/search?q=...` returns at most 20 ILIKE matches
- [ ] Manually verify route ordering — `/admin/videos/search` resolves correctly, `/admin/videos/{id}` still works
- [ ] Manually verify debounced UI behavior at 250ms
