### PR TITLE
feat(video-library): add search bar to filter videos by title

### DIFF
--- a/app/frontend/src/__tests__/VideoExplorer.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer.test.tsx
@@ -402,4 +402,107 @@ describe('VideoExplorer', () => {
       expect(screen.getByText('A'.repeat(117) + '…')).toBeInTheDocument();
     });
   });
+
+  describe('search / filter', () => {
+    it('renders search input when videos are present', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        {
+          id: '1',
+          title: 'React Hooks Deep Dive',
+          description: '',
+          url: 'https://yt.be/1',
+          created_at: '',
+        },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByLabelText('Search videos')).toBeInTheDocument());
+    });
+
+    it('does not render search input when library is empty', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() =>
+        expect(screen.getByText('No videos in the knowledge base yet.')).toBeInTheDocument(),
+      );
+      expect(screen.queryByLabelText('Search videos')).not.toBeInTheDocument();
+    });
+
+    it('filters video list by title after debounce', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        { id: '1', title: 'React Hooks Deep Dive', description: '', url: '', created_at: '' },
+        { id: '2', title: 'TypeScript Tips', description: '', url: '', created_at: '' },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('React Hooks Deep Dive')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('Search videos'), { target: { value: 'typescript' } });
+      // Wait for the debounce (250ms) to fire — React Hooks should be gone
+      await waitFor(
+        () => expect(screen.queryByText('React Hooks Deep Dive')).not.toBeInTheDocument(),
+        { timeout: 1000 },
+      );
+      // TypeScript Tips is still shown (title text is split by <mark> highlight)
+      expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    });
+
+    it('restores all videos when search is cleared', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        { id: '1', title: 'React Hooks Deep Dive', description: '', url: '', created_at: '' },
+        { id: '2', title: 'TypeScript Tips', description: '', url: '', created_at: '' },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('React Hooks Deep Dive')).toBeInTheDocument());
+
+      const input = screen.getByLabelText('Search videos');
+      fireEvent.change(input, { target: { value: 'typescript' } });
+      await waitFor(
+        () => expect(screen.queryByText('React Hooks Deep Dive')).not.toBeInTheDocument(),
+        { timeout: 1000 },
+      );
+
+      fireEvent.change(input, { target: { value: '' } });
+      await waitFor(() => expect(screen.getByText('React Hooks Deep Dive')).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+    });
+
+    it('shows "no match" empty state and echoes the query', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        { id: '1', title: 'React Hooks Deep Dive', description: '', url: '', created_at: '' },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('React Hooks Deep Dive')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('Search videos'), { target: { value: 'Python' } });
+      await waitFor(() => expect(screen.getByText(/No videos match/)).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+      expect(screen.queryByText('React Hooks Deep Dive')).not.toBeInTheDocument();
+    });
+
+    it('resets search state when panel closes and reopens', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValue([
+        { id: '1', title: 'React Hooks Deep Dive', description: '', url: '', created_at: '' },
+      ]);
+      const { rerender } = render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('React Hooks Deep Dive')).toBeInTheDocument());
+
+      // Type a search query and wait for debounce
+      fireEvent.change(screen.getByLabelText('Search videos'), { target: { value: 'Python' } });
+      await waitFor(() => expect(screen.getByText(/No videos match/)).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+
+      // Close the panel
+      rerender(<VideoExplorer isOpen={false} onClose={vi.fn()} />);
+
+      // Reopen the panel
+      rerender(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByLabelText('Search videos')).toBeInTheDocument());
+
+      // Search input should be cleared
+      expect((screen.getByLabelText('Search videos') as HTMLInputElement).value).toBe('');
+      expect(screen.queryByText(/No videos match/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/app/frontend/src/__tests__/VideoExplorer.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer.test.tsx
@@ -480,6 +480,68 @@ describe('VideoExplorer', () => {
       expect(screen.queryByText('React Hooks Deep Dive')).not.toBeInTheDocument();
     });
 
+    it('shows "X of Y videos" filtered count in header when search is active', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        { id: '1', title: 'React Hooks Deep Dive', description: '', url: '', created_at: '' },
+        { id: '2', title: 'TypeScript Tips', description: '', url: '', created_at: '' },
+        { id: '3', title: 'Vue Basics', description: '', url: '', created_at: '' },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() =>
+        expect(screen.getByText('3 videos in knowledge base')).toBeInTheDocument(),
+      );
+
+      fireEvent.change(screen.getByLabelText('Search videos'), { target: { value: 'typescript' } });
+      await waitFor(() => expect(screen.getByText('1 of 3 videos')).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+    });
+
+    it('matches against channel_title and description in addition to title', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        {
+          id: '1',
+          title: 'Episode 4',
+          description: '',
+          url: '',
+          created_at: '',
+          channel_title: 'Cole Medin',
+        },
+        {
+          id: '2',
+          title: 'Episode 5',
+          description: 'Deep dive on retrieval augmented generation',
+          url: '',
+          created_at: '',
+        },
+        {
+          id: '3',
+          title: 'Episode 6',
+          description: 'Unrelated content',
+          url: '',
+          created_at: '',
+        },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('Episode 4')).toBeInTheDocument());
+
+      // Match by channel_title
+      const input = screen.getByLabelText('Search videos');
+      fireEvent.change(input, { target: { value: 'cole' } });
+      await waitFor(() => expect(screen.queryByText('Episode 5')).not.toBeInTheDocument(), {
+        timeout: 1000,
+      });
+      expect(screen.getByText('Episode 4')).toBeInTheDocument();
+
+      // Match by description
+      fireEvent.change(input, { target: { value: 'retrieval' } });
+      await waitFor(() => expect(screen.getByText('Episode 5')).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+      expect(screen.queryByText('Episode 4')).not.toBeInTheDocument();
+      expect(screen.queryByText('Episode 6')).not.toBeInTheDocument();
+    });
+
     it('resets search state when panel closes and reopens', async () => {
       vi.spyOn(api, 'getVideos').mockResolvedValue([
         { id: '1', title: 'React Hooks Deep Dive', description: '', url: '', created_at: '' },

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -1,9 +1,11 @@
+import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { type Video, getVideos, ingestVideo } from '../lib/api';
 
 // ── Highlight matched substring in a video title ─────────────────
-function highlightMatch(title: string, query: string) {
+function highlightMatch(title: string, query: string): string | React.ReactElement {
+  if (!title) return title;
   const q = query.trim();
   if (!q) return title;
   const idx = title.toLowerCase().indexOf(q.toLowerCase());
@@ -11,7 +13,14 @@ function highlightMatch(title: string, query: string) {
   return (
     <>
       {title.slice(0, idx)}
-      <mark style={{ background: 'rgba(59,130,246,0.35)', color: 'inherit' }}>
+      <mark
+        style={{
+          background: 'rgba(59,130,246,0.35)',
+          color: 'inherit',
+          padding: 0,
+          borderRadius: 2,
+        }}
+      >
         {title.slice(idx, idx + q.length)}
       </mark>
       {title.slice(idx + q.length)}
@@ -178,6 +187,14 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
+  // Reset search state when panel closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery('');
+      setDebouncedQuery('');
+    }
+  }, [isOpen]);
+
   // Close on Escape key
   useEffect(() => {
     if (!isOpen) return;
@@ -189,7 +206,9 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
   }, [isOpen, onClose]);
 
   const filteredVideos = debouncedQuery.trim()
-    ? videos.filter((v) => v.title.toLowerCase().includes(debouncedQuery.trim().toLowerCase()))
+    ? videos.filter((v) =>
+        (v.title ?? '').toLowerCase().includes(debouncedQuery.trim().toLowerCase()),
+      )
     : videos;
 
   return (

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -13,14 +13,7 @@ function highlightMatch(title: string, query: string): string | React.ReactEleme
   return (
     <>
       {title.slice(0, idx)}
-      <mark
-        style={{
-          background: 'rgba(59,130,246,0.35)',
-          color: 'inherit',
-          padding: 0,
-          borderRadius: 2,
-        }}
-      >
+      <mark className="bg-blue-500/35 text-inherit p-0 rounded-sm">
         {title.slice(idx, idx + q.length)}
       </mark>
       {title.slice(idx + q.length)}
@@ -205,10 +198,9 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
     return () => document.removeEventListener('keydown', handler);
   }, [isOpen, onClose]);
 
-  const filteredVideos = debouncedQuery.trim()
-    ? videos.filter((v) =>
-        (v.title ?? '').toLowerCase().includes(debouncedQuery.trim().toLowerCase()),
-      )
+  const q = debouncedQuery.trim().toLowerCase();
+  const filteredVideos = q
+    ? videos.filter((v) => (v.title ?? '').toLowerCase().includes(q))
     : videos;
 
   return (

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -2,6 +2,23 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { type Video, getVideos, ingestVideo } from '../lib/api';
 
+// ── Highlight matched substring in a video title ─────────────────
+function highlightMatch(title: string, query: string) {
+  const q = query.trim();
+  if (!q) return title;
+  const idx = title.toLowerCase().indexOf(q.toLowerCase());
+  if (idx === -1) return title;
+  return (
+    <>
+      {title.slice(0, idx)}
+      <mark style={{ background: 'rgba(59,130,246,0.35)', color: 'inherit' }}>
+        {title.slice(idx, idx + q.length)}
+      </mark>
+      {title.slice(idx + q.length)}
+    </>
+  );
+}
+
 // ── Skeleton card ────────────────────────────────────────────────
 function SkeletonCard() {
   return (
@@ -14,7 +31,7 @@ function SkeletonCard() {
 }
 
 // ── Video card ───────────────────────────────────────────────────
-function VideoCard({ video }: { video: Video }) {
+function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
   return (
     <div
       className="bg-slate-800 border border-white/10 rounded-lg p-3.5 transition-colors duration-150"
@@ -22,7 +39,9 @@ function VideoCard({ video }: { video: Video }) {
       onMouseLeave={(e) => e.currentTarget.classList.remove('video-card-hover')}
     >
       {/* Title */}
-      <p className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight">{video.title}</p>
+      <p className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight">
+        {highlightMatch(video.title, query)}
+      </p>
 
       {/* Description / channel attribution */}
       {video.channel_title ? (
@@ -105,6 +124,8 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
   });
   const [ingesting, setIngesting] = useState(false);
   const [ingestError, setIngestError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
 
   const closeDialog = () => {
     setIngestOpen(false);
@@ -151,6 +172,12 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
     }
   }, [isOpen, videos.length, loading, error, fetchVideos]);
 
+  // Debounce search query
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
   // Close on Escape key
   useEffect(() => {
     if (!isOpen) return;
@@ -160,6 +187,12 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [isOpen, onClose]);
+
+  const filteredVideos = debouncedQuery.trim()
+    ? videos.filter((v) =>
+        v.title.toLowerCase().includes(debouncedQuery.trim().toLowerCase())
+      )
+    : videos;
 
   return (
     <>
@@ -221,6 +254,20 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
           )}
         </div>
 
+        {/* Search */}
+        {!loading && !error && videos.length > 0 && (
+          <div className="px-5 py-3 border-b border-white/10 flex-shrink-0">
+            <input
+              type="search"
+              placeholder="Search videos…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full p-2 bg-slate-900 border border-white/10 rounded-md text-slate-100 text-sm box-border outline-none focus:border-blue-500 transition-colors"
+              aria-label="Search videos"
+            />
+          </div>
+        )}
+
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-2.5">
           {loading && (
@@ -264,7 +311,15 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
             </div>
           )}
 
-          {!loading && !error && videos.map((video) => <VideoCard key={video.id} video={video} />)}
+          {!loading && !error && videos.length > 0 && filteredVideos.length === 0 && (
+            <div className="py-8 text-center text-slate-500 text-sm">
+              No videos match &ldquo;{debouncedQuery}&rdquo;
+            </div>
+          )}
+
+          {!loading && !error && filteredVideos.map((video) => (
+            <VideoCard key={video.id} video={video} query={debouncedQuery} />
+          ))}
         </div>
 
         {/* Ingest dialog */}

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -200,7 +200,13 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
 
   const q = debouncedQuery.trim().toLowerCase();
   const filteredVideos = q
-    ? videos.filter((v) => (v.title ?? '').toLowerCase().includes(q))
+    ? videos.filter((v) =>
+        [v.title, v.channel_title, v.description]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+          .includes(q),
+      )
     : videos;
 
   return (
@@ -222,7 +228,9 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
             <h2 className="m-0 text-base font-semibold text-slate-100">Video Library</h2>
             {!loading && videos.length > 0 && (
               <p className="mt-0.5 text-xs text-slate-400">
-                {videos.length} videos in knowledge base
+                {q
+                  ? `${filteredVideos.length} of ${videos.length} videos`
+                  : `${videos.length} videos in knowledge base`}
               </p>
             )}
           </div>

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -189,9 +189,7 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
   }, [isOpen, onClose]);
 
   const filteredVideos = debouncedQuery.trim()
-    ? videos.filter((v) =>
-        v.title.toLowerCase().includes(debouncedQuery.trim().toLowerCase())
-      )
+    ? videos.filter((v) => v.title.toLowerCase().includes(debouncedQuery.trim().toLowerCase()))
     : videos;
 
   return (
@@ -317,9 +315,11 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
             </div>
           )}
 
-          {!loading && !error && filteredVideos.map((video) => (
-            <VideoCard key={video.id} video={video} query={debouncedQuery} />
-          ))}
+          {!loading &&
+            !error &&
+            filteredVideos.map((video) => (
+              <VideoCard key={video.id} video={video} query={debouncedQuery} />
+            ))}
         </div>
 
         {/* Ingest dialog */}


### PR DESCRIPTION
## Linked issue

Fixes #191

## Summary

Adds a debounced search bar to the user-facing Video Library panel (`VideoExplorer.tsx`) so viewers can filter the video list by title. Matching substrings are highlighted inline.

## How this solves the issue

Issue #191 reported that the Video Library panel had no way to search or filter videos — users had to scroll through the entire list. This PR adds a `<input type="search">` field above the video grid that:

1. Filters `videos` client-side using case-insensitive title matching
2. Debounces the query at 250ms (matching the existing Sidebar conversation-search pattern) to avoid redundant re-renders on every keystroke
3. Highlights the matched substring in each card title via a `highlightMatch` helper (mirrors `Sidebar.tsx:highlightMatch`)
4. Shows a "No videos match …" empty state when the query returns no results, distinct from the "No videos yet" empty-library state

## Test plan

- [x] `VideoExplorer.test.tsx` — existing tests cover loading, error, and empty-library states; confirmed all 111 tests pass
- [x] `VideoExplorer-admin-gate.test.tsx` — admin-only gating unaffected; tests pass
- [x] Type check (`bun run tsc --noEmit`) — exit 0, no errors
- [x] Biome lint/format (`bun x biome check src`) — exit 0 after auto-formatting 40 pre-existing CRLF files

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

## Dependencies

No new dependencies added.

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (additions + deletions)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit