### PR TITLE
feat: gated Dynamous content + Circle membership verification (#147)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF on shell scripts and Dockerfile so they work on Linux when this
+# repo is checked out on Windows. Without this rule, Windows' default CRLF
+# would break `bash` on the VPS.
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.dockerfile text eol=lf

--- a/app/backend/alembic/versions/0005_gated_dynamous_content.py
+++ b/app/backend/alembic/versions/0005_gated_dynamous_content.py
@@ -1,0 +1,97 @@
+"""Add multi-source-type support to videos/chunks + Circle membership flag on users.
+
+Schema changes for issue #147 (gated Dynamous content):
+- videos: source_type, content_hash, content_path, lesson_url, metadata
+- chunks: source_type (denormalized for fast ACL filtering)
+- users: is_member, member_verified_at
+
+The `videos` table stays named `videos` (no rename) — the new columns let it hold
+both YouTube and Dynamous course/workshop sources. New columns use safe defaults so
+existing rows upgrade in-place.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-25
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # --- videos: multi-source-type support -------------------------------
+    # source_type discriminates YouTube vs Dynamous content. Existing rows
+    # default to 'youtube' which is correct since pre-#147 only YouTube was
+    # ingested.
+    op.execute(
+        """
+        ALTER TABLE videos
+        ADD COLUMN IF NOT EXISTS source_type TEXT NOT NULL DEFAULT 'youtube',
+        ADD COLUMN IF NOT EXISTS content_hash TEXT,
+        ADD COLUMN IF NOT EXISTS content_path TEXT,
+        ADD COLUMN IF NOT EXISTS lesson_url TEXT,
+        ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS videos_content_path_idx "
+        "ON videos (content_path)"
+    )
+
+    # --- chunks: denormalize source_type for fast ACL filtering ----------
+    # Default 'youtube' is correct for existing rows (all pre-#147 chunks
+    # were embedded from YouTube transcripts).
+    op.execute(
+        """
+        ALTER TABLE chunks
+        ADD COLUMN IF NOT EXISTS source_type TEXT NOT NULL DEFAULT 'youtube'
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS chunks_source_type_idx "
+        "ON chunks (source_type)"
+    )
+
+    # --- users: Circle membership tracking -------------------------------
+    op.execute(
+        """
+        ALTER TABLE users
+        ADD COLUMN IF NOT EXISTS is_member BOOLEAN NOT NULL DEFAULT FALSE,
+        ADD COLUMN IF NOT EXISTS member_verified_at TIMESTAMPTZ
+        """
+    )
+
+
+def downgrade() -> None:
+    # Reverse in dependency order: drop indexes before columns
+    op.execute("DROP INDEX IF EXISTS chunks_source_type_idx")
+    op.execute("DROP INDEX IF EXISTS videos_content_path_idx")
+
+    op.execute(
+        """
+        ALTER TABLE users
+        DROP COLUMN IF EXISTS member_verified_at,
+        DROP COLUMN IF EXISTS is_member
+        """
+    )
+
+    op.execute("ALTER TABLE chunks DROP COLUMN IF EXISTS source_type")
+
+    op.execute(
+        """
+        ALTER TABLE videos
+        DROP COLUMN IF EXISTS metadata,
+        DROP COLUMN IF EXISTS lesson_url,
+        DROP COLUMN IF EXISTS content_path,
+        DROP COLUMN IF EXISTS content_hash,
+        DROP COLUMN IF EXISTS source_type
+        """
+    )

--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -65,6 +65,24 @@ if not ADMIN_USER_EMAIL:
         file=sys.stderr,
     )
 
+# Circle membership verification (issue #147). Without these, paid-content
+# gating fails closed — every user is treated as a non-member and only sees
+# YouTube chunks. The app keeps working; users just don't see Dynamous course
+# content until the env is configured.
+CIRCLE_ADMIN_TOKEN: str = os.environ.get("CIRCLE_ADMIN_TOKEN", "")
+CIRCLE_PAID_ACCESS_GROUP_ID: int = int(os.environ.get("CIRCLE_PAID_ACCESS_GROUP_ID", "0") or "0")
+if not CIRCLE_ADMIN_TOKEN or not CIRCLE_PAID_ACCESS_GROUP_ID:
+    print(
+        "WARNING: Circle membership verification disabled "
+        "(CIRCLE_ADMIN_TOKEN or CIRCLE_PAID_ACCESS_GROUP_ID missing). "
+        "All users will be treated as non-members.",
+        file=sys.stderr,
+    )
+
+# Membership refresh staleness window. /me re-verifies a user against Circle
+# when member_verified_at is NULL or older than this many seconds.
+MEMBERSHIP_REFRESH_SECONDS: int = int(os.environ.get("MEMBERSHIP_REFRESH_SECONDS", "3600"))
+
 OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
 EMBEDDING_MODEL: str = "openai/text-embedding-3-small"
 CHAT_MODEL: str = "anthropic/claude-sonnet-4.6"

--- a/app/backend/db/postgres.py
+++ b/app/backend/db/postgres.py
@@ -19,6 +19,26 @@ logger = logging.getLogger(__name__)
 _pool: asyncpg.Pool | None = None
 
 
+async def _init_connection(conn: asyncpg.Connection) -> None:
+    """Per-connection setup run by asyncpg before the pool hands it to a caller.
+
+    Currently sets pgvector's iterative-scan mode to `relaxed_order`. Without
+    this, filtered ANN queries (chunks WHERE source_type IN (...)) silently
+    fall back to exact scan and lose the HNSW index speedup. See pgvector
+    0.8.0 release notes. Failing this SET should not crash the app — older
+    pgvector versions don't have the GUC, and the fallback (exact scan) is
+    correct, just slower.
+    """
+    try:
+        await conn.execute("SET hnsw.iterative_scan = 'relaxed_order'")
+    except asyncpg.PostgresError as exc:
+        logger.warning(
+            "Could not set hnsw.iterative_scan (pgvector < 0.8.0?): %s; "
+            "filtered ANN queries will fall back to exact scan",
+            exc,
+        )
+
+
 async def init_pg_pool() -> asyncpg.Pool:
     """Create the asyncpg pool if not already created. Idempotent."""
     global _pool
@@ -31,6 +51,7 @@ async def init_pg_pool() -> asyncpg.Pool:
         dsn=DATABASE_URL,
         min_size=1,
         max_size=10,
+        init=_init_connection,
     )
     logger.info("Postgres pool ready.")
     return _pool

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -237,7 +237,12 @@ async def count_chunks() -> int:
 # ---------------------------------------------------------------------------
 
 
-async def keyword_search(query: str, top_k: int, language: str = "english") -> list[dict]:
+async def keyword_search(
+    query: str,
+    top_k: int,
+    language: str = "english",
+    allowed_source_types: list[str] | None = None,
+) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
 
@@ -245,11 +250,17 @@ async def keyword_search(query: str, top_k: int, language: str = "english") -> l
         query: Raw user query string (plainto_tsquery handles escaping)
         top_k: Maximum results to return
         language: tsvector language config (default 'english')
+        allowed_source_types: ACL filter — chunks whose source_type is not in
+            this list are excluded. Defaults to ['youtube'] which is the
+            backwards-compatible behavior for callers that don't yet know
+            about Dynamous content (issue #147).
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
         start_seconds, end_seconds, snippet, rank (ts_rank score)
     """
+    if allowed_source_types is None:
+        allowed_source_types = ["youtube"]
     async with _acquire() as conn:
         rows = await conn.fetch(
             """
@@ -257,16 +268,22 @@ async def keyword_search(query: str, top_k: int, language: str = "english") -> l
                    ts_rank(search_vector, plainto_tsquery($1)) AS rank
             FROM chunks
             WHERE search_vector @@ plainto_tsquery($1)
+              AND source_type = ANY($3::text[])
             ORDER BY rank DESC
             LIMIT $2
             """,
             query,
             top_k,
+            allowed_source_types,
         )
     return [dict(r) for r in rows]
 
 
-async def vector_search_pg(query_embedding: list[float], top_k: int) -> list[dict]:
+async def vector_search_pg(
+    query_embedding: list[float],
+    top_k: int,
+    allowed_source_types: list[str] | None = None,
+) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
 
@@ -278,11 +295,18 @@ async def vector_search_pg(query_embedding: list[float], top_k: int) -> list[dic
     Args:
         query_embedding: List of 1536 floats (text-embedding-3-small dimensions)
         top_k: Maximum results to return
+        allowed_source_types: ACL filter — chunks whose source_type is not in
+            this list are excluded. Defaults to ['youtube'] for backwards
+            compatibility (issue #147). The pool's `hnsw.iterative_scan =
+            relaxed_order` setting (see db/postgres.py) keeps the HNSW index
+            usable under this filter.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
         start_seconds, end_seconds, snippet, distance (cosine distance)
     """
+    if allowed_source_types is None:
+        allowed_source_types = ["youtube"]
     embedding_json = json.dumps(query_embedding)
     async with _acquire() as conn:
         rows = await conn.fetch(
@@ -290,11 +314,13 @@ async def vector_search_pg(query_embedding: list[float], top_k: int) -> list[dic
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
+            WHERE source_type = ANY($3::text[])
             ORDER BY distance
             LIMIT $2
             """,
             embedding_json,
             top_k,
+            allowed_source_types,
         )
     return [dict(r) for r in rows]
 

--- a/app/backend/db/users_repo.py
+++ b/app/backend/db/users_repo.py
@@ -55,7 +55,8 @@ async def get_user_by_email(email: str) -> dict[str, Any] | None:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT id, email, password_hash, created_at, last_login_at
+            SELECT id, email, password_hash, created_at, last_login_at,
+                   is_member, member_verified_at
             FROM users
             WHERE email = $1
             """,
@@ -70,7 +71,8 @@ async def get_user_by_id(user_id: UUID | str) -> dict[str, Any] | None:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT id, email, created_at, last_login_at
+            SELECT id, email, created_at, last_login_at,
+                   is_member, member_verified_at
             FROM users
             WHERE id = $1
             """,
@@ -87,3 +89,37 @@ async def update_last_login(user_id: UUID | str) -> None:
             "UPDATE users SET last_login_at = now() WHERE id = $1",
             UUID(str(user_id)) if not isinstance(user_id, UUID) else user_id,
         )
+
+
+async def set_member_status(
+    user_id: UUID | str,
+    *,
+    is_member: bool,
+    conn: asyncpg.Connection | None = None,
+) -> None:
+    """Set is_member and stamp member_verified_at = now().
+
+    Called from the auth routes after each Circle verification (signup, login,
+    or /me refresh). Optional `conn` lets the caller run this inside an
+    in-flight transaction so the user insert and the membership stamp commit
+    atomically.
+    """
+    uid = UUID(str(user_id)) if not isinstance(user_id, UUID) else user_id
+
+    async def _do(c: asyncpg.Connection) -> None:
+        await c.execute(
+            """
+            UPDATE users
+            SET is_member = $2, member_verified_at = now()
+            WHERE id = $1
+            """,
+            uid,
+            is_member,
+        )
+
+    if conn is not None:
+        await _do(conn)
+        return
+    pool = get_pg_pool()
+    async with pool.acquire() as new_conn:
+        await _do(new_conn)

--- a/app/backend/ingest/dynamous.py
+++ b/app/backend/ingest/dynamous.py
@@ -1,0 +1,279 @@
+"""Ingester for paid Dynamous course/workshop transcripts (issue #147).
+
+Walks a directory of markdown files (output of `scripts/transcribe_all.py`),
+parses YAML-style frontmatter + `## [HH:MM:SS]` segment headings, and upserts
+into the existing `videos` + `chunks` tables with `source_type='dynamous'`.
+
+Idempotent: each source row stores a SHA-256 of the markdown body. Re-running
+ingest skips files whose hash matches what's already in the DB.
+
+Expected file format::
+
+    ---
+    title: "Module 5: Building a Complete Front End"
+    course_slug: module-1
+    section_id: 570048
+    lesson_id: 2274637
+    lesson_url: https://community.dynamous.ai/c/module-1/sections/570048/lessons/2274637
+    source_type: dynamous
+    ---
+
+    ## [00:00:00] Intro
+
+    Welcome to module five...
+
+    ## [00:02:15] Architecture overview
+
+    The agent has three layers...
+
+The ingester runs at app startup (see `backend.main`) so transcripts that
+landed in the volume during deploy are picked up automatically. Failures are
+logged but never crash the app — DynaChat keeps working with whatever it has.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from backend.db.postgres import get_pg_pool
+from backend.rag.chunker import chunk_video_timestamped
+from backend.rag.embeddings import embed_text
+
+logger = logging.getLogger(__name__)
+
+
+# --- Frontmatter / timestamp parsing -----------------------------------------
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
+_TIMESTAMP_HEADING_RE = re.compile(
+    r"^##\s*\[(\d{1,2}):(\d{2}):(\d{2})\](?:\s+(.+))?$",
+    re.MULTILINE,
+)
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Split a markdown file into (frontmatter dict, body).
+
+    Tolerates simple `key: value` and `key: "quoted value"` pairs. Numeric
+    values stay as strings; the caller coerces. Non-frontmatter files are
+    returned with an empty dict and the full text as body.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    fm_block, body = m.group(1), m.group(2)
+    fm: dict[str, Any] = {}
+    for line in fm_block.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, raw_value = line.partition(":")
+        value = raw_value.strip().strip('"').strip("'")
+        fm[key.strip()] = value
+    return fm, body
+
+
+def _parse_segments(body: str) -> list[dict[str, Any]]:
+    """Convert a body with `## [HH:MM:SS] heading` markers into segments.
+
+    Each segment is `{start, end, text, heading}`. The end of a segment is the
+    start of the next; the last segment runs to the end of the file (its
+    `end_seconds` is filled in by the caller using duration heuristics).
+    """
+    matches = list(_TIMESTAMP_HEADING_RE.finditer(body))
+    if not matches:
+        # No timestamp markers — treat the whole body as one segment.
+        clean = body.strip()
+        if not clean:
+            return []
+        return [{"start": 0.0, "end": 0.0, "text": clean, "heading": ""}]
+
+    segments: list[dict[str, Any]] = []
+    for i, m in enumerate(matches):
+        h, mm, ss = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        start = h * 3600 + mm * 60 + ss
+        heading = (m.group(4) or "").strip()
+        text_start = m.end()
+        text_end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        text = body[text_start:text_end].strip()
+        if not text:
+            continue
+        if heading:
+            text = f"{heading}\n\n{text}"
+        end = (
+            int(matches[i + 1].group(1)) * 3600
+            + int(matches[i + 1].group(2)) * 60
+            + int(matches[i + 1].group(3))
+            if i + 1 < len(matches)
+            else float(start)  # filler — caller may override
+        )
+        segments.append({"start": float(start), "end": float(end), "text": text, "heading": heading})
+    # The last segment's end_seconds = start_seconds (we don't know duration);
+    # acceptable since the chunker preserves both for citation rendering.
+    return segments
+
+
+# --- Public entry point ------------------------------------------------------
+
+
+def _hash_body(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+async def ingest_dynamous_content(content_dir: Path) -> dict[str, int]:
+    """Walk *content_dir* and upsert all `*.md` transcripts.
+
+    Returns a counts dict: `{scanned, unchanged, ingested, errors}`.
+
+    Idempotent on no-content-change: re-running with no file changes is a
+    pure read-only sweep (one SELECT per file).
+    """
+    counts = {"scanned": 0, "unchanged": 0, "ingested": 0, "errors": 0}
+    if not content_dir.exists():
+        logger.info("Dynamous content dir %s does not exist — skipping ingest", content_dir)
+        return counts
+
+    pool = get_pg_pool()
+    for md_path in sorted(content_dir.rglob("*.md")):
+        counts["scanned"] += 1
+        rel_path = str(md_path.relative_to(content_dir))
+        try:
+            await _ingest_one_file(md_path, rel_path, pool, counts)
+        except Exception:
+            counts["errors"] += 1
+            logger.exception("Failed to ingest %s", rel_path)
+
+    logger.info(
+        "Dynamous ingest complete: scanned=%d unchanged=%d ingested=%d errors=%d",
+        counts["scanned"],
+        counts["unchanged"],
+        counts["ingested"],
+        counts["errors"],
+    )
+    return counts
+
+
+async def _ingest_one_file(
+    md_path: Path, rel_path: str, pool: Any, counts: dict[str, int]
+) -> None:
+    """Process one transcript file. Idempotent."""
+    text = md_path.read_text(encoding="utf-8")
+    fm, body = _parse_frontmatter(text)
+    body_hash = _hash_body(body)
+
+    title = fm.get("title", md_path.stem)
+    lesson_url = fm.get("lesson_url", "")
+    # course_slug stays inside metadata — we don't surface it as a top-level
+    # column on `videos` (the existing schema doesn't have one) but the JSON
+    # blob preserves it for future reporting / reverse lookups.
+    metadata = {k: v for k, v in fm.items() if k not in {"title", "lesson_url"}}
+
+    async with pool.acquire() as conn:
+        existing = await conn.fetchrow(
+            """
+            SELECT id, content_hash
+            FROM videos
+            WHERE content_path = $1 AND source_type = 'dynamous'
+            LIMIT 1
+            """,
+            rel_path,
+        )
+
+        if existing and existing["content_hash"] == body_hash:
+            counts["unchanged"] += 1
+            return
+
+        # Need to (re)chunk and (re)embed.
+        segments = _parse_segments(body)
+        if not segments:
+            logger.warning("No content extracted from %s; skipping", rel_path)
+            return
+
+        chunks, _ = chunk_video_timestamped(segments)
+        if not chunks:
+            logger.warning("Chunker returned 0 chunks for %s; skipping", rel_path)
+            return
+
+        # Embed each chunk's content. Sequential — modest # of chunks per
+        # transcript; OpenRouter handles rate limiting fine and sequential
+        # keeps error attribution simple.
+        embeddings: list[list[float]] = []
+        for ch in chunks:
+            embeddings.append(embed_text(ch["content"]))
+
+        async with conn.transaction():
+            if existing:
+                # Replace: drop old chunks, update source row.
+                video_id = str(existing["id"])
+                await conn.execute("DELETE FROM chunks WHERE video_id = $1", video_id)
+                await conn.execute(
+                    """
+                    UPDATE videos
+                    SET title = $2,
+                        lesson_url = $3,
+                        content_hash = $4,
+                        metadata = $5::jsonb
+                    WHERE id = $1
+                    """,
+                    video_id,
+                    title,
+                    lesson_url,
+                    body_hash,
+                    json.dumps(metadata),
+                )
+            else:
+                video_id = str(uuid4())
+                await conn.execute(
+                    """
+                    INSERT INTO videos (
+                        id, title, description, url, transcript,
+                        source_type, content_hash, content_path, lesson_url, metadata
+                    )
+                    VALUES (
+                        $1, $2, '', '', '',
+                        'dynamous', $3, $4, $5, $6::jsonb
+                    )
+                    """,
+                    video_id,
+                    title,
+                    body_hash,
+                    rel_path,
+                    lesson_url,
+                    json.dumps(metadata),
+                )
+
+            for idx, (ch, emb) in enumerate(zip(chunks, embeddings, strict=True)):
+                await conn.execute(
+                    """
+                    INSERT INTO chunks (
+                        id, video_id, content, embedding, chunk_index,
+                        start_seconds, end_seconds, snippet, source_type
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5,
+                        $6, $7, $8, 'dynamous'
+                    )
+                    """,
+                    str(uuid4()),
+                    video_id,
+                    ch["content"],
+                    json.dumps(emb),
+                    idx,
+                    float(ch.get("start_seconds", 0.0)),
+                    float(ch.get("end_seconds", 0.0)),
+                    str(ch.get("snippet", ""))[:300],
+                )
+
+        counts["ingested"] += 1
+        logger.info("Ingested %s (%d chunks)", rel_path, len(chunks))
+
+
+__all__ = ["ingest_dynamous_content"]

--- a/app/backend/ingest/dynamous.py
+++ b/app/backend/ingest/dynamous.py
@@ -52,7 +52,11 @@ logger = logging.getLogger(__name__)
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
 _TIMESTAMP_HEADING_RE = re.compile(
-    r"^##\s*\[(\d{1,2}):(\d{2}):(\d{2})\](?:\s+(.+))?$",
+    # The trailing optional-heading group uses `[ \t]+([^\n]+)` (NOT `\s+(.+)`)
+    # because `\s` matches newlines and would happily eat the body content of
+    # the segment as the "heading", leaving an empty body for the chunker.
+    # Anchoring to a single line is required.
+    r"^##[ \t]*\[(\d{1,2}):(\d{2}):(\d{2})\](?:[ \t]+([^\n]+))?[ \t]*$",
     re.MULTILINE,
 )
 

--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -1,0 +1,115 @@
+"""Circle Admin v2 API client for paid-membership verification.
+
+Used by `routes/auth.py` to set the `users.is_member` flag on signup, login,
+and `/me` refresh. Per issue #147 spec:
+
+- 5-second timeout (Circle API is fast; long waits would block auth flow).
+- **Fail-closed**: any error — timeout, network failure, non-2xx response,
+  unexpected JSON shape, missing config — returns False. Users default to
+  non-member status; the next /me refresh retries.
+- The function never raises; callers can call it unconditionally.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from backend.config import CIRCLE_ADMIN_TOKEN, CIRCLE_PAID_ACCESS_GROUP_ID
+
+logger = logging.getLogger(__name__)
+
+CIRCLE_BASE = "https://app.circle.so/api/admin/v2"
+TIMEOUT_SECONDS = 5.0
+
+
+async def verify_paid_member(email: str) -> bool:
+    """Return True iff *email* belongs to an active Circle member in the paid access group.
+
+    Fail-closed: any error path returns False with a warning log. Callers should
+    rely on this never throwing.
+    """
+    if not CIRCLE_ADMIN_TOKEN or not CIRCLE_PAID_ACCESS_GROUP_ID:
+        # Config not set — silently treat everyone as non-member. The startup
+        # warning in config.py already flagged this once.
+        return False
+
+    if not email:
+        return False
+
+    headers = {
+        "Authorization": f"Token {CIRCLE_ADMIN_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS, headers=headers) as client:
+            # Step 1: look up the member by email
+            r = await client.get(
+                f"{CIRCLE_BASE}/community_members/search",
+                params={"email": email},
+            )
+            if r.status_code == 404:
+                # Not a Circle member at all — ordinary case, no log spam.
+                return False
+            if r.status_code != 200:
+                logger.warning(
+                    "Circle member search returned %s for email; fail-closed",
+                    r.status_code,
+                )
+                return False
+
+            member = _extract_member(r.json())
+            if member is None:
+                return False
+            if not member.get("active", True):
+                # Inactive members lose access immediately.
+                return False
+            member_id = member.get("id")
+            if not member_id:
+                logger.warning("Circle member search response missing id; fail-closed")
+                return False
+
+            # Step 2: confirm the member is in the paid access group
+            r2 = await client.get(
+                f"{CIRCLE_BASE}/community_members/{member_id}/access_groups"
+            )
+            if r2.status_code != 200:
+                logger.warning(
+                    "Circle access_groups returned %s for member %s; fail-closed",
+                    r2.status_code,
+                    member_id,
+                )
+                return False
+
+            groups = r2.json().get("records") or []
+            return any(int(g.get("id", 0)) == CIRCLE_PAID_ACCESS_GROUP_ID for g in groups)
+
+    except httpx.TimeoutException:
+        logger.warning("Circle API timed out verifying email; fail-closed")
+        return False
+    except httpx.HTTPError as exc:
+        logger.warning("Circle API HTTP error verifying email: %s; fail-closed", exc)
+        return False
+    except (KeyError, ValueError, TypeError) as exc:
+        logger.warning("Circle API response shape unexpected: %s; fail-closed", exc)
+        return False
+
+
+def _extract_member(body: Any) -> dict[str, Any] | None:
+    """Normalize the search response shape.
+
+    Circle's `/community_members/search` historically returned the member object
+    directly. Newer responses sometimes wrap in `records`. Handle both.
+    """
+    if isinstance(body, dict):
+        if "id" in body:
+            return body
+        recs = body.get("records") if isinstance(body.get("records"), list) else None
+        if recs:
+            first = recs[0]
+            if isinstance(first, dict):
+                return first
+    return None

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -68,6 +68,21 @@ async def lifespan(app: FastAPI):
 
     logger.info("Checking seed data…")
     await seed_if_empty()
+
+    # Ingest paid Dynamous course/workshop transcripts (issue #147). The
+    # private `dynamous-content` repo is git-cloned into the container at
+    # deploy time; this picks up whatever is on disk. Idempotent — files
+    # whose SHA matches what's in the DB are skipped. Failures here never
+    # crash startup; YouTube content keeps working regardless.
+    try:
+        from backend.ingest.dynamous import ingest_dynamous_content
+
+        content_dir = Path(os.environ.get("DYNAMOUS_CONTENT_DIR", "/app/content/dynamous"))
+        counts = await ingest_dynamous_content(content_dir)
+        logger.info("Dynamous ingest counts: %s", counts)
+    except Exception:
+        logger.exception("Dynamous content ingest failed; continuing without it")
+
     logger.info("Startup complete.")
     yield
     logger.info("Shutting down.")

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -39,6 +39,7 @@ async def retrieve_hybrid(
     query_text: str,
     query_embedding: list[float],
     top_k: int = 5,
+    is_member: bool = False,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -47,6 +48,10 @@ async def retrieve_hybrid(
         query_text: Original user query string (used for keyword search)
         query_embedding: Query embedding from embed_text() (used for vector search)
         top_k: Maximum number of results to return (default 5)
+        is_member: If True, paid Dynamous course/workshop content (`source_type
+            = 'dynamous'`) is included alongside the default YouTube content.
+            Non-members see YouTube chunks only. The filter is applied at the
+            SQL layer — non-member retrieval never touches Dynamous chunks.
 
     Returns:
         A list of dicts (length <= top_k), each containing:
@@ -72,12 +77,23 @@ async def retrieve_hybrid(
             "Use the VPS snapshot database via SSH tunnel for local dev."
         )
 
+    allowed_source_types = ["youtube", "dynamous"] if is_member else ["youtube"]
+
     # Over-fetch factor — each method returns 2*top_k before merging
     fetch_k = top_k * HYBRID_OVERFETCH_FACTOR
 
     # Run keyword and vector searches concurrently
-    keyword_task = repository.keyword_search(query_text, top_k=fetch_k, language=KEYWORD_LANGUAGE)
-    vector_task = repository.vector_search_pg(query_embedding, top_k=fetch_k)
+    keyword_task = repository.keyword_search(
+        query_text,
+        top_k=fetch_k,
+        language=KEYWORD_LANGUAGE,
+        allowed_source_types=allowed_source_types,
+    )
+    vector_task = repository.vector_search_pg(
+        query_embedding,
+        top_k=fetch_k,
+        allowed_source_types=allowed_source_types,
+    )
 
     keyword_hits, vector_hits = await keyword_task, await vector_task
 
@@ -94,7 +110,9 @@ async def retrieve_hybrid(
     # RRF merge
     merged = _rrf_merge(keyword_hits, vector_hits, k=HYBRID_K_CONSTANT, top_k=top_k)
 
-    # Hydrate with video metadata (title, url) via cached lookups
+    # Hydrate with video metadata (title, url, source_type, lesson_url) via
+    # cached lookups. source_type + lesson_url drive the frontend citation
+    # rendering split — YouTube uses url+timestamp, Dynamous uses lesson_url.
     results: list[dict] = []
     for chunk in merged:
         video_id = chunk["video_id"]
@@ -102,8 +120,10 @@ async def retrieve_hybrid(
             video = await repository.get_video(video_id)
             if video:
                 _video_cache[video_id] = {
-                    "title": video["title"],
-                    "url": video["url"],
+                    "title": video.get("title", ""),
+                    "url": video.get("url", "") or "",
+                    "source_type": video.get("source_type", "youtube") or "youtube",
+                    "lesson_url": video.get("lesson_url", "") or "",
                 }
             else:
                 logger.warning(
@@ -111,7 +131,12 @@ async def retrieve_hybrid(
                     video_id,
                     chunk.get("id", "?"),
                 )
-                _video_cache[video_id] = {"title": "Unknown Video", "url": ""}
+                _video_cache[video_id] = {
+                    "title": "Unknown Video",
+                    "url": "",
+                    "source_type": "youtube",
+                    "lesson_url": "",
+                }
 
         video_meta = _video_cache[video_id]
         results.append(
@@ -121,6 +146,8 @@ async def retrieve_hybrid(
                 "video_id": video_id,
                 "video_title": video_meta["title"],
                 "video_url": video_meta["url"],
+                "source_type": video_meta["source_type"],
+                "lesson_url": video_meta["lesson_url"],
                 "start_seconds": chunk.get("start_seconds", 0.0),
                 "end_seconds": chunk.get("end_seconds", 0.0),
                 "snippet": chunk.get("snippet", ""),

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -184,7 +184,9 @@ async def _hydrate_chunks(raw_chunks: list[dict]) -> list[dict]:
         info = video or {}
         return vid, {
             "title": info.get("title", "Unknown Video"),
-            "url": info.get("url", ""),
+            "url": info.get("url", "") or "",
+            "source_type": info.get("source_type", "youtube") or "youtube",
+            "lesson_url": info.get("lesson_url", "") or "",
         }
 
     video_cache: dict[str, dict[str, str]] = dict(
@@ -198,6 +200,8 @@ async def _hydrate_chunks(raw_chunks: list[dict]) -> list[dict]:
             "video_id": c.get("video_id", ""),
             "video_title": video_cache.get(c.get("video_id", ""), {}).get("title", "Unknown Video"),
             "video_url": video_cache.get(c.get("video_id", ""), {}).get("url", ""),
+            "source_type": video_cache.get(c.get("video_id", ""), {}).get("source_type", "youtube"),
+            "lesson_url": video_cache.get(c.get("video_id", ""), {}).get("lesson_url", ""),
             "start_seconds": c.get("start_seconds", 0.0),
             "end_seconds": c.get("end_seconds", 0.0),
             "snippet": c.get("snippet", ""),
@@ -238,6 +242,8 @@ _CANONICAL_CHUNK_KEYS = (
     "video_id",
     "video_title",
     "video_url",
+    "source_type",
+    "lesson_url",
     "start_seconds",
     "end_seconds",
     "snippet",
@@ -393,6 +399,7 @@ async def _embed_query(query: str, cache: dict[str, list[float]] | None) -> list
 async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
+    is_member: bool = False,
 ) -> dict[str, Any]:
     """Hybrid (keyword + semantic via RRF) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -408,7 +415,7 @@ async def execute_search_hybrid(
 
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k)
+        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -419,7 +426,10 @@ async def execute_search_hybrid(
     return {"ok": True, "text": _format_search_results(chunks), "chunks": chunks}
 
 
-async def execute_search_keyword(raw_arguments: str | dict) -> dict[str, Any]:
+async def execute_search_keyword(
+    raw_arguments: str | dict,
+    is_member: bool = False,
+) -> dict[str, Any]:
     """Keyword-only (tsvector FTS) search."""
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
 
@@ -431,8 +441,15 @@ async def execute_search_keyword(raw_arguments: str | dict) -> dict[str, Any]:
         return {"ok": False, "error": "missing required parameter: query"}
     top_k = _clamp_top_k(args.get("top_k"))
 
+    allowed = ["youtube", "dynamous"] if is_member else ["youtube"]
+
     try:
-        raw = await repository.keyword_search(query, top_k=top_k, language=KEYWORD_LANGUAGE)
+        raw = await repository.keyword_search(
+            query,
+            top_k=top_k,
+            language=KEYWORD_LANGUAGE,
+            allowed_source_types=allowed,
+        )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
         logger.warning("search_keyword failed: %s", exc, exc_info=True)
@@ -447,6 +464,7 @@ async def execute_search_keyword(raw_arguments: str | dict) -> dict[str, Any]:
 async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
+    is_member: bool = False,
 ) -> dict[str, Any]:
     """Semantic-only (pgvector cosine) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -459,9 +477,13 @@ async def execute_search_semantic(
         return {"ok": False, "error": "missing required parameter: query"}
     top_k = _clamp_top_k(args.get("top_k"))
 
+    allowed = ["youtube", "dynamous"] if is_member else ["youtube"]
+
     try:
         embedding = await _embed_query(query, embedding_cache)
-        raw = await repository.vector_search_pg(embedding, top_k=top_k)
+        raw = await repository.vector_search_pg(
+            embedding, top_k=top_k, allowed_source_types=allowed
+        )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
         logger.warning("search_semantic failed: %s", exc, exc_info=True)
@@ -476,9 +498,14 @@ async def execute_search_semantic(
 async def execute_get_video_transcript(
     raw_arguments: str | dict,
     video_id_whitelist: set[str] | None = None,
+    is_member: bool = False,
 ) -> dict[str, Any]:
     """Full transcript of one video. video_id_whitelist guards against the
-    model hallucinating ids; None disables the check (tests)."""
+    model hallucinating ids; None disables the check (tests).
+
+    Defense-in-depth: a non-member who somehow guesses a Dynamous video_id
+    is blocked here in addition to the search-layer filter.
+    """
     args = _parse_args(raw_arguments)
     if args is None:
         return {"ok": False, "error": "invalid JSON arguments"}
@@ -502,6 +529,12 @@ async def execute_get_video_transcript(
         logger.warning("get_video_transcript: get_video failed for %s: %s", video_id, exc)
         return {"ok": False, "error": f"failed to look up video: {exc}"}
     if not video:
+        return {"ok": False, "error": f"video not found: {video_id}"}
+
+    # Defense-in-depth ACL: non-members cannot pull Dynamous transcripts even
+    # if they somehow obtained the video_id. The search layer should already
+    # have filtered these out — this is the belt to that suspenders.
+    if not is_member and video.get("source_type") == "dynamous":
         return {"ok": False, "error": f"video not found: {video_id}"}
 
     try:
@@ -545,22 +578,30 @@ async def execute_tool(
     raw_arguments: str | dict,
     video_id_whitelist: set[str] | None = None,
     embedding_cache: dict[str, list[float]] | None = None,
+    is_member: bool = False,
 ) -> dict[str, Any]:
     """Dispatch by tool name. Unknown names return an error dict so the
     model sees the refusal and stops calling.
 
     ``embedding_cache`` is optional per-turn memoization — if the same query
     text is passed to hybrid and semantic search in one turn, we embed once.
+
+    ``is_member`` controls retrieval ACL: True surfaces both YouTube and
+    Dynamous (paid) chunks; False sees YouTube only.
     """
     if name == "search_videos":
-        return await execute_search_hybrid(raw_arguments, embedding_cache=embedding_cache)
+        return await execute_search_hybrid(
+            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+        )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments)
+        return await execute_search_keyword(raw_arguments, is_member=is_member)
     if name == "semantic_search_videos":
-        return await execute_search_semantic(raw_arguments, embedding_cache=embedding_cache)
+        return await execute_search_semantic(
+            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+        )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(
-            raw_arguments, video_id_whitelist=video_id_whitelist
+            raw_arguments, video_id_whitelist=video_id_whitelist, is_member=is_member
         )
     return {"ok": False, "error": f"unknown tool: {name}"}
 

--- a/app/backend/routes/auth.py
+++ b/app/backend/routes/auth.py
@@ -9,6 +9,7 @@ gymnastics are required (see CLAUDE.md "Deployment").
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 import asyncpg
@@ -20,9 +21,10 @@ from backend import rate_limit, signup_rate_limit
 from backend.auth.dependencies import COOKIE_NAME, get_current_user, is_admin_email
 from backend.auth.password import hash_password, verify_password
 from backend.auth.tokens import encode_token
-from backend.config import JWT_EXPIRY_SECONDS
+from backend.config import JWT_EXPIRY_SECONDS, MEMBERSHIP_REFRESH_SECONDS
 from backend.db import users_repo
 from backend.db.postgres import get_pg_pool
+from backend.integrations import circle
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +60,7 @@ class MeResponse(BaseModel):
     id: str
     email: str
     is_admin: bool
+    is_member: bool
     messages_used_today: int
     messages_remaining_today: int
     rate_window_resets_at: str | None
@@ -163,6 +166,13 @@ async def signup(
 
         await signup_rate_limit.record(conn, ip=ip, email_attempted=body.email, outcome="accepted")
 
+    # Verify Circle membership AFTER the user-creation transaction commits.
+    # Holding a DB connection across an external HTTP call would block the
+    # pool for up to 5s. circle.verify_paid_member is fail-closed, never
+    # raises — failures default to is_member=False; next /me will retry.
+    is_member = await circle.verify_paid_member(body.email)
+    await users_repo.set_member_status(user["id"], is_member=is_member)
+
     _set_session_cookie(response, str(user["id"]))
     return _user_to_response(user)
 
@@ -176,6 +186,14 @@ async def login(body: LoginRequest, response: Response) -> UserResponse:
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password"
         )
     await users_repo.update_last_login(user["id"])
+
+    # Re-verify Circle membership on every login. circle.verify_paid_member
+    # is fail-closed (returns bool, never raises) so a Circle outage cannot
+    # break login — the user falls back to non-member until the next /me
+    # refresh resolves it.
+    is_member = await circle.verify_paid_member(body.email)
+    await users_repo.set_member_status(user["id"], is_member=is_member)
+
     _set_session_cookie(response, str(user["id"]))
     return _user_to_response(user)
 
@@ -195,13 +213,30 @@ async def logout() -> Response:
 
 @router.get("/me", response_model=MeResponse)
 async def me(user: dict[str, Any] = Depends(get_current_user)) -> MeResponse:
-    """Return the currently-authenticated user plus their daily quota counter."""
-    status = await rate_limit.get_status(user["id"])
+    """Return the currently-authenticated user plus their daily quota counter.
+
+    Also opportunistically re-verifies Circle membership when the cached
+    `member_verified_at` is older than `MEMBERSHIP_REFRESH_SECONDS`. This is
+    the path that flips a previously-failed Circle check (e.g. API outage at
+    login time) once Circle recovers, without requiring the user to log out
+    and back in.
+    """
+    is_member = bool(user.get("is_member") or False)
+    verified_at = user.get("member_verified_at")
+    needs_refresh = verified_at is None or (
+        (datetime.now(UTC) - verified_at).total_seconds() > MEMBERSHIP_REFRESH_SECONDS
+    )
+    if needs_refresh:
+        is_member = await circle.verify_paid_member(str(user["email"]))
+        await users_repo.set_member_status(user["id"], is_member=is_member)
+
+    rl_status = await rate_limit.get_status(user["id"])
     return MeResponse(
         id=str(user["id"]),
         email=str(user["email"]),
         is_admin=is_admin_email(str(user["email"])),
-        messages_used_today=status.used,
-        messages_remaining_today=status.remaining,
-        rate_window_resets_at=status.resets_at.isoformat() if status.resets_at else None,
+        is_member=is_member,
+        messages_used_today=rl_status.used,
+        messages_remaining_today=rl_status.remaining,
+        rate_window_resets_at=rl_status.resets_at.isoformat() if rl_status.resets_at else None,
     )

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -139,6 +139,11 @@ async def create_message(
             )
             video_id_whitelist = set()
 
+        # Captured at the start of the turn so the entire tool sequence sees
+        # consistent ACL — even if /me later flips is_member, the in-flight
+        # turn won't change behavior mid-flight.
+        is_member_for_turn = bool(current_user.get("is_member") or False)
+
         async def _executor(name: str, raw_args: str) -> str:
             # Pass `None` (not empty set) when the whitelist failed to load so
             # the transcript tool falls back to open lookups instead of rejecting
@@ -149,6 +154,7 @@ async def create_message(
                 raw_args,
                 video_id_whitelist=whitelist,
                 embedding_cache=embedding_cache,
+                is_member=is_member_for_turn,
             )
             if result.get("ok") and result.get("chunks"):
                 tool_chunks_acc.extend(result["chunks"])

--- a/app/backend/tests/test_auth.py
+++ b/app/backend/tests/test_auth.py
@@ -39,6 +39,8 @@ def fake_users_repo(monkeypatch):
             "password_hash": password_hash,
             "created_at": None,
             "last_login_at": None,
+            "is_member": False,
+            "member_verified_at": None,
         }
         store[uid] = row
         return {k: v for k, v in row.items() if k != "password_hash"}
@@ -61,12 +63,21 @@ def fake_users_repo(monkeypatch):
         if u:
             u["last_login_at"] = "now"
 
+    async def set_member_status(user_id: Any, *, is_member: bool, **kwargs: Any) -> None:
+        from datetime import UTC, datetime
+
+        u = store.get(str(user_id))
+        if u:
+            u["is_member"] = is_member
+            u["member_verified_at"] = datetime.now(UTC)
+
     from backend.db import users_repo
 
     monkeypatch.setattr(users_repo, "create_user", create_user)
     monkeypatch.setattr(users_repo, "get_user_by_email", get_user_by_email)
     monkeypatch.setattr(users_repo, "get_user_by_id", get_user_by_id)
     monkeypatch.setattr(users_repo, "update_last_login", update_last_login)
+    monkeypatch.setattr(users_repo, "set_member_status", set_member_status)
 
     # Patch auth.dependencies.users_repo.get_user_by_id too — it's imported as
     # `from backend.db import users_repo` so the module-level name is aliased.
@@ -80,6 +91,17 @@ def fake_users_repo(monkeypatch):
     monkeypatch.setattr(auth_route.users_repo, "create_user", create_user)
     monkeypatch.setattr(auth_route.users_repo, "get_user_by_email", get_user_by_email)
     monkeypatch.setattr(auth_route.users_repo, "update_last_login", update_last_login)
+    monkeypatch.setattr(auth_route.users_repo, "set_member_status", set_member_status)
+
+    # Stub Circle verification — default to False so existing tests pass without
+    # touching the network. Tests that exercise Circle behavior override this.
+    from backend.integrations import circle as circle_module
+
+    async def fake_verify(email: str) -> bool:
+        return False
+
+    monkeypatch.setattr(circle_module, "verify_paid_member", fake_verify)
+    monkeypatch.setattr(auth_route.circle, "verify_paid_member", fake_verify)
 
     return store
 

--- a/app/backend/tests/test_auth_circle.py
+++ b/app/backend/tests/test_auth_circle.py
@@ -1,0 +1,242 @@
+"""End-to-end-ish auth tests covering Circle membership flow.
+
+Reuses the in-memory fake_users_repo + stub_pg_lifecycle fixtures from
+test_auth.py via conftest's auto-discovery; we override `circle.verify_paid_member`
+per test to exercise the Member / non-Member / Circle-down branches.
+
+Acceptance criteria from issue #147 covered:
+- (3) signup with email NOT in Circle → user created, is_member=False on /me
+- (4) Circle outage during login → login still succeeds, /me reflects False
+- (8) returning user logs in → is_member updated based on current Circle state
+- /me opportunistic refresh after MEMBERSHIP_REFRESH_SECONDS (mocked to 0 here)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Standard secrets BEFORE app import.
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+
+# Reuse the fixtures from test_auth.py (pytest discovers them via conftest auto-loading
+# of files in the same directory tree). To make this file self-contained without
+# importing the fixture from a sibling test module, we redeclare the slim subset
+# we need here.
+
+
+@pytest.fixture(autouse=True)
+def fake_users_repo(monkeypatch):
+    from uuid import uuid4
+
+    store: dict[str, dict[str, Any]] = {}
+
+    async def create_user(email: str, password_hash: str, **kwargs: Any) -> dict[str, Any]:
+        import asyncpg
+
+        for u in store.values():
+            if str(u["email"]).lower() == email.lower():
+                raise asyncpg.UniqueViolationError("duplicate email")
+        uid = str(uuid4())
+        row = {
+            "id": uid,
+            "email": email,
+            "password_hash": password_hash,
+            "created_at": None,
+            "last_login_at": None,
+            "is_member": False,
+            "member_verified_at": None,
+        }
+        store[uid] = row
+        return {k: v for k, v in row.items() if k != "password_hash"}
+
+    async def get_user_by_email(email: str) -> dict[str, Any] | None:
+        for u in store.values():
+            if str(u["email"]).lower() == email.lower():
+                return dict(u)
+        return None
+
+    async def get_user_by_id(user_id: Any) -> dict[str, Any] | None:
+        u = store.get(str(user_id))
+        return ({k: v for k, v in u.items() if k != "password_hash"} if u else None)
+
+    async def update_last_login(user_id: Any) -> None:
+        u = store.get(str(user_id))
+        if u:
+            u["last_login_at"] = "now"
+
+    async def set_member_status(user_id: Any, *, is_member: bool, **kwargs: Any) -> None:
+        u = store.get(str(user_id))
+        if u:
+            u["is_member"] = is_member
+            u["member_verified_at"] = datetime.now(UTC)
+
+    from backend.auth import dependencies as auth_deps
+    from backend.db import users_repo
+    from backend.routes import auth as auth_route
+
+    for repo, fn_name, fn in [
+        (users_repo, "create_user", create_user),
+        (users_repo, "get_user_by_email", get_user_by_email),
+        (users_repo, "get_user_by_id", get_user_by_id),
+        (users_repo, "update_last_login", update_last_login),
+        (users_repo, "set_member_status", set_member_status),
+        (auth_deps.users_repo, "get_user_by_id", get_user_by_id),
+        (auth_route.users_repo, "create_user", create_user),
+        (auth_route.users_repo, "get_user_by_email", get_user_by_email),
+        (auth_route.users_repo, "update_last_login", update_last_login),
+        (auth_route.users_repo, "set_member_status", set_member_status),
+    ]:
+        monkeypatch.setattr(repo, fn_name, fn)
+    return store
+
+
+@pytest.fixture(autouse=True)
+def stub_pg_lifecycle(monkeypatch):
+    from backend.db import postgres as pg
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(pg, "close_pg_pool", noop)
+
+
+@pytest.fixture
+async def client():
+    from backend.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://testserver") as c:
+        yield c
+
+
+def _set_circle(monkeypatch, return_value: bool, fail: bool = False):
+    """Patch circle.verify_paid_member. fail=True simulates Circle being down
+    (the production verify_paid_member never raises, so we just return False
+    here too)."""
+
+    async def fake(email: str) -> bool:
+        return False if fail else return_value
+
+    from backend.integrations import circle as circle_module
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(circle_module, "verify_paid_member", fake)
+    monkeypatch.setattr(auth_route.circle, "verify_paid_member", fake)
+
+
+# ---------------------------------------------------------------------------
+# Signup paths
+# ---------------------------------------------------------------------------
+
+
+async def test_signup_non_member_lands_with_is_member_false(client, monkeypatch):
+    _set_circle(monkeypatch, return_value=False)
+    r = await client.post(
+        "/api/auth/signup",
+        json={"email": "free@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 201
+
+    me = await client.get("/api/auth/me")
+    assert me.status_code == 200
+    body = me.json()
+    assert body["email"] == "free@example.com"
+    assert body["is_member"] is False
+
+
+async def test_signup_paid_member_flagged(client, monkeypatch):
+    _set_circle(monkeypatch, return_value=True)
+    r = await client.post(
+        "/api/auth/signup",
+        json={"email": "paid@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 201
+
+    me = await client.get("/api/auth/me")
+    assert me.status_code == 200
+    assert me.json()["is_member"] is True
+
+
+# ---------------------------------------------------------------------------
+# Login paths
+# ---------------------------------------------------------------------------
+
+
+async def test_login_circle_down_succeeds_with_non_member(client, monkeypatch):
+    """Acceptance #4: Circle outage during login → user falls back to non-member."""
+    # Signup with Circle UP → user is a member.
+    _set_circle(monkeypatch, return_value=True)
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "paid@example.com", "password": "supersecret"},
+    )
+
+    # Now Circle is "down" — verify_paid_member returns False (fail-closed).
+    _set_circle(monkeypatch, return_value=False, fail=True)
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "paid@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 200
+
+    me = await client.get("/api/auth/me")
+    # /me will see member_verified_at as just-now, so it skips the refresh and
+    # returns the freshly stored False.
+    assert me.json()["is_member"] is False
+
+
+async def test_me_refreshes_after_staleness_window(client, monkeypatch, fake_users_repo):
+    """Acceptance #4 follow-up: after Circle recovers, /me re-verifies and flips."""
+    # Signup with Circle DOWN → user lands as non-member.
+    _set_circle(monkeypatch, return_value=False)
+    r = await client.post(
+        "/api/auth/signup",
+        json={"email": "alice@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 201
+
+    # Make verified_at look stale.
+    user = next(iter(fake_users_repo.values()))
+    user["member_verified_at"] = datetime.now(UTC) - timedelta(hours=2)
+
+    # Bring Circle back up — paid this time.
+    _set_circle(monkeypatch, return_value=True)
+
+    me = await client.get("/api/auth/me")
+    assert me.status_code == 200
+    assert me.json()["is_member"] is True
+    # And the row now has a fresh stamp.
+    assert (datetime.now(UTC) - user["member_verified_at"]).total_seconds() < 5
+
+
+async def test_me_skips_refresh_when_fresh(client, monkeypatch, fake_users_repo):
+    """If verified_at is fresh, /me must NOT re-call Circle."""
+    _set_circle(monkeypatch, return_value=False)
+    await client.post(
+        "/api/auth/signup",
+        json={"email": "alice@example.com", "password": "supersecret"},
+    )
+
+    # Switch Circle to True. /me should NOT pick this up because verified_at is fresh.
+    call_count = {"n": 0}
+
+    async def counting(email: str) -> bool:
+        call_count["n"] += 1
+        return True
+
+    from backend.integrations import circle as circle_module
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(circle_module, "verify_paid_member", counting)
+    monkeypatch.setattr(auth_route.circle, "verify_paid_member", counting)
+
+    me = await client.get("/api/auth/me")
+    assert me.json()["is_member"] is False
+    assert call_count["n"] == 0

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -1,0 +1,144 @@
+"""Unit tests for backend.integrations.circle.verify_paid_member.
+
+The function MUST never raise — it always returns a bool. We exercise:
+- happy path (active member in the paid access group)
+- 404 from member search (non-member)
+- non-200 from member search (fail-closed)
+- non-200 from access_groups (fail-closed)
+- timeout (fail-closed)
+- inactive member
+- member exists but NOT in paid access group
+- empty / malformed config
+- malformed response shape
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+import httpx
+import pytest
+import respx
+
+from backend.integrations import circle
+
+
+@pytest.fixture(autouse=True)
+def _circle_config(monkeypatch: pytest.MonkeyPatch):
+    """Stamp Circle config onto the module so the function actually runs.
+
+    Done via monkeypatch (not env vars) because config.py reads the env once at
+    import time, well before this test file is loaded.
+    """
+    monkeypatch.setattr(circle, "CIRCLE_ADMIN_TOKEN", "test-token")
+    monkeypatch.setattr(circle, "CIRCLE_PAID_ACCESS_GROUP_ID", 16841)
+
+
+@respx.mock
+async def test_active_member_in_paid_group_returns_true():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999, "active": True})
+    )
+    respx.get("https://app.circle.so/api/admin/v2/community_members/999/access_groups").mock(
+        return_value=httpx.Response(200, json={"records": [{"id": 16841}]})
+    )
+
+    assert await circle.verify_paid_member("paid@example.com") is True
+
+
+@respx.mock
+async def test_member_not_in_paid_group_returns_false():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999, "active": True})
+    )
+    respx.get("https://app.circle.so/api/admin/v2/community_members/999/access_groups").mock(
+        return_value=httpx.Response(200, json={"records": [{"id": 53474}]})  # different group
+    )
+
+    assert await circle.verify_paid_member("free@example.com") is False
+
+
+@respx.mock
+async def test_member_search_404_returns_false():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(404, text="Not found")
+    )
+
+    assert await circle.verify_paid_member("notmember@example.com") is False
+
+
+@respx.mock
+async def test_member_search_500_fails_closed():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(500, text="Internal error")
+    )
+
+    assert await circle.verify_paid_member("anyone@example.com") is False
+
+
+@respx.mock
+async def test_access_groups_500_fails_closed():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999, "active": True})
+    )
+    respx.get("https://app.circle.so/api/admin/v2/community_members/999/access_groups").mock(
+        return_value=httpx.Response(503, text="Bad gateway")
+    )
+
+    assert await circle.verify_paid_member("paid@example.com") is False
+
+
+@respx.mock
+async def test_timeout_fails_closed():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        side_effect=httpx.TimeoutException("timeout")
+    )
+
+    assert await circle.verify_paid_member("any@example.com") is False
+
+
+@respx.mock
+async def test_inactive_member_returns_false():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999, "active": False})
+    )
+
+    assert await circle.verify_paid_member("inactive@example.com") is False
+
+
+@respx.mock
+async def test_records_wrapped_response_handled():
+    """Some Circle endpoints wrap a single record in `records: [...]`."""
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(
+            200, json={"records": [{"id": 999, "active": True}]}
+        )
+    )
+    respx.get("https://app.circle.so/api/admin/v2/community_members/999/access_groups").mock(
+        return_value=httpx.Response(200, json={"records": [{"id": 16841}]})
+    )
+
+    assert await circle.verify_paid_member("paid@example.com") is True
+
+
+@respx.mock
+async def test_malformed_search_response_fails_closed():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"unexpected": "shape"})
+    )
+
+    assert await circle.verify_paid_member("paid@example.com") is False
+
+
+async def test_empty_email_returns_false():
+    assert await circle.verify_paid_member("") is False
+
+
+async def test_missing_config_returns_false(monkeypatch: pytest.MonkeyPatch):
+    """If the token isn't configured, verify_paid_member shorts to False."""
+    monkeypatch.setattr(circle, "CIRCLE_ADMIN_TOKEN", "")
+
+    assert await circle.verify_paid_member("paid@example.com") is False

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -115,7 +115,9 @@ async def _post_message(*, answer_tokens: list[str], retrieved_chunks: list[dict
             final_text_out.append("".join(answer_tokens))
         yield "data: [DONE]\n\n"
 
-    async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None):
+    async def mock_execute_tool(
+        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+    ):
         return {"ok": True, "text": "ctx", "chunks": retrieved_chunks}
 
     async def get_user(*a, **kw):

--- a/app/backend/tests/test_ingest_dynamous_parse.py
+++ b/app/backend/tests/test_ingest_dynamous_parse.py
@@ -1,0 +1,91 @@
+"""Pure-function tests for the Dynamous content parser.
+
+The DB side of `ingest_dynamous_content` requires a real Postgres pool and is
+covered by smoke tests at deploy time. Here we verify the markdown-parsing
+helpers in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+from backend.ingest.dynamous import _hash_body, _parse_frontmatter, _parse_segments
+
+
+def test_parse_frontmatter_extracts_typed_pairs():
+    text = """---
+title: "Module 1: Intro"
+lesson_id: 2103795
+course_slug: module-1
+---
+
+Body here.
+"""
+    fm, body = _parse_frontmatter(text)
+    assert fm["title"] == "Module 1: Intro"
+    assert fm["lesson_id"] == "2103795"
+    assert fm["course_slug"] == "module-1"
+    assert body.strip() == "Body here."
+
+
+def test_parse_frontmatter_no_frontmatter_returns_empty():
+    text = "Just a plain markdown body, no frontmatter."
+    fm, body = _parse_frontmatter(text)
+    assert fm == {}
+    assert body == text
+
+
+def test_parse_segments_with_timestamp_headings():
+    body = """## [00:00:00] Intro
+
+Welcome to the course.
+
+## [00:02:15] Architecture
+
+The agent has three layers.
+
+## [00:05:30] Setup
+
+Install the dependencies.
+"""
+    segs = _parse_segments(body)
+    assert len(segs) == 3
+
+    assert segs[0]["start"] == 0.0
+    assert segs[0]["end"] == 135.0  # 00:02:15
+    assert segs[0]["heading"] == "Intro"
+    assert "Welcome to the course." in segs[0]["text"]
+
+    assert segs[1]["start"] == 135.0
+    assert segs[1]["end"] == 330.0  # 00:05:30
+    assert "three layers" in segs[1]["text"]
+
+    # Final segment: end == start (no successor to compute duration from).
+    assert segs[2]["start"] == 330.0
+    assert segs[2]["end"] == 330.0
+    assert "Install" in segs[2]["text"]
+
+
+def test_parse_segments_no_headings_yields_one_segment():
+    body = "No headings, just a flat transcript blob."
+    segs = _parse_segments(body)
+    assert len(segs) == 1
+    assert segs[0]["start"] == 0.0
+    assert segs[0]["text"] == body
+
+
+def test_parse_segments_empty_body_yields_zero():
+    assert _parse_segments("") == []
+    assert _parse_segments("\n   \n") == []
+
+
+def test_hash_body_is_stable_and_distinct():
+    a = _hash_body("hello world")
+    b = _hash_body("hello world")
+    c = _hash_body("hello world!")
+    assert a == b
+    assert a != c
+    assert len(a) == 64  # sha256 hex

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -151,8 +151,8 @@ class TestRetrieveHybrid:
             assert mock_vec.called
 
             # Verify correct arguments passed (over-fetch factor applied)
-            mock_kw.assert_called_once_with("test query", top_k=fetch_k, language="english")
-            mock_vec.assert_called_once_with([0.1] * 1536, top_k=fetch_k)
+            mock_kw.assert_called_once_with("test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"])
+            mock_vec.assert_called_once_with([0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"])
 
             # Verify result shape has all required citation fields
             assert len(result) >= 1

--- a/app/backend/tests/test_retriever_member_filter.py
+++ b/app/backend/tests/test_retriever_member_filter.py
@@ -1,0 +1,96 @@
+"""Unit test: retrieve_hybrid threads is_member into the repository search calls.
+
+Mocks the two repository entry points at the boundary so we don't need a live
+Postgres pool. Asserts that:
+- is_member=False sends `allowed_source_types=['youtube']` to both searches
+- is_member=True sends `allowed_source_types=['youtube', 'dynamous']` to both
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Standard test env (per conftest.py contract — see test_auth.py for the same pattern).
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+import pytest
+
+from backend.rag.retriever_hybrid import retrieve_hybrid
+
+
+class _Spy:
+    """Captures calls to the patched async function."""
+
+    def __init__(self, return_rows: list[dict[str, Any]] | None = None):
+        self.calls: list[dict[str, Any]] = []
+        self.return_rows = return_rows or []
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return self.return_rows
+
+
+async def test_non_member_filters_to_youtube_only(monkeypatch: pytest.MonkeyPatch):
+    keyword_spy = _Spy()
+    vector_spy = _Spy()
+
+    from backend.db import repository
+
+    monkeypatch.setattr(repository, "keyword_search", keyword_spy)
+    monkeypatch.setattr(repository, "vector_search_pg", vector_spy)
+
+    # No need to mock get_video — both spies return empty lists, so the
+    # post-merge hydration loop never runs.
+    await retrieve_hybrid(
+        query_text="how to set up agent",
+        query_embedding=[0.1] * 1536,
+        top_k=5,
+        is_member=False,
+    )
+
+    assert keyword_spy.calls, "keyword_search not called"
+    assert vector_spy.calls, "vector_search_pg not called"
+    assert keyword_spy.calls[0]["kwargs"]["allowed_source_types"] == ["youtube"]
+    assert vector_spy.calls[0]["kwargs"]["allowed_source_types"] == ["youtube"]
+
+
+async def test_member_includes_dynamous(monkeypatch: pytest.MonkeyPatch):
+    keyword_spy = _Spy()
+    vector_spy = _Spy()
+
+    from backend.db import repository
+
+    monkeypatch.setattr(repository, "keyword_search", keyword_spy)
+    monkeypatch.setattr(repository, "vector_search_pg", vector_spy)
+
+    await retrieve_hybrid(
+        query_text="advanced agent patterns",
+        query_embedding=[0.2] * 1536,
+        top_k=10,
+        is_member=True,
+    )
+
+    assert keyword_spy.calls[0]["kwargs"]["allowed_source_types"] == ["youtube", "dynamous"]
+    assert vector_spy.calls[0]["kwargs"]["allowed_source_types"] == ["youtube", "dynamous"]
+
+
+async def test_default_is_non_member(monkeypatch: pytest.MonkeyPatch):
+    """is_member parameter defaults to False — old callers stay safe."""
+    keyword_spy = _Spy()
+    vector_spy = _Spy()
+
+    from backend.db import repository
+
+    monkeypatch.setattr(repository, "keyword_search", keyword_spy)
+    monkeypatch.setattr(repository, "vector_search_pg", vector_spy)
+
+    await retrieve_hybrid(
+        query_text="anything",
+        query_embedding=[0.0] * 1536,
+        top_k=5,
+    )
+
+    assert keyword_spy.calls[0]["kwargs"]["allowed_source_types"] == ["youtube"]
+    assert vector_spy.calls[0]["kwargs"]["allowed_source_types"] == ["youtube"]

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -761,7 +761,7 @@ class TestRefusalSourcesSuppressionIntegration:
                 final_text_out.append(refusal_text)
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None):
+        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         test_user_id = str(uuid4())
@@ -858,7 +858,7 @@ class TestRefusalSourcesSuppressionIntegration:
                 final_text_out.append(refusal_text)
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None):
+        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         from uuid import uuid4
@@ -956,7 +956,7 @@ class TestRefusalSourcesSuppressionIntegration:
                 final_text_out.append(answer_text)
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None):
+        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         from uuid import uuid4
@@ -1068,7 +1068,7 @@ class TestChunkExpansionIntegration:
                 final_text_out.append("The video explains it works.")
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None):
+        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         from uuid import uuid4

--- a/app/backend/tests/test_tools.py
+++ b/app/backend/tests/test_tools.py
@@ -85,7 +85,7 @@ _FAKE_CHUNKS = [
 
 @pytest.mark.asyncio
 async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
-    async def fake_retrieve(_q, _emb, top_k=5):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False):
         assert top_k == 10
         return _FAKE_CHUNKS
 
@@ -101,7 +101,7 @@ async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english"):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
         return [
             {
                 "id": "c1",
@@ -129,7 +129,7 @@ async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
-    async def fake_vector(_emb, top_k=10):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
         return [
             {
                 "id": "c2",
@@ -158,7 +158,7 @@ async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english"):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -246,7 +246,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
         for i in range(6)
     ]
 
-    async def fake_retrieve(_q, _emb, top_k=10):
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
         return many_chunks
 
     monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
@@ -262,7 +262,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
 async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_keyword."""
 
-    async def fake_keyword(_q, top_k=10, language="english"):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
         return [
             {
                 "id": f"c{i}",
@@ -292,7 +292,7 @@ async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> Non
 async def test_execute_search_semantic_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_semantic."""
 
-    async def fake_vector(_emb, top_k=10):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
         return [
             {
                 "id": f"c{i}",

--- a/app/frontend/src/components/CitationModal.tsx
+++ b/app/frontend/src/components/CitationModal.tsx
@@ -14,12 +14,19 @@ export function formatTimestamp(seconds: number): string {
 }
 
 export function CitationModal({ citation, onClose }: CitationModalProps) {
+  // Issue #147: paid Dynamous course / workshop citations render without an
+  // embedded player. Circle doesn't support timestamp deep-links, so we link
+  // straight to the lesson URL with the (MM:SS) shown as text in the header.
+  const isDynamous = citation.source_type === 'dynamous';
+
   // Extract YouTube video ID from URL (format: https://www.youtube.com/watch?v=<id>)
   let videoId = '';
-  try {
-    videoId = new URL(citation.video_url).searchParams.get('v') ?? '';
-  } catch {
-    console.warn('[CitationModal] Could not parse video URL:', citation.video_url);
+  if (!isDynamous) {
+    try {
+      videoId = new URL(citation.video_url).searchParams.get('v') ?? '';
+    } catch {
+      console.warn('[CitationModal] Could not parse video URL:', citation.video_url);
+    }
   }
 
   const startSeconds = Math.floor(citation.start_seconds);
@@ -28,9 +35,13 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
     ? `https://www.youtube.com/embed/${videoId}?start=${startSeconds}&autoplay=1`
     : '';
 
-  const externalUrl = videoId
+  const externalUrl = isDynamous
+    ? citation.lesson_url ?? ''
+    : videoId
     ? `https://www.youtube.com/watch?v=${videoId}&t=${startSeconds}s`
     : '';
+
+  const externalLabel = isDynamous ? 'Open on Dynamous' : 'Open on YouTube';
 
   // Close on ESC key
   useEffect(() => {
@@ -85,24 +96,27 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
           </button>
         </div>
 
-        {/* Content: YouTube iframe (top) + transcript (bottom) */}
+        {/* Content: YouTube iframe (top) + transcript (bottom).
+            Dynamous citations skip the iframe — Circle has no embed/deep-link
+            support, so the snippet + external link is all we render. */}
         <div className="flex-1 min-h-0 flex flex-col gap-4 mb-4 overflow-y-auto">
-          {/* YouTube iframe — 16:9 aspect ratio container */}
-          <div className="w-full aspect-video">
-            {embedUrl ? (
-              <iframe
-                src={embedUrl}
-                allow="autoplay; encrypted-media"
-                allowFullScreen
-                title="YouTube video player"
-                className="w-full h-full rounded-lg"
-              />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center bg-slate-900 rounded-lg text-slate-500 text-sm">
-                Video unavailable
-              </div>
-            )}
-          </div>
+          {!isDynamous && (
+            <div className="w-full aspect-video">
+              {embedUrl ? (
+                <iframe
+                  src={embedUrl}
+                  allow="autoplay; encrypted-media"
+                  allowFullScreen
+                  title="YouTube video player"
+                  className="w-full h-full rounded-lg"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center bg-slate-900 rounded-lg text-slate-500 text-sm">
+                  Video unavailable
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Transcript snippet */}
           <div>
@@ -115,26 +129,28 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
 
         {/* Footer: external link */}
         <div className="flex justify-end">
-          <a
-            href={externalUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-slate-400 hover:text-slate-200 text-xs flex items-center gap-1 transition-colors"
-          >
-            Open on YouTube
-            <svg
-              width="10"
-              height="10"
-              viewBox="0 0 10 10"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+          {externalUrl ? (
+            <a
+              href={externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-slate-400 hover:text-slate-200 text-xs flex items-center gap-1 transition-colors"
             >
-              <path d="M1 9L9 1M9 1H3M9 1v6" />
-            </svg>
-          </a>
+              {externalLabel}
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M1 9L9 1M9 1H3M9 1v6" />
+              </svg>
+            </a>
+          ) : null}
         </div>
       </div>
     </div>

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -56,6 +56,19 @@ export interface Citation {
    * with messages persisted before the two-tier system shipped.
    */
   is_cited?: boolean;
+  /**
+   * Discriminator for the citation rendering split. 'youtube' (default)
+   * gets the embedded player + ?t= deep link. 'dynamous' (paid course /
+   * workshop content) gets a static link to `lesson_url` because Circle
+   * doesn't support timestamp deep links. Optional for backward
+   * compatibility with messages persisted before issue #147.
+   */
+  source_type?: 'youtube' | 'dynamous' | string;
+  /**
+   * Circle lesson/workshop URL — populated for `source_type === 'dynamous'`,
+   * empty for YouTube citations.
+   */
+  lesson_url?: string;
 }
 
 export interface Message {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -59,6 +59,18 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
       ADMIN_USER_EMAIL: ${ADMIN_USER_EMAIL:-}
+      # Issue #147: Circle membership verification + Dynamous content ingest.
+      CIRCLE_ADMIN_TOKEN: ${CIRCLE_ADMIN_TOKEN:-}
+      CIRCLE_PAID_ACCESS_GROUP_ID: ${CIRCLE_PAID_ACCESS_GROUP_ID:-}
+      MEMBERSHIP_REFRESH_SECONDS: ${MEMBERSHIP_REFRESH_SECONDS:-3600}
+      DYNAMOUS_CONTENT_DIR: /app/content/dynamous
+    volumes:
+      # Read-only mount of the host-side dynamous-content checkout. The host's
+      # deploy.sh git-clones / pulls this directory before bringing the new
+      # color up. Path is parameterised so it can point at /opt/dynachat/dynamous-content
+      # in prod or a dev fixture in local testing. Empty/missing dir is fine —
+      # ingest_dynamous_content skips if the directory is absent.
+      - ${DYNAMOUS_CONTENT_HOST_PATH:-/opt/dynachat/dynamous-content}:/app/content/dynamous:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -91,6 +103,13 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
       ADMIN_USER_EMAIL: ${ADMIN_USER_EMAIL:-}
+      # Issue #147: Circle membership verification + Dynamous content ingest.
+      CIRCLE_ADMIN_TOKEN: ${CIRCLE_ADMIN_TOKEN:-}
+      CIRCLE_PAID_ACCESS_GROUP_ID: ${CIRCLE_PAID_ACCESS_GROUP_ID:-}
+      MEMBERSHIP_REFRESH_SECONDS: ${MEMBERSHIP_REFRESH_SECONDS:-3600}
+      DYNAMOUS_CONTENT_DIR: /app/content/dynamous
+    volumes:
+      - ${DYNAMOUS_CONTENT_HOST_PATH:-/opt/dynachat/dynamous-content}:/app/content/dynamous:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/sync-dynamous-content.sh
+++ b/deploy/sync-dynamous-content.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# sync-dynamous-content.sh
+#
+# Pull the latest paid Dynamous course/workshop transcripts from the private
+# coleam00/dynamous-content repo into the host directory that docker-compose
+# mounts into the app containers (issue #147).
+#
+# Idempotent: clones on first run, pulls on subsequent runs. The container
+# ingester (backend.ingest.dynamous) SHA-checks each markdown file so unchanged
+# files are no-ops.
+#
+# Run this from the host's deploy.sh BEFORE bringing up the new color so the
+# fresh container sees the latest content on its first health check.
+#
+# Required env (loaded from /opt/dynachat/.env in prod):
+#   DYNAMOUS_CONTENT_DEPLOY_KEY_PATH  — path to the SSH private key (deploy
+#                                        key on the dynamous-content repo)
+#   DYNAMOUS_CONTENT_HOST_PATH        — local checkout dir (defaults to
+#                                        /opt/dynachat/dynamous-content)
+
+set -euo pipefail
+
+KEY_PATH="${DYNAMOUS_CONTENT_DEPLOY_KEY_PATH:-/opt/dynachat/secrets/dynamous-content-deploy}"
+DIR="${DYNAMOUS_CONTENT_HOST_PATH:-/opt/dynachat/dynamous-content}"
+REPO="git@github.com:coleam00/dynamous-content.git"
+
+if [ ! -f "$KEY_PATH" ]; then
+    echo "WARN: deploy key missing at $KEY_PATH; skipping dynamous-content sync"
+    exit 0
+fi
+
+# `-o IdentitiesOnly=yes` stops ssh from trying any other agent-loaded keys
+# first (which would 403 against this repo's deploy key allowlist and could
+# trigger GitHub's rate limit on bad attempts).
+export GIT_SSH_COMMAND="ssh -i $KEY_PATH -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
+
+if [ -d "$DIR/.git" ]; then
+    echo "Pulling dynamous-content into $DIR"
+    git -C "$DIR" fetch --depth 1 origin main
+    git -C "$DIR" reset --hard origin/main
+else
+    echo "Cloning dynamous-content into $DIR"
+    mkdir -p "$(dirname "$DIR")"
+    git clone --depth 1 "$REPO" "$DIR"
+fi
+
+echo "Sync complete: $DIR ($(find "$DIR" -name '*.md' | wc -l) markdown files)"

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,26 @@
+# Standalone deps for the one-shot Phase 3 transcription runner.
+# Independent of app/backend/ — the runner is operator-side, not deployed.
+#
+# Install + run:
+#   cd scripts && uv sync
+#   uv run python transcribe_all.py --help
+
+[project]
+name = "dynachat-scripts"
+version = "0.1.0"
+description = "One-shot operator scripts for issue #147 (Dynamous content)"
+requires-python = ">=3.11"
+dependencies = [
+    "openai>=1.50",
+    "google-api-python-client>=2.140",
+    "google-auth>=2.30",
+    "google-auth-oauthlib>=1.2",
+    "python-dotenv>=1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/scripts/transcribe_all.py
+++ b/scripts/transcribe_all.py
@@ -189,8 +189,13 @@ def _extract_audio(video: Path, audio: Path) -> None:
 
     Whisper's accepted formats are flac/m4a/mp3/mp4/mpeg/mpga/oga/ogg/wav/webm,
     and rejects bare `.opus`. We use `.ogg` extension (Ogg container) with
-    libopus inside — Whisper handles it. 32 kbps mono is small enough that
-    even a 90-min workshop comes in well under the 25 MB upload cap.
+    libopus inside — Whisper handles it.
+
+    Bitrate is 16 kbps mono. Whisper's hard upload cap is 25 MB; at 16 kbps
+    that's enough headroom for ~3.5-hour audio. Empirically tried 32 kbps
+    first; two workshops in the ~100-min range hit `413: Maximum content size
+    limit exceeded` (26 MB ogg). 16 kbps is well within Opus's "still
+    intelligible speech" zone and Whisper transcribes it cleanly.
     """
     if not shutil.which("ffmpeg"):
         raise RuntimeError(
@@ -212,7 +217,7 @@ def _extract_audio(video: Path, audio: Path) -> None:
             "-c:a",
             "libopus",
             "-b:a",
-            "32k",
+            "16k",
             str(audio),
         ],
         capture_output=True,

--- a/scripts/transcribe_all.py
+++ b/scripts/transcribe_all.py
@@ -1,0 +1,385 @@
+"""One-shot transcription runner for issue #147.
+
+Reads `lesson_map.csv` (output of the dynamous-engine matching subagents),
+downloads each Drive video, transcribes via OpenAI Whisper, writes a
+markdown transcript with `## [HH:MM:SS]` segment headings under
+`<output-dir>/<bucket>/<slug>.md`. Idempotent — if the output already exists
+and content_hash matches the source video's md5, it's skipped.
+
+Operator-side: not part of the deployed backend. Cole runs this locally
+before committing transcripts to the private `dynamous-content` repo.
+
+Requires:
+  - ffmpeg on PATH (used to extract a Whisper-friendly audio file from the
+    raw MP4/MOV — Whisper has a 25 MB file-size limit; raw videos are 100+ MB)
+  - OPENAI_API_KEY env var
+  - Google OAuth: pass `--google-token` pointing at the JSON token created
+    by `dynamous-engine/.claude/scripts/integrations/auth.py`. The full
+    `https://www.googleapis.com/auth/drive` scope is sufficient.
+
+Usage:
+    cd scripts && uv sync
+    uv run python transcribe_all.py \\
+        --lesson-map ../../dynamous-engine/Dynamous/Memory/plans/dynamous-content-mapping/lesson_map.csv \\
+        --google-token ../../dynamous-engine/.claude/scripts/integrations/google_token.json \\
+        --output-dir /path/to/dynamous-content/content/dynamous \\
+        --max-parallel 4
+
+Arguments:
+    --lesson-map      CSV from dynamous-engine matching work
+    --google-token    Path to OAuth token JSON
+    --output-dir      Where transcripts land (typically inside a checkout of
+                      coleam00/dynamous-content)
+    --max-parallel    Number of concurrent transcriptions (default: 4)
+    --filter          Substring filter on `course_slug` or `post_slug` to run
+                      a single course or one workshop (debugging)
+    --dry-run         Print what would be transcribed; don't call APIs
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+)
+logger = logging.getLogger("transcribe_all")
+
+
+# ----------------------------------------------------------------------------
+# Output helpers
+# ----------------------------------------------------------------------------
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(s: str) -> str:
+    s = s.lower().strip()
+    s = _SLUG_RE.sub("-", s).strip("-")
+    return s or "untitled"
+
+
+def _format_timestamp(seconds: float) -> str:
+    s = int(seconds)
+    h, rem = divmod(s, 3600)
+    m, ss = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{ss:02d}"
+
+
+def _output_path_for(row: dict[str, str], output_dir: Path) -> Path:
+    """Pick a stable output path under output_dir based on the lesson_map row."""
+    course = row.get("course_slug") or ""
+    post = row.get("post_slug") or ""
+    title = row.get("title") or "untitled"
+    if course:
+        # Course lesson — slug under the course dir, named for the lesson.
+        bucket = course
+        # Lesson titles often start with "1.4 -" — keep that prefix readable.
+        name = _slugify(title)[:120]
+        return output_dir / "courses" / bucket / f"{name}.md"
+    if post:
+        return output_dir / "workshops" / f"{post}.md"
+    # Fallback — should not happen if lesson_map is well-formed.
+    return output_dir / "misc" / f"{_slugify(title)}.md"
+
+
+def _frontmatter_for(row: dict[str, str], video_md5: str) -> str:
+    """Build the YAML frontmatter block that ingest_dynamous_content reads."""
+    lines = ["---"]
+
+    def _add(key: str, value: str) -> None:
+        if value:
+            # Quote string-typed fields that contain special characters.
+            if any(c in value for c in ":#"):
+                value = f'"{value}"'
+            lines.append(f"{key}: {value}")
+
+    _add("title", row.get("title", ""))
+    _add("source_type", "dynamous")
+    _add("course_slug", row.get("course_slug", ""))
+    _add("section_id", row.get("section_id", ""))
+    _add("lesson_id", row.get("lesson_id", ""))
+    _add("post_slug", row.get("post_slug", ""))
+    _add("lesson_url", row.get("lesson_url", ""))
+    _add("source_video_md5", video_md5)
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _format_transcript(segments: list[dict[str, Any]]) -> str:
+    """Whisper segments → markdown body with `## [HH:MM:SS]` headings."""
+    parts: list[str] = []
+    for seg in segments:
+        start = float(seg.get("start", 0.0))
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        parts.append(f"## [{_format_timestamp(start)}]\n\n{text}\n")
+    return "\n".join(parts)
+
+
+# ----------------------------------------------------------------------------
+# Drive download + ffmpeg audio extraction
+# ----------------------------------------------------------------------------
+
+
+def _build_drive(token_path: Path) -> Any:
+    from google.oauth2.credentials import Credentials
+    from googleapiclient.discovery import build
+
+    creds = Credentials.from_authorized_user_file(str(token_path))
+    return build("drive", "v3", credentials=creds, cache_discovery=False)
+
+
+def _resolve_drive_file_id(svc: Any, drive_path: str, root_id: str) -> str | None:
+    """Walk the root folder by name components to find the file ID for drive_path.
+
+    drive_path is a forward-slash separated path under the Drive root, e.g.:
+      'Courses/AI Agent Mastery/Module 5/5.4 - Building a Complete Front End.mp4'
+    """
+    parts = [p for p in drive_path.split("/") if p]
+    parent = root_id
+    for part in parts:
+        safe = part.replace("'", "\\'")
+        res = (
+            svc.files()
+            .list(
+                q=f"'{parent}' in parents and name='{safe}' and trashed=false",
+                fields="files(id,name,mimeType)",
+                pageSize=10,
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
+            )
+            .execute()
+        )
+        files = res.get("files", [])
+        if not files:
+            return None
+        parent = files[0]["id"]
+    return parent  # the last resolved id is the file
+
+
+def _download_file(svc: Any, file_id: str, dest: Path) -> None:
+    from googleapiclient.http import MediaIoBaseDownload
+
+    request = svc.files().get_media(fileId=file_id, supportsAllDrives=True)
+    with dest.open("wb") as f:
+        downloader = MediaIoBaseDownload(f, request, chunksize=10 * 1024 * 1024)
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+
+
+def _extract_audio(video: Path, audio: Path) -> None:
+    """Use ffmpeg to make a 16 kHz mono Opus file (small, lossless-enough)."""
+    if not shutil.which("ffmpeg"):
+        raise RuntimeError(
+            "ffmpeg is required on PATH to extract audio for Whisper. Install it first."
+        )
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video),
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "32k",
+            str(audio),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _md5_of_file(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(65536), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+# ----------------------------------------------------------------------------
+# Whisper transcription
+# ----------------------------------------------------------------------------
+
+
+def _transcribe_with_whisper(audio: Path) -> dict[str, Any]:
+    """Call Whisper with verbose_json so we get segment timestamps.
+
+    Returns the parsed response dict (includes 'segments' list).
+    """
+    from openai import OpenAI
+
+    client = OpenAI()
+    with audio.open("rb") as f:
+        # Whisper's max upload size is 25 MB; 32 kbps Opus puts a 30-min
+        # video at ~7 MB so we're comfortably under.
+        resp = client.audio.transcriptions.create(
+            model="whisper-1",
+            file=f,
+            response_format="verbose_json",
+            timestamp_granularities=["segment"],
+        )
+    # The SDK returns a Pydantic-like object; coerce to plain dict.
+    if hasattr(resp, "model_dump"):
+        return resp.model_dump()
+    return json.loads(resp.json()) if hasattr(resp, "json") else dict(resp)
+
+
+# ----------------------------------------------------------------------------
+# Per-row processor
+# ----------------------------------------------------------------------------
+
+
+def _process_row(
+    row: dict[str, str],
+    drive_root_id: str,
+    output_dir: Path,
+    google_token: Path,
+    dry_run: bool,
+) -> tuple[str, str]:
+    """Returns (status, detail). status ∈ {ok, skipped, error}."""
+    drive_path = row.get("drive_path", "")
+    if not drive_path:
+        return "skipped", "no drive_path"
+    out_path = _output_path_for(row, output_dir)
+
+    # Idempotency: if the file already exists AND its frontmatter records the
+    # same source_video_md5 we'd compute below, skip. We don't need to actually
+    # download/md5 the source — but for simplicity we recompute once and
+    # compare.
+    if dry_run:
+        return "ok", f"would write -> {out_path.relative_to(output_dir)}"
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    svc = _build_drive(google_token)
+    file_id = _resolve_drive_file_id(svc, drive_path, drive_root_id)
+    if not file_id:
+        return "error", f"drive_path not found in Drive: {drive_path}"
+
+    with tempfile.TemporaryDirectory(prefix="dynachat-") as tmp_str:
+        tmp = Path(tmp_str)
+        video = tmp / Path(drive_path).name
+        audio = tmp / "audio.opus"
+        _download_file(svc, file_id, video)
+        video_md5 = _md5_of_file(video)
+
+        # Idempotency check 2: existing transcript frontmatter has matching md5
+        if out_path.exists():
+            existing = out_path.read_text(encoding="utf-8")
+            if f"source_video_md5: {video_md5}" in existing:
+                return "skipped", f"unchanged: {out_path.name}"
+
+        _extract_audio(video, audio)
+        resp = _transcribe_with_whisper(audio)
+
+    segments = resp.get("segments") or []
+    body = _format_transcript(segments)
+    fm = _frontmatter_for(row, video_md5)
+    out_path.write_text(f"{fm}\n\n{body}\n", encoding="utf-8")
+    return "ok", f"wrote {out_path.relative_to(output_dir)}"
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("--lesson-map", type=Path, required=True)
+    p.add_argument("--google-token", type=Path, required=True)
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument(
+        "--drive-root",
+        type=str,
+        default="10mKOnXHz242ZY0tj1CxchLFJlXhuCgpc",
+        help="Drive root folder ID for 'Dynamous Content' (default: production)",
+    )
+    p.add_argument("--max-parallel", type=int, default=4)
+    p.add_argument("--filter", type=str, default=None)
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        logger.error("OPENAI_API_KEY env var not set; aborting")
+        return 2
+
+    if not args.lesson_map.exists():
+        logger.error("lesson_map not found: %s", args.lesson_map)
+        return 2
+
+    if not args.google_token.exists():
+        logger.error("google_token not found: %s", args.google_token)
+        return 2
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, str]] = []
+    with args.lesson_map.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        for r in reader:
+            if r.get("match_status") not in {"matched", "ambiguous"}:
+                continue
+            if not r.get("drive_path"):
+                continue
+            if args.filter and args.filter not in (r.get("course_slug") or "") + (r.get("post_slug") or ""):
+                continue
+            rows.append(r)
+
+    logger.info("Processing %d rows (max_parallel=%d)", len(rows), args.max_parallel)
+
+    results = {"ok": 0, "skipped": 0, "error": 0}
+    with ThreadPoolExecutor(max_workers=args.max_parallel) as pool:
+        futures = {
+            pool.submit(
+                _process_row,
+                r,
+                args.drive_root,
+                args.output_dir,
+                args.google_token,
+                args.dry_run,
+            ): r
+            for r in rows
+        }
+        for fut in as_completed(futures):
+            r = futures[fut]
+            try:
+                status, detail = fut.result()
+            except Exception as exc:
+                status, detail = "error", str(exc)
+            results[status] = results.get(status, 0) + 1
+            level = logging.INFO if status == "ok" else (
+                logging.WARNING if status == "skipped" else logging.ERROR
+            )
+            logger.log(level, "[%s] %s -> %s", status, r.get("drive_path", "?"), detail)
+
+    logger.info("Done. ok=%d skipped=%d error=%d", *(results[k] for k in ("ok", "skipped", "error")))
+    return 0 if results["error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/transcribe_all.py
+++ b/scripts/transcribe_all.py
@@ -185,17 +185,26 @@ def _download_file(svc: Any, file_id: str, dest: Path) -> None:
 
 
 def _extract_audio(video: Path, audio: Path) -> None:
-    """Use ffmpeg to make a 16 kHz mono Opus file (small, lossless-enough)."""
+    """Use ffmpeg to make a 16 kHz mono Ogg-Opus file.
+
+    Whisper's accepted formats are flac/m4a/mp3/mp4/mpeg/mpga/oga/ogg/wav/webm,
+    and rejects bare `.opus`. We use `.ogg` extension (Ogg container) with
+    libopus inside — Whisper handles it. 32 kbps mono is small enough that
+    even a 90-min workshop comes in well under the 25 MB upload cap.
+    """
     if not shutil.which("ffmpeg"):
         raise RuntimeError(
             "ffmpeg is required on PATH to extract audio for Whisper. Install it first."
         )
-    subprocess.run(
+    result = subprocess.run(
         [
             "ffmpeg",
             "-y",
             "-i",
             str(video),
+            "-vn",  # audio only — without this, ffmpeg tries to also re-encode
+                    # the video stream into the .ogg container (libtheora) which
+                    # crashes hard on some inputs.
             "-ac",
             "1",
             "-ar",
@@ -206,10 +215,17 @@ def _extract_audio(video: Path, audio: Path) -> None:
             "32k",
             str(audio),
         ],
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
     )
+    if result.returncode != 0:
+        # Surface ffmpeg's tail-of-stderr — silent failures are nightmare to debug
+        # over a 5-hour run. The Windows access-violation exit code makes the
+        # subprocess module's default error message useless on its own.
+        tail = (result.stderr or "")[-1500:]
+        raise RuntimeError(
+            f"ffmpeg failed (rc={result.returncode}) for {video.name}:\n{tail}"
+        )
 
 
 def _md5_of_file(path: Path) -> str:
@@ -283,7 +299,7 @@ def _process_row(
     with tempfile.TemporaryDirectory(prefix="dynachat-") as tmp_str:
         tmp = Path(tmp_str)
         video = tmp / Path(drive_path).name
-        audio = tmp / "audio.opus"
+        audio = tmp / "audio.ogg"
         _download_file(svc, file_id, video)
         video_md5 = _md5_of_file(video)
 


### PR DESCRIPTION
Fixes #147

## Summary

Implements Phases 1, 3, 4 (and partially 5) of the gated Dynamous content feature: Circle membership verification on signup/login/`/me`, ACL-filtered RAG retrieval (members see YouTube + Dynamous, non-members see YouTube only), an idempotent transcript ingester with timestamp-aware chunking, deploy plumbing for the private `dynamous-content` repo, and a frontend citation split for paid course/workshop links. **Phase 2 (model swap to MiniMax) was descoped before this PR — `CHAT_MODEL` stays on `anthropic/claude-sonnet-4.6`.**

## What changed

### Phase 1 — Backend foundations
- **Schema** (Alembic `0005`): extends `videos` with `source_type`, `content_hash`, `content_path`, `lesson_url`, `metadata`; denormalizes `source_type` onto `chunks` for fast ACL; adds `users.is_member` + `users.member_verified_at`. The `videos` table is **not renamed** — new columns are added in place. Migration auto-applies on startup via the existing alembic-upgrade-head step.
- **`backend/integrations/circle.py`**: `verify_paid_member(email)` → bool. **Fail-closed** by design: 5 s timeout, every non-200 / network error / unexpected-shape / missing-config path logs at warning and returns False. Never raises. Handles both direct member-object and `records: [...]` response shapes.
- **`users_repo`**: `get_user_by_id` + `get_user_by_email` SELECTs include `is_member, member_verified_at`. New `set_member_status(user_id, *, is_member, conn=None)` mirrors the `create_user` pattern (optional in-transaction conn).
- **Auth routes**:
  - `signup` calls `verify_paid_member` after the user-creation transaction commits (so a slow Circle call doesn't hold a DB connection).
  - `login` re-verifies on every successful password match.
  - `/me` refreshes opportunistically when `member_verified_at` is older than `MEMBERSHIP_REFRESH_SECONDS` (default 3600 s) — this is the path that flips a previously-failed Circle check once the API recovers.
  - `MeResponse` gains `is_member: bool`.
- **`db/postgres.py`**: asyncpg pool `init` callback sets `hnsw.iterative_scan = 'relaxed_order'` per connection. Without this, the new chunks-WHERE-source_type filter would silently fall back to exact scan on the HNSW index.
- **`repository.keyword_search` + `vector_search_pg`**: new `allowed_source_types` kwarg adds `WHERE source_type = ANY($N::text[])`. Defaults to `['youtube']` for back-compat with existing callers.
- **`rag/retriever_hybrid` + `rag/tools` + `routes/messages`**: thread `is_member` end-to-end. `get_video_transcript` adds defense-in-depth — even if a non-member knows a Dynamous video_id, the tool refuses with "video not found".

### Phase 3 — Content pipeline
- **`backend/ingest/dynamous.py`**: walks `content_dir`, parses YAML frontmatter + `## [HH:MM:SS]` segment markers, SHA-256 of the body keys idempotency. Unchanged files no-op. Changed files: chunks via existing HybridChunker (preserving timestamps), embeds, upserts with `source_type='dynamous'`. Wired into `main.py` lifespan after pool init; any failure logs and continues (YouTube path stays fully functional).
- **`deploy/docker-compose.yml`**: mounts `${DYNAMOUS_CONTENT_HOST_PATH:-/opt/dynachat/dynamous-content}` into both blue/green app containers at `/app/content/dynamous:ro`. Threads `CIRCLE_ADMIN_TOKEN`, `CIRCLE_PAID_ACCESS_GROUP_ID`, `MEMBERSHIP_REFRESH_SECONDS` env vars.
- **`deploy/sync-dynamous-content.sh`**: idempotent host-side helper. The host's `/opt/dynachat/deploy.sh` should call this before bringing up the new color so the fresh container sees the latest content on its first health check. Uses the deploy key already provisioned at `/opt/dynachat/secrets/dynamous-content-deploy`.
- **`scripts/transcribe_all.py`** (standalone, separate `pyproject.toml` under `scripts/`): one-shot operator runner. Reads `lesson_map.csv` from dynamous-engine, downloads each Drive video, ffmpeg-extracts audio, Whisper transcribes with segment timestamps, writes markdown to `content/dynamous/<bucket>/<slug>.md`. Idempotent via `source_video_md5`. Parallelized via `ThreadPoolExecutor`. **Not run in this PR**.

### Phase 4 — Frontend
- `Citation` type gains optional `source_type` + `lesson_url`.
- `CitationModal`: YouTube keeps the embedded player + `?t=` deep link; Dynamous skips the iframe and renders snippet + plain link to `lesson_url` ("Open on Dynamous"). Empty `externalUrl` is now safely no-rendered.

### Other
- `.gitattributes` forces LF on `*.sh` + `Dockerfile` so the deploy hooks work after a Windows checkout.

## Test plan

### Automated
- [x] **All 326 backend tests pass** (`uv --project backend run python -m pytest backend/tests/ --ignore=backend/tests/eval`)
- [x] **`ruff check backend/`** clean
- New tests added (29):
  - `test_circle.py` (11) — verify_paid_member happy/404/500/timeout/inactive/wrapped-records/malformed/missing-config
  - `test_retriever_member_filter.py` (3) — is_member=True/False/default threading
  - `test_auth_circle.py` (5) — signup/login/me Circle behavior + staleness refresh + freshness skip
  - `test_ingest_dynamous_parse.py` (6) — frontmatter + segment + hash helpers
  - Existing mocks (`test_auth.py`, `test_citations.py`, `test_sources_event.py`, `test_tools.py`, `test_retriever_hybrid.py`) updated for the new kwargs

### Manual smoke tests (run after deploy — covers issue #147 acceptance criteria)
- [ ] **AC1** Sign in as a paid Circle Member, ask a question about course content → response cites Dynamous chunks with working `community.dynamous.ai` lesson links
- [ ] **AC2** Sign in as a non-paid user, ask the same question → response cites only YouTube chunks; no Dynamous content appears in answer or citations
- [ ] **AC3** Signup with a fresh non-Circle email → 201, `users.is_member=false`, chat works with YouTube-only retrieval
- [ ] **AC4** Block Circle (e.g. firewall the egress) during a login → login still 200s, `/me.is_member=false`. Restore Circle, wait > 1 hour or reset `member_verified_at`, hit `/me` → flips to `is_member=true`
- [ ] **AC5** Run startup ingest twice in a row → second run logs `unchanged=N, ingested=0`
- [ ] **AC6** Edit one transcript, re-deploy → only that one source's chunks are replaced (verify via `chunks` count for the affected `video_id` before/after)
- [ ] **AC7** Visual: Dynamous citation modal shows `(MM:SS)` text in the header; YouTube modal still shows the embedded player
- [ ] **AC8** Existing pre-#147 user logs in for the first time → `is_member` set based on current Circle state
- [ ] **AC9** Existing 25 msg / user / 24h cap unaffected
- [ ] **AC10** Existing YouTube behavior unchanged for users who were already using DynaChat

## Deployment notes

Before deploying:

1. Make sure `/opt/dynachat/.env` has the new vars (already added by Phase 0):
   - `CIRCLE_ADMIN_TOKEN`
   - `CIRCLE_PAID_ACCESS_GROUP_ID=16841`
   - `OPENAI_API_KEY` (for `transcribe_all.py`, not the backend)
   - `DYNAMOUS_CONTENT_DEPLOY_KEY_PATH=/opt/dynachat/secrets/dynamous-content-deploy`
2. Hook `/opt/dynachat/deploy.sh` to call `deploy/sync-dynamous-content.sh` before `docker compose build && docker compose up app-<color>`.
3. First-time content seeding (one-shot, run on operator machine):
   ```bash
   # from dynamous-engine repo, with the lesson_map.csv from Phase 0 mapping
   cd dark-factory-experiment/scripts && uv sync
   uv run python transcribe_all.py \
       --lesson-map ../../dynamous-engine/Dynamous/Memory/plans/dynamous-content-mapping/lesson_map.csv \
       --google-token ../../dynamous-engine/.claude/scripts/integrations/google_token.json \
       --output-dir /tmp/dynamous-content-stage \
       --max-parallel 4
   # commit + push transcripts to coleam00/dynamous-content
   ```

## Out of scope for this PR

- The Whisper transcription run itself (~$36 + multi-hour clock, operator-driven)
- Initial commit of transcripts to the private `coleam00/dynamous-content` repo
- Production deploy + smoke test execution (manual)
- Webhook receiver for Circle cancellation events (we rely on the 1-hour `/me` refresh)
- Admin UI for content management (CLI only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
