### PR TITLE
fix(citations): expose chunk_id in tool-result text so LLM can actually emit markers

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -44,10 +44,7 @@ def _get_async_client() -> AsyncOpenAI:
 _BASE_SYSTEM_PROMPT = """\
 You are a helpful assistant with access to transcripts from a YouTube creator's video library. You answer questions by retrieving grounded content from that library via the tools below.
 
-When you reference a video, use its title only. Never write YouTube video IDs or raw source identifiers in your prose — the UI renders sources separately as clickable chips, so inline tokens like "(Source: Video HAkSUBdsd6M)" are redundant clutter. The one structured exception is the citation marker described below.
-
-CITATIONS — MANDATORY when grounding a claim in retrieved content:
-After any sentence that draws on a retrieved chunk, append the marker `[c:<chunk_id>]` immediately at the end of that sentence, using the literal `chunk_id` value from the tool result. Cite only chunks you actually used to support that specific claim — chunks you retrieved but did not lean on are context, not citations, and must NOT receive a marker. Multiple chunks supporting the same sentence stack: `[c:abc][c:def]`. Do not cite training knowledge — markers are for retrieved chunks only. The UI strips these markers from the displayed text and uses them to render a focused "Sources cited" list, with the broader retrieval kept as an expandable transparency layer.
+When you reference a video, use its title only. Never write YouTube video IDs or raw source identifiers as commentary in your prose — phrasings like "(Source: Video HAkSUBdsd6M)" or "[Building AI Agents]" inline are redundant clutter; the UI renders sources separately as clickable chips. The structured citation marker described in CITATIONS below is the one exception: it is a UI protocol token, not exposition, and is stripped before the user sees the text.
 
 Answer based ONLY on content you retrieved via your tools. If your searches return no relevant material, clearly and briefly decline. When declining because the library does not cover the topic, include this exact phrase in your reply: "the video library does not cover that topic". The exact phrasing is important — the UI relies on it to suppress misleading source citations on off-topic questions. Keep the decline short (two to three sentences) and do not invent content."""
 
@@ -65,7 +62,45 @@ Strategy:
 - Default to `search_videos` unless the question clearly calls for keyword or semantic specifically.
 - If the first call returns insufficient or irrelevant context, issue another with a better query or a different strategy.
 - Reach for `get_video_transcript` only when chunk-level results are clearly not enough.
-- You have {max_per_turn} tool calls total per user turn. Spend them deliberately."""
+- You have {max_per_turn} tool calls total per user turn. Spend them deliberately.
+
+CITATIONS — REQUIRED, NOT OPTIONAL.
+
+Every chunk in a tool result begins with a marker like `[c:abc123]`. After
+any sentence in your answer that draws from a retrieved chunk, append the
+SAME marker that appeared at the start of that chunk. Markers are stripped
+from the displayed text by the UI and used to render the prominent
+"Sources cited" list. Without the marker the user sees no citation chip
+for that chunk.
+
+Worked example.
+
+  Tool result you receive:
+
+      [c:abc123] Pydantic AI Tutorial at 03:15
+      The key is to define your data models first using Pydantic.
+
+      ---
+
+      [c:def456] Pydantic AI Tutorial at 05:42
+      Once you have your models, you can pass them to the agent as the
+      result_type parameter.
+
+  Your answer (markers shown — they will be stripped from what the user sees):
+
+      Cole's approach starts with defining Pydantic data models[c:abc123].
+      He then passes those models to the agent as the result_type
+      parameter[c:def456].
+
+Rules.
+- The marker is required for every sentence grounded in a retrieved chunk.
+  No marker = no citation chip renders.
+- Cite only chunks you actually drew from. Retrieved chunks you did not lean
+  on are context, not citations — do not mark them.
+- Multiple chunks supporting the same sentence stack: `[c:abc123][c:def456]`.
+- Copy the marker verbatim from the tool result. Do not invent ids.
+- Markers are protocol tokens, not exposition: never explain them, never
+  describe them, just emit them at sentence end."""
 
 
 SYSTEM_PROMPT_TEMPLATE = _BASE_SYSTEM_PROMPT

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -210,15 +210,25 @@ async def _hydrate_chunks(raw_chunks: list[dict]) -> list[dict]:
 
 
 def _format_search_results(chunks: list[dict]) -> str:
-    """Format chunks as the LLM-facing tool result text with [mm:ss] markers."""
+    """Format chunks as the LLM-facing tool result text.
+
+    Each chunk is prefixed with a literal ``[c:<chunk_id>]`` marker — the same
+    form the model is instructed to emit when citing the chunk in its answer.
+    Putting the marker directly in the LLM's input gives it the exact token
+    to copy back: see issue #176 for why this is required (the prior format
+    omitted chunk_id entirely, leaving the model unable to follow the citation
+    instruction even when it tried).
+    """
     if not chunks:
         return "No relevant chunks found. Try a different query or strategy."
     parts = []
     for c in chunks:
         title = c.get("video_title") or "Unknown Video"
+        chunk_id = c.get("chunk_id") or ""
         start = int(c.get("start_seconds") or 0.0)
         mins, secs = divmod(start, 60)
-        parts.append(f"[Source: {title} at {mins:02d}:{secs:02d}]\n{c.get('content', '')}")
+        marker = f"[c:{chunk_id}] " if chunk_id else ""
+        parts.append(f"{marker}{title} at {mins:02d}:{secs:02d}\n{c.get('content', '')}")
     return "\n\n---\n\n".join(parts)
 
 
@@ -327,12 +337,21 @@ def _format_transcript(video: dict, chunks: list[dict], max_chars: int | None = 
     total_chunks = 0
     for c in chunks:
         total_chunks += 1
+        # Raw chunks from list_chunks_for_video use ``id``; canonical chunks
+        # (constructed for the citations payload) use ``chunk_id``. Accept
+        # either so the LLM-facing text always carries a [c:<id>] marker.
+        chunk_id = c.get("chunk_id") or c.get("id") or ""
         start = int(c.get("start_seconds") or 0.0)
         mins, secs = divmod(start, 60)
         content = (c.get("content") or "").strip()
         if not content:
             continue
-        piece = f"[{mins:02d}:{secs:02d}] {content}"
+        # Keep `[c:<id>]` and `[mm:ss]` as separate brackets so the marker
+        # regex (which only matches `[A-Za-z0-9_-]+` inside the brackets)
+        # still parses cleanly. Order: marker first, then the existing
+        # timestamp prefix the LLM has already been trained against.
+        marker_prefix = f"[c:{chunk_id}] " if chunk_id else ""
+        piece = f"{marker_prefix}[{mins:02d}:{secs:02d}] {content}"
         # Account for the "\n\n" separator we will join with.
         addition = len(piece) + 2
         if max_chars is not None and char_count + addition > max_chars:

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -34,6 +34,41 @@ class TestParsing:
 # Stream-safe stripping --------------------------------------------------
 
 
+class TestFormatterMarkerRoundTrip:
+    """The LLM-facing tool result must contain `[c:<chunk_id>]` markers in the
+    same form the citation parser extracts — that contract is what makes
+    marker emission possible at all (issue #176 follow-up).
+    """
+
+    def test_search_format_emits_marker_extractable_by_parser(self) -> None:
+        from backend.rag.tools import _format_search_results
+
+        chunks = [
+            {
+                "chunk_id": "abc-123",
+                "video_title": "T",
+                "start_seconds": 0.0,
+                "content": "x",
+            },
+            {
+                "chunk_id": "def_456",
+                "video_title": "T",
+                "start_seconds": 60.0,
+                "content": "y",
+            },
+        ]
+        text = _format_search_results(chunks)
+        assert extract_cited_chunk_ids(text) == {"abc-123", "def_456"}
+
+    def test_transcript_format_emits_marker_extractable_by_parser(self) -> None:
+        from backend.rag.tools import _format_transcript
+
+        # Transcript path uses raw chunks where the id field is "id" not "chunk_id".
+        chunks = [{"id": "raw-id-1", "start_seconds": 0.0, "content": "hello"}]
+        text = _format_transcript({"title": "Demo"}, chunks, max_chars=None)
+        assert extract_cited_chunk_ids(text) == {"raw-id-1"}
+
+
 class TestStreamStripper:
     def _run(self, tokens: list[str]) -> str:
         s = CitationMarkerStripper()


### PR DESCRIPTION
## Summary

Follow-up to #180. The two-tier system shipped, but the validate-pr E2E (and Cole's own observation) showed Sonnet 4.6 was not actually emitting `[c:<chunk_id>]` markers in production. The cap fallback caught it, but the prominent "Sources cited" tier never rendered.

## Root cause

**The LLM never saw any chunk_ids.** Both `_format_search_results` and `_format_transcript` formatted chunks for the model like:

```
[Source: Building AI Agents at 02:30]
<content>
```

`chunk_id` is a field on the chunk dict but it was dropped before reaching the prompt. Sonnet had no raw material to put inside `[c:_____]` — it physically couldn't follow the instruction.

## Fix

**Bake the marker directly into the LLM's input.** Each chunk in the tool result now begins with the literal `[c:<chunk_id>]` token — the exact same form the model is asked to emit when citing. The model just copies it.

```
[c:abc123] Building AI Agents at 02:30
<content>
```

For the transcript path, `[c:<id>]` and the existing `[mm:ss]` stay as separate brackets (the marker regex only accepts `[A-Za-z0-9_-]` inside, so jamming the timestamp in there breaks parsing):

```
[c:abc123] [02:30] <content line>
```

## Prompt changes

- Moved the CITATIONS section to the end of `_TOOL_GUIDANCE` — recency bias matters; it's the last instruction the model reads before responding.
- Labelled it `REQUIRED, NOT OPTIONAL`. Added a worked example with both a sample tool result and the answer-with-markers the model should produce.
- Reframed the existing "no IDs in prose" rule so it's clear the structured marker is the one intended ID-like token, not a contradiction.

## Test plan

- [x] ruff + mypy clean
- [x] 334 backend tests pass (332 prior + 2 new)
- [x] New `TestFormatterMarkerRoundTrip` tests prove `_format_search_results` and `_format_transcript` emit markers parseable by `extract_cited_chunk_ids`
- [x] Existing format tests still pass — the new marker is additive (the title and timestamp substrings the tests check for are still present)
- [ ] Post-deploy: agent-browser regression on `chat.dynamous.ai` with a known answerable question; verify the **"Sources cited"** tier actually renders with a small focused list (proving Sonnet emits markers now that it can see them)

## Why this is small

97 insertions / 8 deletions across 3 files. No frontend changes — the issue was entirely on the backend prompt+formatter side. The frontend two-tier render from #180 already handles both cases (markers emitted → Tier 1 visible; no markers → Tier 2 single list with the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
