### PR TITLE
feat(video-explorer): make video library titles clickable links

### DIFF
--- a/app/frontend/src/__tests__/VideoExplorer.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer.test.tsx
@@ -567,4 +567,66 @@ describe('VideoExplorer', () => {
       expect(screen.queryByText(/No videos match/)).not.toBeInTheDocument();
     });
   });
+
+  describe('title link', () => {
+    it('renders title as a link to video.url for a YouTube video', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        {
+          id: '1',
+          title: 'YouTube Video Title',
+          description: '',
+          url: 'https://youtube.com/watch?v=abc123',
+          created_at: '2024-01-01T00:00:00Z',
+          source_type: 'youtube',
+        },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('YouTube Video Title')).toBeInTheDocument());
+
+      const link = screen.getByRole('link', { name: 'YouTube Video Title' }) as HTMLAnchorElement;
+      expect(link.href).toContain('youtube.com/watch?v=abc123');
+      expect(link.target).toBe('_blank');
+      expect(link.rel).toContain('noopener');
+      expect(link.rel).toContain('noreferrer');
+    });
+
+    it('renders title as a link to lesson_url for a Dynamous video', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        {
+          id: '2',
+          title: 'Dynamous Lesson Title',
+          description: '',
+          url: 'https://youtube.com/watch?v=xyz',
+          created_at: '2024-01-01T00:00:00Z',
+          source_type: 'dynamous',
+          lesson_url: 'https://community.dynamous.ai/c/lessons/episode-7',
+        },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('Dynamous Lesson Title')).toBeInTheDocument());
+
+      const link = screen.getByRole('link', {
+        name: 'Dynamous Lesson Title',
+      }) as HTMLAnchorElement;
+      expect(link.href).toContain('community.dynamous.ai');
+      expect(link.target).toBe('_blank');
+    });
+
+    it('renders title as plain text when no URL is available', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        {
+          id: '3',
+          title: 'Untitled Video',
+          description: '',
+          url: '',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() => expect(screen.getByText('Untitled Video')).toBeInTheDocument());
+
+      // Title should not be a link
+      expect(screen.queryByRole('link', { name: 'Untitled Video' })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/app/frontend/src/__tests__/VideoExplorer.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer.test.tsx
@@ -610,6 +610,34 @@ describe('VideoExplorer', () => {
       }) as HTMLAnchorElement;
       expect(link.href).toContain('community.dynamous.ai');
       expect(link.target).toBe('_blank');
+      expect(link.rel).toContain('noopener');
+      expect(link.rel).toContain('noreferrer');
+    });
+
+    it('renders title as a link to video.url when source_type is dynamous but lesson_url is absent', async () => {
+      vi.spyOn(api, 'getVideos').mockResolvedValueOnce([
+        {
+          id: '4',
+          title: 'Dynamous Video Without Lesson URL',
+          description: '',
+          url: 'https://youtube.com/watch?v=fallback',
+          created_at: '2024-01-01T00:00:00Z',
+          source_type: 'dynamous',
+          // lesson_url intentionally omitted
+        },
+      ]);
+      render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
+      await waitFor(() =>
+        expect(screen.getByText('Dynamous Video Without Lesson URL')).toBeInTheDocument()
+      );
+
+      const link = screen.getByRole('link', {
+        name: 'Dynamous Video Without Lesson URL',
+      }) as HTMLAnchorElement;
+      expect(link.href).toContain('youtube.com/watch?v=fallback');
+      expect(link.target).toBe('_blank');
+      expect(link.rel).toContain('noopener');
+      expect(link.rel).toContain('noreferrer');
     });
 
     it('renders title as plain text when no URL is available', async () => {

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -49,9 +49,7 @@ function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
           href={titleHref}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight no-underline block"
-          onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')}
-          onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}
+          className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight no-underline hover:underline focus-visible:underline block"
         >
           {highlightMatch(video.title, query)}
         </a>

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -34,6 +34,9 @@ function SkeletonCard() {
 
 // ── Video card ───────────────────────────────────────────────────
 function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
+  const titleHref =
+    video.source_type === 'dynamous' ? (video.lesson_url ?? video.url) : video.url;
+
   return (
     <div
       className="bg-slate-800 border border-white/10 rounded-lg p-3.5 transition-colors duration-150"
@@ -41,9 +44,22 @@ function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
       onMouseLeave={(e) => e.currentTarget.classList.remove('video-card-hover')}
     >
       {/* Title */}
-      <p className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight">
-        {highlightMatch(video.title, query)}
-      </p>
+      {titleHref ? (
+        <a
+          href={titleHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight no-underline block"
+          onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')}
+          onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}
+        >
+          {highlightMatch(video.title, query)}
+        </a>
+      ) : (
+        <p className="text-sm font-semibold text-slate-100 mb-1.5 leading-tight">
+          {highlightMatch(video.title, query)}
+        </p>
+      )}
 
       {/* Description / channel attribution */}
       {video.channel_title ? (

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -31,6 +31,8 @@ export interface Video {
   created_at: string;
   channel_id?: string;
   channel_title?: string;
+  source_type?: 'youtube' | 'dynamous' | string;
+  lesson_url?: string;
 }
 
 export interface Conversation {

--- a/docs/API.md
+++ b/docs/API.md
@@ -323,10 +323,15 @@ List all ingested videos.
     "title": "Introduction to Python",
     "description": "Learn Python basics...",
     "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "source_type": "youtube",
+    "lesson_url": null,
     "created_at": "2026-03-01T10:00:00Z"
   }
 ]
 ```
+
+`source_type` is `"youtube"` for standard YouTube content and `"dynamous"` for Dynamous community lessons.
+`lesson_url` is only present for `source_type: "dynamous"` and points to the Dynamous lesson page.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `source_type` and `lesson_url` fields to the `Video` TypeScript interface in `api.ts` (backend already returns them)
- Replace the plain `<p>` title in `VideoExplorer.tsx` with a conditional `<a>` that routes to `lesson_url` for Dynamous content or `url` for YouTube, opening in a new tab with `rel="noopener noreferrer"`
- Add 3 test cases: YouTube title link, Dynamous title link, and no-URL plain text fallback

## Test plan
- [x] TypeScript compiles clean (`bun x tsc --noEmit`)
- [x] All 134 frontend tests pass (`bun run test`), including 3 new title link tests
- [x] Lint passes on changed files (`bun x biome check` — pre-existing CRLF warnings in unrelated files only)

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)