### PR TITLE
fix(conversations): filter empty "New Conversation" rows from sidebar

### DIFF
--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -106,7 +106,13 @@ describe('useConversations', () => {
     it('excludes empty conversations from search results', async () => {
       const conversations = [
         { id: '1', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
-        { id: '2', title: 'New Conversation', created_at: '', updated_at: '', preview: 'Has messages' },
+        {
+          id: '2',
+          title: 'New Conversation',
+          created_at: '',
+          updated_at: '',
+          preview: 'Has messages',
+        },
       ];
       vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
 

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -10,7 +10,9 @@ describe('useConversations', () => {
 
   describe('rename', () => {
     it('should optimistically update conversation title', async () => {
-      const conversations = [{ id: '1', title: 'Old Title', created_at: '', updated_at: '' }];
+      const conversations = [
+        { id: '1', title: 'Old Title', created_at: '', updated_at: '', preview: 'Hello' },
+      ];
       vi.spyOn(api, 'getConversations').mockResolvedValueOnce(conversations as api.Conversation[]);
       vi.spyOn(api, 'renameConversation').mockResolvedValueOnce({} as api.Conversation);
 
@@ -26,7 +28,9 @@ describe('useConversations', () => {
     });
 
     it('should revert on API failure and return error', async () => {
-      const conversations = [{ id: '1', title: 'Original', created_at: '', updated_at: '' }];
+      const conversations = [
+        { id: '1', title: 'Original', created_at: '', updated_at: '', preview: 'Hello' },
+      ];
       vi.spyOn(api, 'getConversations').mockResolvedValueOnce(conversations as api.Conversation[]);
       vi.spyOn(api, 'renameConversation').mockRejectedValueOnce(new Error('Network error'));
 
@@ -41,66 +45,98 @@ describe('useConversations', () => {
     });
   });
 
-  describe('search', () => {
-    it('calls searchConversations when query is non-empty', async () => {
-      const matches = [
-        { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '' },
-        { id: '3', title: 'python advanced', created_at: '', updated_at: '' },
+  describe('empty conversation filtering', () => {
+    it('filters out conversations with no messages (preview === null)', async () => {
+      const conversations = [
+        { id: '1', title: 'Chat A', created_at: '', updated_at: '', preview: 'Hello' },
+        { id: '2', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
+        { id: '3', title: 'Chat B', created_at: '', updated_at: '', preview: 'World' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue([] as api.Conversation[]);
-      const spy = vi
-        .spyOn(api, 'searchConversations')
-        .mockResolvedValueOnce(matches as api.Conversation[]);
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations());
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
+      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['1', '3']);
+      // conversations (unfiltered) still contains all three for guard logic
+      expect(result.current.conversations).toHaveLength(3);
+    });
+
+    it('includes a conversation after its first message is sent', async () => {
+      const conversations = [
+        { id: '1', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations());
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(0));
+
+      // Simulate first message arriving (refetch returns updated data)
+      const updated = [
+        {
+          id: '1',
+          title: 'New Conversation',
+          created_at: '',
+          updated_at: '',
+          preview: 'First message',
+        },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(updated as api.Conversation[]);
+      await result.current.refetch();
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+    });
+  });
+
+  describe('client-side search', () => {
+    it('filters conversations by title case-insensitively', async () => {
+      const conversations = [
+        { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '', preview: 'Hello' },
+        { id: '2', title: 'JavaScript Guide', created_at: '', updated_at: '', preview: 'Hi' },
+        { id: '3', title: 'python advanced', created_at: '', updated_at: '', preview: 'Hey' },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
 
       const { result } = renderHook(() => useConversations('python'));
 
-      await waitFor(() => expect(spy).toHaveBeenCalledWith('python'));
-      await waitFor(() => expect(result.current.conversations).toHaveLength(2));
-      expect(result.current.filteredConversations).toHaveLength(2);
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
+      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['1', '3']);
     });
 
-    it('calls getConversations (not search) when query is empty', async () => {
+    it('excludes empty conversations from search results', async () => {
       const conversations = [
-        { id: '1', title: 'Chat A', created_at: '', updated_at: '' },
-        { id: '2', title: 'Chat B', created_at: '', updated_at: '' },
+        { id: '1', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
+        { id: '2', title: 'New Conversation', created_at: '', updated_at: '', preview: 'Has messages' },
       ];
-      const getSpy = vi
-        .spyOn(api, 'getConversations')
-        .mockResolvedValue(conversations as api.Conversation[]);
-      const searchSpy = vi.spyOn(api, 'searchConversations');
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('New'));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('2');
+    });
+
+    it('returns full list when query is empty', async () => {
+      const conversations = [
+        { id: '1', title: 'Chat A', created_at: '', updated_at: '', preview: 'Hello' },
+        { id: '2', title: 'Chat B', created_at: '', updated_at: '', preview: 'World' },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
 
       const { result } = renderHook(() => useConversations(''));
 
-      await waitFor(() => expect(result.current.conversations).toHaveLength(2));
-      expect(getSpy).toHaveBeenCalled();
-      expect(searchSpy).not.toHaveBeenCalled();
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
     });
 
-    it('trims whitespace-only queries and falls back to full list', async () => {
-      vi.spyOn(api, 'getConversations').mockResolvedValue([
-        { id: '1', title: 'Chat A', created_at: '', updated_at: '' },
-      ] as api.Conversation[]);
-      const searchSpy = vi.spyOn(api, 'searchConversations');
+    it('trims whitespace-only queries and returns full list', async () => {
+      const conversations = [
+        { id: '1', title: 'Chat A', created_at: '', updated_at: '', preview: 'Hello' },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
 
-      renderHook(() => useConversations('   '));
+      const { result } = renderHook(() => useConversations('   '));
 
-      await waitFor(() => expect(api.getConversations).toHaveBeenCalled());
-      expect(searchSpy).not.toHaveBeenCalled();
-    });
-
-    it('refetches when searchQuery prop changes', async () => {
-      vi.spyOn(api, 'getConversations').mockResolvedValue([] as api.Conversation[]);
-      const searchSpy = vi
-        .spyOn(api, 'searchConversations')
-        .mockResolvedValue([] as api.Conversation[]);
-
-      const { rerender } = renderHook(({ q }: { q: string }) => useConversations(q), {
-        initialProps: { q: 'alpha' },
-      });
-      await waitFor(() => expect(searchSpy).toHaveBeenCalledWith('alpha'));
-
-      rerender({ q: 'beta' });
-      await waitFor(() => expect(searchSpy).toHaveBeenCalledWith('beta'));
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
     });
   });
 });

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -45,21 +45,65 @@ describe('useConversations', () => {
     });
   });
 
+  describe('load error handling', () => {
+    it('sets error and clears loading when load fails', async () => {
+      vi.spyOn(api, 'getConversations').mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() => useConversations());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.error).toBe('Network error');
+      expect(result.current.filteredConversations).toEqual([]);
+    });
+
+    it('drops stale responses when concurrent loads overlap', async () => {
+      let resolveStale: (v: api.Conversation[]) => void = () => {};
+      const stalePromise = new Promise<api.Conversation[]>((r) => {
+        resolveStale = r;
+      });
+
+      vi.spyOn(api, 'getConversations')
+        .mockReturnValueOnce(stalePromise)
+        .mockResolvedValueOnce([
+          { id: 'fresh', title: 'Fresh', created_at: '', updated_at: '', preview: 'X' },
+        ] as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations());
+
+      // Trigger overlap: kick off a second refetch before the first (stale) resolves.
+      void result.current.refetch();
+
+      // Fresh response lands first.
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('fresh');
+
+      // Now resolve the stale promise — its result must NOT overwrite the fresh data.
+      resolveStale([
+        { id: 'stale', title: 'Stale', created_at: '', updated_at: '', preview: 'Y' },
+      ] as api.Conversation[]);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(result.current.filteredConversations[0].id).toBe('fresh');
+    });
+  });
+
   describe('empty conversation filtering', () => {
     it('filters out conversations with no messages (preview === null)', async () => {
       const conversations = [
         { id: '1', title: 'Chat A', created_at: '', updated_at: '', preview: 'Hello' },
         { id: '2', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
         { id: '3', title: 'Chat B', created_at: '', updated_at: '', preview: 'World' },
+        // Empty-string preview must pass through — strict null check, not falsy check.
+        { id: '4', title: 'Chat C', created_at: '', updated_at: '', preview: '' },
       ];
       vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
 
       const { result } = renderHook(() => useConversations());
 
-      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
-      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['1', '3']);
-      // conversations (unfiltered) still contains all three for guard logic
-      expect(result.current.conversations).toHaveLength(3);
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(3));
+      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['1', '3', '4']);
+      // conversations (unfiltered) still contains all four for guard logic
+      expect(result.current.conversations).toHaveLength(4);
     });
 
     it('includes a conversation after its first message is sent', async () => {
@@ -143,6 +187,32 @@ describe('useConversations', () => {
       const { result } = renderHook(() => useConversations('   '));
 
       await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+    });
+
+    it('returns empty list when query has no matches', async () => {
+      const conversations = [
+        { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '', preview: 'Hello' },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('rust'));
+
+      // Wait for the underlying load to settle, then assert the filter returns []
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.filteredConversations).toHaveLength(0);
+    });
+
+    it('trims leading/trailing whitespace from non-empty queries', async () => {
+      const conversations = [
+        { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '', preview: 'Hello' },
+        { id: '2', title: 'JavaScript', created_at: '', updated_at: '', preview: 'Hi' },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('  python  '));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('1');
     });
   });
 });

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  type Conversation,
-  getConversations,
-  renameConversation,
-} from '../lib/api';
+import { type Conversation, getConversations, renameConversation } from '../lib/api';
 
 export function useConversations(searchQuery?: string) {
   const [conversations, setConversations] = useState<Conversation[]>([]);

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -3,7 +3,6 @@ import {
   type Conversation,
   getConversations,
   renameConversation,
-  searchConversations,
 } from '../lib/api';
 
 export function useConversations(searchQuery?: string) {
@@ -15,11 +14,10 @@ export function useConversations(searchQuery?: string) {
   const fetchIdRef = useRef(0);
 
   const load = useCallback(async () => {
-    const trimmed = (searchQuery ?? '').trim();
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = trimmed ? await searchConversations(trimmed) : await getConversations();
+      const data = await getConversations();
       if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
       if (myId === fetchIdRef.current) {
@@ -28,7 +26,7 @@ export function useConversations(searchQuery?: string) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, [searchQuery]);
+  }, []);
 
   useEffect(() => {
     load();
@@ -47,12 +45,21 @@ export function useConversations(searchQuery?: string) {
     }
   };
 
+  // Filter out conversations with zero messages (preview === null).
+  // Keep conversations unfiltered for guard logic in Sidebar.tsx.
+  const withMessages = conversations.filter((c) => c.preview !== null);
+
+  const trimmed = (searchQuery ?? '').trim().toLowerCase();
+  const filteredConversations = trimmed
+    ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
+    : withMessages;
+
   return {
     conversations,
     loading,
     error,
     refetch: load,
     rename,
-    filteredConversations: conversations,
+    filteredConversations,
   };
 }


### PR DESCRIPTION
## Linked issue

Fixes #173

## Summary

Frontend-only fix for empty "New Conversation" rows accumulating in the sidebar. The `useConversations` hook now filters out conversations whose `preview === null` (indicating zero messages) before rendering, and switches search to client-side filtering of the full list.

## How this solves the issue

Clicking **+ New Chat** eagerly creates a `conversations` row so the user can start typing immediately. If the user refreshes before sending any message, the empty row persists and `GET /api/conversations` returns it. Because `db/repository.py` and `routes/conversations.py` are protected paths, the fix cannot be applied on the backend.

The `useConversations` hook already separates `conversations` (raw, for guard logic) from `filteredConversations` (render list). This PR:

1. Always fetches the full conversation list via `getConversations()` so `preview` is available for every row.
2. Filters out conversations with `preview === null` into `withMessages`.
3. Applies client-side case-insensitive title search on top of `withMessages`.
4. Returns `conversations` unfiltered so `Sidebar.tsx`'s `handleNewChat` guard (which checks for an active empty conversation) continues to work.

## Test plan

- [x] `useConversations` filters out conversations with `preview === null` (empty conversation filtering regression test)
- [x] `useConversations` includes a conversation after its first message is sent
- [x] `useConversations` filters conversations by title case-insensitively (client-side search)
- [x] `useConversations` excludes empty conversations from search results
- [x] `useConversations` returns full list when query is empty or whitespace-only
- [x] 125 frontend Vitest tests pass

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

Validator will run agent-browser regression during behavioral validation.

## Dependencies

No new dependencies added.

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (additions + deletions) — 153 lines across 2 files
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit