### PR TITLE
fix(chat): reset streaming state on conversation switch

### DIFF
--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -422,6 +422,11 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           pendingUserMsgIdRef.current = null;
         }
 
+        // Intentional abort (navigation or user cancel) — no error toast
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          return;
+        }
+
         if (e instanceof RateLimitError) {
           // MISSION §10 #1 — daily cap hit. No retry; the user literally
           // can't send another message until the window slides forward.

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -96,8 +96,8 @@ function EmptyState({ onStarterClick }: EmptyStateProps) {
         Ask anything about the video library
       </h2>
       <p style={{ margin: '0 0 24px', color: '#94a3b8', maxWidth: 380, lineHeight: 1.6 }}>
-        This AI has access to transcripts from Cole Medin&apos;s YouTube channel and the
-        Dynamous course + workshop library.
+        This AI has access to transcripts from Cole Medin&apos;s YouTube channel and the Dynamous
+        course + workshop library.
       </p>
       <div
         style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%', maxWidth: 400 }}
@@ -362,7 +362,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
         if (isStreaming) return;
         try {
           const conv = await createConversation();
-          navigate(`/c/${conv.id}`, { state: { initialMessage: content } satisfies ConvLocationState });
+          navigate(`/c/${conv.id}`, {
+            state: { initialMessage: content } satisfies ConvLocationState,
+          });
         } catch (e) {
           console.error(
             '[ChatArea] Failed to create conversation:',

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -302,7 +302,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     isStreaming,
     startStream,
     abortStream,
-  } = useStreamingResponse();
+  } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
   const { refresh: refreshAuth } = useAuth();
 

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -283,7 +283,7 @@ describe('conversationId reset — state clears on navigation', () => {
     vi.clearAllMocks();
   });
 
-  it('resets all streaming state when conversationId changes', async () => {
+  it('resets all streaming state when conversationId changes', () => {
     vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
 
     const { result, rerender } = renderHook(
@@ -308,7 +308,7 @@ describe('conversationId reset — state clears on navigation', () => {
     expect(result.current.streamingStatus).toBeNull();
   });
 
-  it('resets streaming state when conversationId changes to null', async () => {
+  it('resets streaming state when conversationId changes to null', () => {
     vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
 
     const { result, rerender } = renderHook(

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for useStreamingResponse hook SSE parsing.
+ * Tests for useStreamingResponse hook SSE parsing and state management.
  *
  * Verifies:
  *   - Parses sources event with Citation[] objects into streamingSources state
  *   - Handles malformed sources JSON gracefully with console.warn
+ *   - Resets all streaming state (and aborts in-flight fetch) when conversationId changes
  */
 
 import { act, renderHook } from '@testing-library/react';
@@ -295,6 +296,9 @@ describe('conversationId reset — state clears on navigation', () => {
       void result.current.startStream('conv-a', 'hello', vi.fn());
     });
 
+    // Verify streaming started before testing the reset
+    expect(result.current.isStreaming).toBe(true);
+
     // Switch conversation — effect should reset all state
     rerender({ convId: 'conv-b' });
 
@@ -344,9 +348,88 @@ describe('conversationId reset — state clears on navigation', () => {
       await result.current.startStream('conv-a', 'hi', onComplete);
     });
 
-    // Re-render with same conversationId — onComplete should have been called
+    // Re-render with same conversationId — effect must NOT reset state
     rerender({ convId: 'conv-a' });
 
+    // onComplete was called by startStream when the stream completed above
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ fullText: 'Hello' }));
+  });
+});
+
+describe('sources event — hook state via renderHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dispatches sources to streamingSources state via the real hook', async () => {
+    const citation = {
+      chunk_id: 'chunk-1',
+      video_id: 'vid-1',
+      video_title: 'Test Video',
+      video_url: 'https://www.youtube.com/watch?v=abc123',
+      start_seconds: 10,
+      end_seconds: 20,
+      snippet: 'Test snippet text',
+    };
+    const sseChunks = [
+      `event: sources\ndata: ${JSON.stringify([citation])}\n\n`,
+      'data: "Answer"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', onComplete);
+    });
+
+    // Sources are passed to onComplete before the finally block clears state
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sources: [expect.objectContaining({ chunk_id: 'chunk-1' })],
+      }),
+    );
+  });
+
+  it('leaves streamingSources empty and warns on malformed sources JSON', async () => {
+    const sseChunks = [
+      'event: sources\ndata: not-valid-json\n\n',
+      'data: "Answer"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', onComplete);
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useStreamingResponse] Failed to parse sources event:',
+      expect.any(Error),
+    );
+    // onComplete still fires with empty sources on parse failure
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ sources: [] }));
   });
 });

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -283,10 +283,7 @@ describe('conversationId reset — state clears on navigation', () => {
   });
 
   it('resets all streaming state when conversationId changes', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockReturnValue(new Promise(() => {})),
-    );
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
 
     const { result, rerender } = renderHook(
       ({ convId }: { convId: string | null }) => useStreamingResponse(convId),
@@ -308,10 +305,7 @@ describe('conversationId reset — state clears on navigation', () => {
   });
 
   it('resets streaming state when conversationId changes to null', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockReturnValue(new Promise(() => {})),
-    );
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
 
     const { result, rerender } = renderHook(
       ({ convId }: { convId: string | null }) => useStreamingResponse(convId),
@@ -329,10 +323,7 @@ describe('conversationId reset — state clears on navigation', () => {
   });
 
   it('does not reset state when conversationId stays the same', async () => {
-    const sseChunks = [
-      'data: "Hello"\n\n',
-      'data: [DONE]\n\n',
-    ];
+    const sseChunks = ['data: "Hello"\n\n', 'data: [DONE]\n\n'];
 
     vi.stubGlobal(
       'fetch',

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -155,7 +155,7 @@ describe('status event SSE parsing — hook state transitions', () => {
     );
 
     const onComplete = vi.fn();
-    const { result } = renderHook(() => useStreamingResponse());
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
 
     await act(async () => {
       await result.current.startStream('conv-1', 'hi', onComplete);
@@ -189,7 +189,7 @@ describe('status event SSE parsing — hook state transitions', () => {
       }),
     );
 
-    const { result } = renderHook(() => useStreamingResponse());
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
 
     await act(async () => {
       await result.current.startStream('conv-1', 'hi', vi.fn());
@@ -216,7 +216,7 @@ describe('status event SSE parsing — hook state transitions', () => {
       }),
     );
 
-    const { result } = renderHook(() => useStreamingResponse());
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
 
     await act(async () => {
       await result.current.startStream('conv-1', 'hi', vi.fn());
@@ -247,7 +247,7 @@ describe('status event SSE parsing — hook state transitions', () => {
       }),
     );
 
-    const { result } = renderHook(() => useStreamingResponse());
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
 
     await act(async () => {
       await result.current.startStream('conv-1', 'hi', vi.fn());
@@ -263,16 +263,99 @@ describe('abortStream', () => {
   });
 
   it('should be a no-op when no stream is active', () => {
-    const { result } = renderHook(() => useStreamingResponse());
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
     expect(result.current.abortStream).not.toThrow();
     expect(result.current.isStreaming).toBe(false);
   });
 
   it('should be callable multiple times without throwing', () => {
-    const { result } = renderHook(() => useStreamingResponse());
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
     result.current.abortStream();
     result.current.abortStream();
     result.current.abortStream();
     expect(result.current.isStreaming).toBe(false);
+  });
+});
+
+describe('conversationId reset — state clears on navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resets all streaming state when conversationId changes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise(() => {})),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ convId }: { convId: string | null }) => useStreamingResponse(convId),
+      { initialProps: { convId: 'conv-a' } },
+    );
+
+    // Start streaming (fire-and-forget — promise never resolves)
+    act(() => {
+      void result.current.startStream('conv-a', 'hello', vi.fn());
+    });
+
+    // Switch conversation — effect should reset all state
+    rerender({ convId: 'conv-b' });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.streamingSources).toHaveLength(0);
+    expect(result.current.streamingStatus).toBeNull();
+  });
+
+  it('resets streaming state when conversationId changes to null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise(() => {})),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ convId }: { convId: string | null }) => useStreamingResponse(convId),
+      { initialProps: { convId: 'conv-a' as string | null } },
+    );
+
+    act(() => {
+      void result.current.startStream('conv-a', 'hello', vi.fn());
+    });
+
+    rerender({ convId: null });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+  });
+
+  it('does not reset state when conversationId stays the same', async () => {
+    const sseChunks = [
+      'data: "Hello"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ convId }: { convId: string | null }) => useStreamingResponse(convId),
+      { initialProps: { convId: 'conv-a' } },
+    );
+
+    await act(async () => {
+      await result.current.startStream('conv-a', 'hi', onComplete);
+    });
+
+    // Re-render with same conversationId — onComplete should have been called
+    rerender({ convId: 'conv-a' });
+
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ fullText: 'Hello' }));
   });
 });

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { type Citation, RateLimitError } from '../lib/api';
 
 export interface StreamResult {
@@ -11,13 +11,26 @@ export interface StreamingStatus {
   subject: string;
 }
 
-export function useStreamingResponse() {
+export function useStreamingResponse(conversationId: string | null) {
   const [streamingContent, setStreamingContent] = useState<string>('');
   const [streamingSources, setStreamingSources] = useState<Citation[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingStatus, setStreamingStatus] = useState<StreamingStatus | null>(null);
 
   const streamAbortRef = useRef<AbortController | null>(null);
+
+  // Reset all streaming state and abort any in-flight fetch when the
+  // conversation changes. Mirrors the reset pattern in useMessages.ts.
+  useEffect(() => {
+    if (streamAbortRef.current) {
+      streamAbortRef.current.abort();
+      streamAbortRef.current = null;
+    }
+    setIsStreaming(false);
+    setStreamingContent('');
+    setStreamingSources([]);
+    setStreamingStatus(null);
+  }, [conversationId]);
 
   const abortStream = useCallback(() => {
     if (streamAbortRef.current) {


### PR DESCRIPTION
## Summary

- `useStreamingResponse` now accepts a `conversationId` parameter and resets all streaming state (+ aborts in-flight fetch) when it changes
- `ChatArea` forwards its `conversationId` prop into the hook
- Added 3 tests covering reset-on-nav, reset-to-null, and no-reset-on-same-id

## Problem

Streaming state (`isStreaming`, `streamingContent`, `streamingSources`, `streamingStatus`) persisted across conversation switches because `useStreamingResponse` had no awareness of the active conversation. A stuck or in-flight stream bled into other conversations, showing a phantom streaming indicator that only cleared on full page refresh.

## Root cause

`useStreamingResponse` owned mutable state but lacked a `conversationId` dependency and a `useEffect` to reset+abort on change — unlike `useMessages` which already had this pattern.

## Test plan

- [x] Type check passes (`bun run tsc --noEmit`)
- [x] All 134 frontend tests pass (`bun run test`)
- [x] New tests verify state resets on conversationId change
- [ ] Manual: start a stream → switch conversations → verify no stale streaming UI

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)