### PR TITLE
fix(citations): collapse same-video chunks into single citation chip

### DIFF
--- a/app/backend/alembic/versions/0005_gated_dynamous_content.py
+++ b/app/backend/alembic/versions/0005_gated_dynamous_content.py
@@ -41,10 +41,7 @@ def upgrade() -> None:
         ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb
         """
     )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS videos_content_path_idx "
-        "ON videos (content_path)"
-    )
+    op.execute("CREATE INDEX IF NOT EXISTS videos_content_path_idx ON videos (content_path)")
 
     # --- chunks: denormalize source_type for fast ACL filtering ----------
     # Default 'youtube' is correct for existing rows (all pre-#147 chunks
@@ -55,10 +52,7 @@ def upgrade() -> None:
         ADD COLUMN IF NOT EXISTS source_type TEXT NOT NULL DEFAULT 'youtube'
         """
     )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS chunks_source_type_idx "
-        "ON chunks (source_type)"
-    )
+    op.execute("CREATE INDEX IF NOT EXISTS chunks_source_type_idx ON chunks (source_type)")
 
     # --- users: Circle membership tracking -------------------------------
     op.execute(

--- a/app/backend/ingest/dynamous.py
+++ b/app/backend/ingest/dynamous.py
@@ -119,7 +119,9 @@ def _parse_segments(body: str) -> list[dict[str, Any]]:
             if i + 1 < len(matches)
             else float(start)  # filler — caller may override
         )
-        segments.append({"start": float(start), "end": float(end), "text": text, "heading": heading})
+        segments.append(
+            {"start": float(start), "end": float(end), "text": text, "heading": heading}
+        )
     # The last segment's end_seconds = start_seconds (we don't know duration);
     # acceptable since the chunker preserves both for citation rendering.
     return segments
@@ -165,9 +167,7 @@ async def ingest_dynamous_content(content_dir: Path) -> dict[str, int]:
     return counts
 
 
-async def _ingest_one_file(
-    md_path: Path, rel_path: str, pool: Any, counts: dict[str, int]
-) -> None:
+async def _ingest_one_file(md_path: Path, rel_path: str, pool: Any, counts: dict[str, int]) -> None:
     """Process one transcript file. Idempotent."""
     text = md_path.read_text(encoding="utf-8")
     fm, body = _parse_frontmatter(text)

--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -73,9 +73,7 @@ async def verify_paid_member(email: str) -> bool:
                 return False
 
             # Step 2: confirm the member is in the paid access group
-            r2 = await client.get(
-                f"{CIRCLE_BASE}/community_members/{member_id}/access_groups"
-            )
+            r2 = await client.get(f"{CIRCLE_BASE}/community_members/{member_id}/access_groups")
             if r2.status_code != 200:
                 logger.warning(
                     "Circle access_groups returned %s for member %s; fail-closed",

--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -134,7 +134,7 @@ async def build_system_prompt(max_tool_calls: int = 0, is_member: bool = False) 
     if CATALOG_ENABLED:
         videos = await catalog.get_catalog()
         if not is_member:
-            videos = [v for v in videos if (v.get("source_type") or "youtube") == "youtube"]
+            videos = [v for v in videos if v.get("source_type", "youtube") == "youtube"]
         if videos:
             blocks.append(catalog.build_catalog_block(videos, CATALOG_TIER))
             return blocks

--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -104,7 +104,8 @@ Rules.
 - Multiple chunks supporting the same sentence stack: `[c:abc123][c:def456]`.
 - Copy the marker verbatim from the tool result. Do not invent ids.
 - Markers are protocol tokens, not exposition: never explain them, never
-  describe them, just emit them at sentence end."""
+  describe them, just emit them at sentence end.
+- When multiple chunks come from the same video, cite only one marker per video per sentence. The UI automatically collapses same-video citations into a single chip — emitting every chunk marker from a transcript call clutters the raw text without adding information for the user."""
 
 
 SYSTEM_PROMPT_TEMPLATE = _BASE_SYSTEM_PROMPT
@@ -133,10 +134,7 @@ async def build_system_prompt(max_tool_calls: int = 0, is_member: bool = False) 
     if CATALOG_ENABLED:
         videos = await catalog.get_catalog()
         if not is_member:
-            videos = [
-                v for v in videos
-                if (v.get("source_type") or "youtube") == "youtube"
-            ]
+            videos = [v for v in videos if (v.get("source_type") or "youtube") == "youtube"]
         if videos:
             blocks.append(catalog.build_catalog_block(videos, CATALOG_TIER))
             return blocks

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -211,6 +211,10 @@ async def create_message(
                         cited_ids = extract_cited_chunk_ids(final_text_raw)
                         for chunk in source_citations:
                             chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+                        # Collapse same-video chunks (issue #208): keep one
+                        # entry per video_id, choosing the earliest-cited
+                        # timestamp as the representative.
+                        source_citations[:] = _collapse_by_video(source_citations)
                         # Cap fallback (issue #176): cited pass through, non-cited sliced.
                         cited = [c for c in source_citations if c.get("is_cited")]
                         uncited = [c for c in source_citations if not c.get("is_cited")]
@@ -460,3 +464,45 @@ async def _maybe_set_conversation_title(
         else:
             title = first_user_message.strip()
         await repository.update_conversation_title(conv_id, user_id=user_id, title=title)
+
+
+def _collapse_by_video(chunks: list[dict]) -> list[dict]:
+    """Collapse multiple chunks from the same video into a single citation entry.
+
+    After the ``is_cited`` pass, chunks from the same video are redundant in
+    the UI — the user needs one clickable chip per video, not one per 5-second
+    transcript segment (issue #208).
+
+    For each ``video_id`` group:
+    - ``is_cited`` is True if ANY chunk in the group was cited by the LLM.
+    - ``start_seconds`` is the earliest timestamp among cited chunks (or among
+      all chunks if none were cited), so the deep-link opens near the most
+      relevant moment.
+    - ``segment_count`` records how many chunks were collapsed so the frontend
+      can optionally display "(N segments)".
+    - All other fields are taken from the representative chunk.
+
+    Insertion order of videos is preserved (first-seen wins).
+    """
+    seen: dict[str, list[dict]] = {}
+    for c in chunks:
+        vid = c.get("video_id") or ""
+        if vid not in seen:
+            seen[vid] = []
+        seen[vid].append(c)
+
+    collapsed: list[dict] = []
+    for group in seen.values():
+        cited_in_group = [c for c in group if c.get("is_cited")]
+        if cited_in_group:
+            representative = min(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0)
+            is_cited = True
+        else:
+            representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
+            is_cited = False
+        entry = dict(representative)
+        entry["is_cited"] = is_cited
+        entry["segment_count"] = len(group)
+        collapsed.append(entry)
+
+    return collapsed

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -142,7 +142,7 @@ async def create_message(
         # Captured at the start of the turn so the entire tool sequence sees
         # consistent ACL — even if /me later flips is_member, the in-flight
         # turn won't change behavior mid-flight.
-        is_member_for_turn = bool(current_user.get("is_member") or False)
+        is_member_for_turn = bool(current_user.get("is_member", False))
 
         async def _executor(name: str, raw_args: str) -> str:
             # Pass `None` (not empty set) when the whitelist failed to load so

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -466,7 +466,7 @@ async def _maybe_set_conversation_title(
         await repository.update_conversation_title(conv_id, user_id=user_id, title=title)
 
 
-def _collapse_by_video(chunks: list[dict]) -> list[dict]:
+def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Collapse multiple chunks from the same video into a single citation entry.
 
     After the ``is_cited`` pass, chunks from the same video are redundant in

--- a/app/backend/scripts/sync_channel.py
+++ b/app/backend/scripts/sync_channel.py
@@ -51,9 +51,7 @@ async def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     logger = logging.getLogger("sync_channel_cli")
-    logger.info(
-        "starting channel sync via CLI (limit=%s, force=%s)", args.limit, args.force
-    )
+    logger.info("starting channel sync via CLI (limit=%s, force=%s)", args.limit, args.force)
 
     # Stand the asyncpg pool up ourselves — the FastAPI lifespan does this
     # at uvicorn startup, but we're a separate Python process inside the same

--- a/app/backend/tests/test_auth_circle.py
+++ b/app/backend/tests/test_auth_circle.py
@@ -64,7 +64,7 @@ def fake_users_repo(monkeypatch):
 
     async def get_user_by_id(user_id: Any) -> dict[str, Any] | None:
         u = store.get(str(user_id))
-        return ({k: v for k, v in u.items() if k != "password_hash"} if u else None)
+        return {k: v for k, v in u.items() if k != "password_hash"} if u else None
 
     async def update_last_login(user_id: Any) -> None:
         u = store.get(str(user_id))

--- a/app/backend/tests/test_catalog.py
+++ b/app/backend/tests/test_catalog.py
@@ -175,9 +175,24 @@ async def test_build_system_prompt_catalog_excludes_dynamous_for_non_members() -
     from backend.llm.openrouter import build_system_prompt
 
     full_catalog = [
-        {"id": "yt-1", "title": "YouTube Vid 1", "url": "https://youtu.be/x", "source_type": "youtube"},
-        {"id": "dyn-1", "title": "1.6 Conversational vs. Autonomous Agents", "url": "", "source_type": "dynamous"},
-        {"id": "yt-2", "title": "YouTube Vid 2", "url": "https://youtu.be/y", "source_type": "youtube"},
+        {
+            "id": "yt-1",
+            "title": "YouTube Vid 1",
+            "url": "https://youtu.be/x",
+            "source_type": "youtube",
+        },
+        {
+            "id": "dyn-1",
+            "title": "1.6 Conversational vs. Autonomous Agents",
+            "url": "",
+            "source_type": "dynamous",
+        },
+        {
+            "id": "yt-2",
+            "title": "YouTube Vid 2",
+            "url": "https://youtu.be/y",
+            "source_type": "youtube",
+        },
     ]
     with (
         patch("backend.llm.openrouter.CATALOG_ENABLED", True),
@@ -200,8 +215,18 @@ async def test_build_system_prompt_catalog_includes_dynamous_for_members() -> No
     from backend.llm.openrouter import build_system_prompt
 
     full_catalog = [
-        {"id": "yt-1", "title": "YouTube Vid 1", "url": "https://youtu.be/x", "source_type": "youtube"},
-        {"id": "dyn-1", "title": "1.6 Conversational vs. Autonomous Agents", "url": "", "source_type": "dynamous"},
+        {
+            "id": "yt-1",
+            "title": "YouTube Vid 1",
+            "url": "https://youtu.be/x",
+            "source_type": "youtube",
+        },
+        {
+            "id": "dyn-1",
+            "title": "1.6 Conversational vs. Autonomous Agents",
+            "url": "",
+            "source_type": "dynamous",
+        },
     ]
     with (
         patch("backend.llm.openrouter.CATALOG_ENABLED", True),

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -113,9 +113,7 @@ async def test_inactive_member_returns_false():
 async def test_records_wrapped_response_handled():
     """Some Circle endpoints wrap a single record in `records: [...]`."""
     respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
-        return_value=httpx.Response(
-            200, json={"records": [{"id": 999, "active": True}]}
-        )
+        return_value=httpx.Response(200, json={"records": [{"id": 999, "active": True}]})
     )
     respx.get("https://app.circle.so/api/admin/v2/community_members/999/access_groups").mock(
         return_value=httpx.Response(200, json={"records": [{"id": 16841}]})

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -260,3 +260,21 @@ class TestSseIntegration:
         assert by_vid["v2"]["is_cited"] is True
         assert by_vid["v2"]["segment_count"] == 3
         assert by_vid["v2"]["start_seconds"] == 0.0  # v2c0
+
+    async def test_collapse_uncited_group_picks_earliest_timestamp(self) -> None:
+        """All same-video chunks uncited → is_cited=False, earliest start_seconds selected."""
+        chunks = [
+            {**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)}
+            for i in range(3)
+        ]
+        # No markers in answer — nothing cited
+        body = await _post_message(
+            answer_tokens=["Plain answer."],
+            retrieved_chunks=chunks,
+        )
+        payload = _parse_sources(body)
+        assert len(payload) == 1
+        entry = payload[0]
+        assert entry["is_cited"] is False
+        assert entry["segment_count"] == 3
+        assert entry["start_seconds"] == 0.0  # c0, earliest

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -106,7 +106,7 @@ async def _post_message(*, answer_tokens: list[str], retrieved_chunks: list[dict
         tool_executor=None,
         max_tool_calls=0,
         final_text_out=None,
-    **_kwargs,
+        **_kwargs,
     ):
         if tool_executor is not None:
             await tool_executor("search_videos", json.dumps({"query": "t"}))
@@ -195,10 +195,11 @@ class TestSseIntegration:
         assert payload[0]["is_cited"] is True
 
     async def test_uncited_capped_at_citations_max_count(self) -> None:
-        """No markers + retrieval > cap → SSE payload sliced to CITATIONS_MAX_COUNT."""
+        """No markers + retrieval > cap → SSE payload sliced to CITATIONS_MAX_COUNT.
+        Each chunk uses a distinct video_id so collapse doesn't reduce the count."""
         from backend.config import CITATIONS_MAX_COUNT
 
-        chunks = [_chunk(f"c{i}") for i in range(CITATIONS_MAX_COUNT + 5)]
+        chunks = [_chunk(f"c{i}", f"v{i}") for i in range(CITATIONS_MAX_COUNT + 5)]
         body = await _post_message(
             answer_tokens=["Plain answer with no markers."],
             retrieved_chunks=chunks,
@@ -207,10 +208,11 @@ class TestSseIntegration:
 
     async def test_cited_pass_through_uncited_capped(self) -> None:
         """Cited chunks always render (model's choice); only the consulted
-        tier is capped. Verifies the cap targets the right list."""
+        tier is capped. Verifies the cap targets the right list.
+        Each chunk uses a distinct video_id so collapse doesn't reduce the count."""
         from backend.config import CITATIONS_MAX_COUNT
 
-        chunks = [_chunk(f"c{i}") for i in range(CITATIONS_MAX_COUNT + 3)]
+        chunks = [_chunk(f"c{i}", f"v{i}") for i in range(CITATIONS_MAX_COUNT + 3)]
         body = await _post_message(
             answer_tokens=[f"Cited [c:c0][c:c{CITATIONS_MAX_COUNT + 1}]."],
             retrieved_chunks=chunks,
@@ -220,3 +222,41 @@ class TestSseIntegration:
         assert cited_ids == {"c0", f"c{CITATIONS_MAX_COUNT + 1}"}
         # 2 cited + CITATIONS_MAX_COUNT non-cited = 12 total.
         assert len(payload) == 2 + CITATIONS_MAX_COUNT
+
+    async def test_same_video_chunks_collapsed_to_one_citation(self) -> None:
+        """Multiple chunks from the same video collapse into a single citation
+        entry (issue #208). segment_count reflects the original chunk count."""
+        chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)} for i in range(5)]
+        # Only c2 (start_seconds=20.0) is cited
+        body = await _post_message(
+            answer_tokens=["Answer [c:c2]."],
+            retrieved_chunks=chunks,
+        )
+        payload = _parse_sources(body)
+        assert len(payload) == 1
+        entry = payload[0]
+        assert entry["video_id"] == "v1"
+        assert entry["is_cited"] is True
+        assert entry["segment_count"] == 5
+        # Representative picks earliest cited chunk → c2 at 20.0s
+        assert entry["start_seconds"] == 20.0
+
+    async def test_collapse_two_videos_preserves_both(self) -> None:
+        """Chunks from two different videos collapse to two entries, each with
+        correct is_cited and segment_count."""
+        chunks_v1 = [{**_chunk(f"v1c{i}", "v1"), "start_seconds": float(i * 5)} for i in range(3)]
+        chunks_v2 = [{**_chunk(f"v2c{i}", "v2"), "start_seconds": float(i * 5)} for i in range(3)]
+        # v1c1 and v2c0 are cited
+        body = await _post_message(
+            answer_tokens=["From v1 [c:v1c1]. From v2 [c:v2c0]."],
+            retrieved_chunks=chunks_v1 + chunks_v2,
+        )
+        payload = _parse_sources(body)
+        assert len(payload) == 2
+        by_vid = {e["video_id"]: e for e in payload}
+        assert by_vid["v1"]["is_cited"] is True
+        assert by_vid["v1"]["segment_count"] == 3
+        assert by_vid["v1"]["start_seconds"] == 5.0  # v1c1
+        assert by_vid["v2"]["is_cited"] is True
+        assert by_vid["v2"]["segment_count"] == 3
+        assert by_vid["v2"]["start_seconds"] == 0.0  # v2c0

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -151,8 +151,12 @@ class TestRetrieveHybrid:
             assert mock_vec.called
 
             # Verify correct arguments passed (over-fetch factor applied)
-            mock_kw.assert_called_once_with("test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"])
-            mock_vec.assert_called_once_with([0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"])
+            mock_kw.assert_called_once_with(
+                "test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"]
+            )
+            mock_vec.assert_called_once_with(
+                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"]
+            )
 
             # Verify result shape has all required citation fields
             assert len(result) >= 1

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -752,7 +752,12 @@ class TestRefusalSourcesSuppressionIntegration:
         ]
 
         async def mock_stream_chat(
-            messages, tools=None, tool_executor=None, max_tool_calls=0, final_text_out=None, **_kwargs
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
         ):
             if tool_executor is not None:
                 await tool_executor("search_videos", json.dumps({"query": "test"}))
@@ -761,7 +766,9 @@ class TestRefusalSourcesSuppressionIntegration:
                 final_text_out.append(refusal_text)
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         test_user_id = str(uuid4())
@@ -849,7 +856,12 @@ class TestRefusalSourcesSuppressionIntegration:
         # an injected closure. We simulate a successful search + then a refusal
         # response by calling the executor ourselves inside mock_stream_chat.
         async def mock_stream_chat(
-            messages, tools=None, tool_executor=None, max_tool_calls=0, final_text_out=None, **_kwargs
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
         ):
             if tool_executor is not None:
                 await tool_executor("search_videos", json.dumps({"query": "test"}))
@@ -858,7 +870,9 @@ class TestRefusalSourcesSuppressionIntegration:
                 final_text_out.append(refusal_text)
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         from uuid import uuid4
@@ -947,7 +961,12 @@ class TestRefusalSourcesSuppressionIntegration:
         ]
 
         async def mock_stream_chat(
-            messages, tools=None, tool_executor=None, max_tool_calls=0, final_text_out=None, **_kwargs
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
         ):
             if tool_executor is not None:
                 await tool_executor("search_videos", json.dumps({"query": "test"}))
@@ -956,7 +975,9 @@ class TestRefusalSourcesSuppressionIntegration:
                 final_text_out.append(answer_text)
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         from uuid import uuid4
@@ -1060,7 +1081,7 @@ class TestChunkExpansionIntegration:
             tool_executor=None,
             max_tool_calls=0,
             final_text_out=None,
-        **_kwargs,
+            **_kwargs,
         ):
             if tool_executor is not None:
                 await tool_executor("search_videos", json.dumps({"query": "test"}))
@@ -1069,7 +1090,9 @@ class TestChunkExpansionIntegration:
                 final_text_out.append("The video explains it works.")
             yield done_chunk
 
-        async def mock_execute_tool(name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False):
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
         from uuid import uuid4

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -96,8 +96,8 @@ function EmptyState({ onStarterClick }: EmptyStateProps) {
         Ask anything about the video library
       </h2>
       <p style={{ margin: '0 0 24px', color: '#94a3b8', maxWidth: 380, lineHeight: 1.6 }}>
-        This AI has access to transcripts from Cole Medin&apos;s YouTube channel and the
-        Dynamous course + workshop library.
+        This AI has access to transcripts from Cole Medin&apos;s YouTube channel and the Dynamous
+        course + workshop library.
       </p>
       <div
         style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%', maxWidth: 400 }}
@@ -362,7 +362,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
         if (isStreaming) return;
         try {
           const conv = await createConversation();
-          navigate(`/c/${conv.id}`, { state: { initialMessage: content } satisfies ConvLocationState });
+          navigate(`/c/${conv.id}`, {
+            state: { initialMessage: content } satisfies ConvLocationState,
+          });
         } catch (e) {
           console.error(
             '[ChatArea] Failed to create conversation:',

--- a/app/frontend/src/components/CitationModal.tsx
+++ b/app/frontend/src/components/CitationModal.tsx
@@ -36,10 +36,10 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
     : '';
 
   const externalUrl = isDynamous
-    ? citation.lesson_url ?? ''
+    ? (citation.lesson_url ?? '')
     : videoId
-    ? `https://www.youtube.com/watch?v=${videoId}&t=${startSeconds}s`
-    : '';
+      ? `https://www.youtube.com/watch?v=${videoId}&t=${startSeconds}s`
+      : '';
 
   const externalLabel = isDynamous ? 'Open on Dynamous' : 'Open on YouTube';
 

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { Citation } from '../lib/api';
 import { Message } from './Message';
 
 describe('Message — streamingStatus rendering', () => {
@@ -49,5 +50,62 @@ describe('Message — streamingStatus rendering', () => {
     );
     expect(screen.getByText('Answer here.')).toBeInTheDocument();
     expect(screen.queryByText(/Searching/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — citation chip segment_count label', () => {
+  const baseCitation: Citation = {
+    chunk_id: 'c1',
+    video_id: 'v1',
+    video_title: 'Demo Video',
+    video_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    start_seconds: 60,
+    end_seconds: 70,
+    snippet: 'snippet text',
+    is_cited: true,
+  };
+
+  it('shows "(N segments)" suffix when segment_count > 1', () => {
+    const citation = { ...baseCitation, segment_count: 4 };
+    render(
+      <Message
+        role="assistant"
+        content="Answer text."
+        isStreaming={false}
+        streamingStatus={null}
+        sources={[citation]}
+        onCitationClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /\(4 segments\)/ })).toBeInTheDocument();
+  });
+
+  it('omits segment label when segment_count is 1', () => {
+    const citation = { ...baseCitation, segment_count: 1 };
+    render(
+      <Message
+        role="assistant"
+        content="Answer text."
+        isStreaming={false}
+        streamingStatus={null}
+        sources={[citation]}
+        onCitationClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+
+  it('omits segment label when segment_count is absent', () => {
+    render(
+      <Message
+        role="assistant"
+        content="Answer text."
+        isStreaming={false}
+        streamingStatus={null}
+        sources={[baseCitation]}
+        onCitationClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -61,6 +61,9 @@ function citationChip(
       }}
     >
       {formatTimestamp(citation.start_seconds)} — {citation.video_title}
+      {citation.segment_count && citation.segment_count > 1
+        ? ` (${citation.segment_count} segments)`
+        : ''}
     </button>
   );
 }

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -61,9 +61,7 @@ function citationChip(
       }}
     >
       {formatTimestamp(citation.start_seconds)} — {citation.video_title}
-      {citation.segment_count && citation.segment_count > 1
-        ? ` (${citation.segment_count} segments)`
-        : ''}
+      {(citation.segment_count ?? 0) > 1 ? ` (${citation.segment_count} segments)` : ''}
     </button>
   );
 }

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -107,6 +107,19 @@ export class ApiError extends Error {
   }
 }
 
+// Try to extract `detail` from the FastAPI JSON error envelope, fall
+// back to raw text so we still surface unexpected responses.
+async function parseErrorDetail(res: Response): Promise<string> {
+  const text = await res.text();
+  try {
+    const parsed = JSON.parse(text) as { detail?: string };
+    if (typeof parsed?.detail === 'string') return parsed.detail;
+  } catch {
+    // not JSON — keep text as-is
+  }
+  return text;
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     credentials: 'include',
@@ -122,19 +135,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     throw new ApiError(401, 'Not authenticated');
   }
   if (!res.ok) {
-    const text = await res.text();
-    // Try to extract `detail` from the FastAPI JSON error envelope, fall
-    // back to raw text so we still surface unexpected responses.
-    let detail = text;
-    try {
-      const parsed = JSON.parse(text) as { detail?: string };
-      if (parsed && typeof parsed.detail === 'string') {
-        detail = parsed.detail;
-      }
-    } catch {
-      // not JSON — keep `text` as-is
-    }
-    throw new ApiError(res.status, detail);
+    throw new ApiError(res.status, await parseErrorDetail(res));
   }
   return res.json() as Promise<T>;
 }
@@ -225,15 +226,7 @@ export const deleteVideo = async (id: string): Promise<void> => {
     credentials: 'include',
   });
   if (!res.ok) {
-    const text = await res.text();
-    let detail = text;
-    try {
-      const parsed = JSON.parse(text) as { detail?: string };
-      if (parsed && typeof parsed.detail === 'string') detail = parsed.detail;
-    } catch {
-      // not JSON
-    }
-    throw new ApiError(res.status, detail);
+    throw new ApiError(res.status, await parseErrorDetail(res));
   }
 };
 

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -69,6 +69,11 @@ export interface Citation {
    * empty for YouTube citations.
    */
   lesson_url?: string;
+  /**
+   * Number of transcript segments collapsed into this citation (issue #208).
+   * Only present for citations generated server-side after collapse.
+   */
+  segment_count?: number;
 }
 
 export interface Message {

--- a/docs/API.md
+++ b/docs/API.md
@@ -266,10 +266,13 @@ Example sources array:
     "video_url": "https://www.youtube.com/watch?v=abc123xyz",
     "start_seconds": 145.5,
     "end_seconds": 162.3,
-    "snippet": "...decorators wrap a function to extend its behavior..."
+    "snippet": "...decorators wrap a function to extend its behavior...",
+    "segment_count": 3
   }
 ]
 ```
+
+`segment_count` — number of transcript chunks from the same video that were collapsed into this single citation entry. Always ≥ 1. The frontend displays "(N segments)" when this value is > 1.
 
 **`[DONE]` Terminator:**
 ```


### PR DESCRIPTION
## Linked issue

Fixes #208

## Summary

When the LLM calls `get_video_transcript`, all 40+ chunks from that video accumulated in `source_citations` — every 5-second segment became its own chip. This PR adds server-side collapse (`_collapse_by_video()` in `routes/messages.py`) that groups chunks by `video_id` and keeps one representative entry per video, plus a system-prompt nudge discouraging redundant per-video citation markers.

## How this solves the issue

`_collapse_by_video()` is called after `is_cited` is stamped on each chunk but before the cap split. It groups all chunks by `video_id`, picks the earliest-cited timestamp as the representative, propagates `is_cited=True` if any chunk in the group was cited, and sets `segment_count=len(group)`. The result: one `source_citations` entry per video instead of one per chunk. The frontend reads `segment_count` and appends `(N segments)` to the chip label when `> 1`. A one-sentence nudge in `_TOOL_GUIDANCE` also tells the LLM it only needs to emit one marker per video, reducing marker noise in the raw answer text.

## Test plan

- [x] `test_same_video_chunks_collapsed_to_one_citation` — 5 same-video chunks collapse to 1 entry; `segment_count=5`, `is_cited=True`, `start_seconds` picks the earliest cited timestamp
- [x] `test_collapse_two_videos_preserves_both` — 3 chunks × 2 videos → 2 entries, each with correct `is_cited` and `segment_count=3`
- [x] All 4 pre-existing citation tests still pass (including `test_uncited_capped_at_citations_max_count` and `test_cited_pass_through_uncited_capped`, which required distinct `video_id` values per chunk after collapse)
- [x] Full suite: 368 passed, 67 skipped, 0 failed (`uv run pytest tests -xvs`)
- [x] TypeScript: `bun run tsc --noEmit` — 0 errors
- [x] Vitest: 131 passed across 14 test files

## Agent-browser regression

- [ ] Full happy-path regression passes (sign-in → new conversation → ask question → streaming response → citations → citation modal with embedded player)

## Dependencies

No new dependencies.

## Governance / protected files

- [x] No protected files modified
- [x] PR size is within 500 lines (additions + deletions)
- [x] No weakening of authentication, authorization, or the 25 msg/day rate limit

## Manual smoke-test (post-merge)

On the `/opt/dynachat` host after deploy:
1. Ask a question about a specific video (e.g. "How does Cole build AI agents?")
2. Confirm the "Sources cited" row shows **one chip per video**, not 40+
3. Confirm the chip label includes `(N segments)` when the full transcript was fetched
4. Click the chip → embedded YouTube player opens at the correct timestamp deep-link