### PR TITLE
fix(prompt): reframe get_video_transcript as expected next step on single-winner questions

### DIFF
--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -58,12 +58,13 @@ You have four retrieval tools. You MUST call at least one before answering any q
 - `search_videos(query, top_k=10)` — hybrid search (keyword + semantic via RRF). Your default. Start here.
 - `keyword_search_videos(query, top_k=10)` — exact-term matching (tsvector FTS). Best for proper nouns, acronyms, literal phrases.
 - `semantic_search_videos(query, top_k=10)` — conceptual similarity (vector cosine). Best when the user's wording may not match transcripts literally.
-- `get_video_transcript(video_id)` — full timestamped transcript of one video. Call only after a search surfaced a video and you need its full arc. Expensive — use sparingly.
+- `get_video_transcript(video_id)` — full timestamped transcript of one video. Use this whenever search confidently identifies a single video that addresses the asked topic. Chunk-level search results often skip the elaboration the full transcript captures, so the transcript call is what lets you give precise, accurate detail rather than a partial guess.
 
 Strategy:
 - Default to `search_videos` unless the question clearly calls for keyword or semantic specifically.
 - If the first call returns insufficient or irrelevant context, issue another with a better query or a different strategy.
-- Reach for `get_video_transcript` only when chunk-level results are clearly not enough.
+- When two or more search chunks come from the same video and that video clearly addresses the asked topic, your next step is `get_video_transcript(video_id)` on that video. This is the expected flow, not an escape hatch — chunks alone routinely lack fine-grained detail (acronym expansions, step-by-step breakdowns, exact terminology), and the full transcript fixes that. Skipping this step on a single-winner question leads to confidently wrong answers from partial chunks.
+- For broad questions that genuinely span many videos (no clear single winner), more `search_videos` calls with refined queries beat one transcript dump — transcript is for going deep on a confidently-identified video.
 - You have {max_per_turn} tool calls total per user turn. Spend them deliberately.
 
 CITATIONS — REQUIRED, NOT OPTIONAL.


### PR DESCRIPTION
After the tone fix (#185) shipped, live testing showed Sonnet stopped apologizing but started **confidently hallucinating** from partial chunks. WISC framework answer expanded 'C' as 'Context' instead of correct 'Compress' — the model guessed because chunks didn't include the detail.

Root cause: the prompt actively discouraged calling `get_video_transcript` (*'Expensive — use sparingly'*). Sonnet is risk-averse and treated it as a last-resort escape hatch.

Reframes transcript as **the expected next step** when search confidently identifies a single-winner video. Adds explicit trigger ('two or more chunks from the same video → call transcript') and an anti-pattern call-out ('Skipping this step on a single-winner question leads to confidently wrong answers from partial chunks'). Counter-balanced for broad questions to prevent over-triggering.

Guardrails unchanged: LLM_TOOLS_MAX_PER_TURN=6, TRANSCRIPT_TOOL_MAX_CHARS=120000, CITATIONS_MAX_COUNT=10.

3+/2- in one file. Tests green.

Refs #176