### PR TITLE
fix(chat): suppress EmptyState during chip-driven first-send

### DIFF
--- a/app/frontend/src/__tests__/ChatArea-refreshConversationsRef.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-refreshConversationsRef.test.tsx
@@ -321,4 +321,34 @@ describe('ChatArea refreshConversationsRef', () => {
       'error',
     );
   });
+
+  // Regression test for issue #205: chip-driven first-send left EmptyState visible
+  // because the showMessages branch rendered EmptyState whenever messages.length === 0,
+  // even during the window between route-change and the dispatchedInitialRef effect firing.
+  it('should not render EmptyState when location.state.initialMessage is present (#205)', async () => {
+    // Prevent the dispatchedInitialRef effect's handleSend from making real fetch calls
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }),
+    } as unknown as Response);
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: '/c/conv-1', state: { initialMessage: 'How do subagents work?' } },
+        ]}
+      >
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    // Even though messages === [] on first render, EmptyState must not appear
+    // because location.state.initialMessage signals a first-send in flight.
+    expect(screen.queryByText('Ask anything about the video library')).not.toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -96,8 +96,8 @@ function EmptyState({ onStarterClick }: EmptyStateProps) {
         Ask anything about the video library
       </h2>
       <p style={{ margin: '0 0 24px', color: '#94a3b8', maxWidth: 380, lineHeight: 1.6 }}>
-        This AI has access to transcripts from Cole Medin&apos;s YouTube channel and the
-        Dynamous course + workshop library.
+        This AI has access to transcripts from Cole Medin&apos;s YouTube channel and the Dynamous
+        course + workshop library.
       </p>
       <div
         style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%', maxWidth: 400 }}
@@ -362,7 +362,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
         if (isStreaming) return;
         try {
           const conv = await createConversation();
-          navigate(`/c/${conv.id}`, { state: { initialMessage: content } satisfies ConvLocationState });
+          navigate(`/c/${conv.id}`, {
+            state: { initialMessage: content } satisfies ConvLocationState,
+          });
         } catch (e) {
           console.error(
             '[ChatArea] Failed to create conversation:',
@@ -593,7 +595,10 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
 
         {showMessages && (
           <div style={{ padding: '24px 24px 0', display: 'flex', flexDirection: 'column' }}>
-            {messages.length === 0 && !inlineError ? (
+            {messages.length === 0 &&
+            !inlineError &&
+            !isStreaming &&
+            !location.state?.initialMessage ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
               messages.map((msg) => (

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -493,7 +493,11 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const showMessages = !loading && !error && !notFound && !showEmpty;
   const showSkeleton = loading && !showEmpty;
 
-  const showStreamingBubble = isStreaming;
+  // True when messages.length===0 but a first-send is in flight (chip → navigate → mount).
+  // isStreaming covers the streaming window; location.state?.initialMessage covers the gap
+  // before dispatchedInitialRef fires (#205).
+  const showEmptyInConversation =
+    messages.length === 0 && !inlineError && !isStreaming && !location.state?.initialMessage;
 
   const handleExport = useCallback(() => {
     try {
@@ -595,12 +599,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
 
         {showMessages && (
           <div style={{ padding: '24px 24px 0', display: 'flex', flexDirection: 'column' }}>
-            {/* Hide EmptyState during first-send: !isStreaming covers the streaming window,
-                !location.state?.initialMessage covers the gap before dispatchedInitialRef fires (#205) */}
-            {messages.length === 0 &&
-            !inlineError &&
-            !isStreaming &&
-            !location.state?.initialMessage ? (
+            {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
               messages.map((msg) => (
@@ -615,7 +614,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             )}
 
             {/* Streaming assistant bubble */}
-            {showStreamingBubble && (
+            {isStreaming && (
               <Message
                 role="assistant"
                 content={streamingContent}

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -595,6 +595,8 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
 
         {showMessages && (
           <div style={{ padding: '24px 24px 0', display: 'flex', flexDirection: 'column' }}>
+            {/* Hide EmptyState during first-send: !isStreaming covers the streaming window,
+                !location.state?.initialMessage covers the gap before dispatchedInitialRef fires (#205) */}
             {messages.length === 0 &&
             !inlineError &&
             !isStreaming &&


### PR DESCRIPTION
## Summary

Fixes #205

- The `showMessages` branch in `ChatArea.tsx` rendered `<EmptyState>` whenever `messages.length === 0 && !inlineError`, even during the render window between route-change and the `dispatchedInitialRef` effect firing
- Extended the gate to `!isStreaming && !location.state?.initialMessage` so the empty-state is suppressed whenever a chip-driven first-send is in flight
- Added a regression test verifying `<EmptyState>` is absent when `location.state.initialMessage` is present on mount

## Root cause

When a user clicks a suggestion chip → fills input → hits Send:
1. `handleSend` with no `conversationId` creates a conversation and navigates to `/c/:id` with `state: { initialMessage: content }`
2. The new `ChatArea` mounts with `conversationId` set → `showMessages = true`
3. **First render (before `dispatchedInitialRef` effect fires):** `messages = []`, `isStreaming = false`, old gate evaluates to `true` → `EmptyState` renders (bug)
4. Effect fires: `navigate(replace, state:null)` + `setMessages([tempMsg])` batched by React 18 into one re-render → EmptyState gone

The fix adds two guards:
- `!location.state?.initialMessage` — blocks EmptyState on first render (state still present before effect)
- `!isStreaming` — defense-in-depth for any streaming-starts-before-messages edge case

## Test plan

- [x] All 132 existing frontend tests pass (`bun run test --run`)
- [x] Biome check passes on modified files (`bun x biome check src/components/ChatArea.tsx src/__tests__/...`)
- [x] TypeScript check clean (`bun run tsc --noEmit`)
- [ ] Manual smoke-test: open chat.dynamous.ai, click any suggestion chip, verify empty-state clears immediately and user message bubble appears before assistant streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)