### PR TITLE
chore(deploy): drop channel sync from hourly to daily

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,7 +61,7 @@ container by `docker exec`-ing into the color named in `upstream.conf`. Two
 systemd units in `deploy/systemd/` drive it on a schedule:
 
 - `dynachat-channel-sync.service` — one-shot, calls `sync-channel.sh`
-- `dynachat-channel-sync.timer`   — every hour, with a 5-min jitter
+- `dynachat-channel-sync.timer`   — daily at 00:00 UTC, with a 30-min jitter
 
 ### Install on a host
 

--- a/deploy/systemd/dynachat-channel-sync.timer
+++ b/deploy/systemd/dynachat-channel-sync.timer
@@ -1,15 +1,14 @@
 [Unit]
-Description=Hourly trigger for DynaChat YouTube channel sync
+Description=Daily trigger for DynaChat YouTube channel sync
 Requires=dynachat-channel-sync.service
 
 [Timer]
-# Run roughly hourly. Persistent=true catches up after host reboots so the
-# clock doesn't drift across maintenance windows. RandomizedDelaySec spreads
-# the load so we don't hammer Supadata at :00 every hour if multiple
-# instances ever exist.
-OnBootSec=10min
-OnUnitActiveSec=1h
-RandomizedDelaySec=5min
+# Once a day at 00:00 UTC ± 30min jitter. Persistent=true catches up if the
+# host was down at the scheduled time so we don't silently skip days across
+# maintenance windows. Cole publishes new videos infrequently enough that
+# hourly was overkill and a daily cadence keeps Supadata calls cheap.
+OnCalendar=daily
+RandomizedDelaySec=30min
 Persistent=true
 Unit=dynachat-channel-sync.service
 


### PR DESCRIPTION
## Summary

Cole publishes new YouTube videos infrequently (a few per week) so hitting Supadata 24× per day was overkill. Move the systemd timer to once-daily at 00:00 UTC with a 30-min jitter, keeping `Persistent=true` so we catch up if the host was down at the scheduled time.

Follow-up to #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)