### PR TITLE
chore(canary): switch chat model to google/gemini-3-flash-preview

### DIFF
--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -85,7 +85,14 @@ MEMBERSHIP_REFRESH_SECONDS: int = int(os.environ.get("MEMBERSHIP_REFRESH_SECONDS
 
 OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
 EMBEDDING_MODEL: str = "openai/text-embedding-3-small"
-CHAT_MODEL: str = "anthropic/claude-sonnet-4.6"
+# OpenRouter slug for the chat model. Defaults to Sonnet 4.6 for prod; can be
+# overridden per-deploy to canary a different model (e.g. google/gemini-3-flash-preview).
+CHAT_MODEL: str = os.environ.get("CHAT_MODEL", "anthropic/claude-sonnet-4.6")
+# When the model is a reasoning model (Gemini 3 Flash, OpenAI o-series, etc.)
+# we can disable thinking to maximize tokens/sec on workloads that don't need
+# long chain-of-thought (e.g. RAG with explicit tool guidance). "minimal" maps
+# to disabled-or-near-zero thinking budget across providers via OpenRouter.
+LLM_REASONING_EFFORT: str = os.environ.get("LLM_REASONING_EFFORT", "").strip().lower()
 
 # Postgres — required for all data (chat + auth). The app fails fast without it.
 # In prod, docker-compose injects DATABASE_URL from the POSTGRES_* vars.

--- a/app/backend/llm/openrouter.py
+++ b/app/backend/llm/openrouter.py
@@ -24,6 +24,7 @@ from backend.config import (
     CATALOG_ENABLED,
     CATALOG_TIER,
     CHAT_MODEL,
+    LLM_REASONING_EFFORT,
     OPENROUTER_API_KEY,
     OPENROUTER_BASE_URL,
 )
@@ -215,6 +216,11 @@ async def stream_chat(
         # content. Silent ~10%/24h failures in prod traced back to this.
         "max_tokens": 8192,
     }
+    if LLM_REASONING_EFFORT:
+        # OpenRouter normalises this across providers — for Gemini 3 Flash,
+        # "minimal" maps to thinking disabled (~190+ tok/s); for OpenAI o-series
+        # it maps to lowest reasoning budget. Anthropic ignores it.
+        base_kwargs["extra_body"] = {"reasoning": {"effort": LLM_REASONING_EFFORT}}
     if tools_active:
         base_kwargs["tools"] = tools
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -71,6 +71,11 @@ services:
       CATALOG_ENABLED: ${CATALOG_ENABLED:-false}
       CATALOG_TIER: ${CATALOG_TIER:-standard}
       CATALOG_CACHE_TTL_SECONDS: ${CATALOG_CACHE_TTL_SECONDS:-3600}
+      # OpenRouter chat model + optional reasoning effort override. Defaults
+      # match the prod baseline; canary deploys override these to test new
+      # models on the inactive blue/green slot before flipping Caddy.
+      CHAT_MODEL: ${CHAT_MODEL:-anthropic/claude-sonnet-4.6}
+      LLM_REASONING_EFFORT: ${LLM_REASONING_EFFORT:-}
     volumes:
       # Read-only mount of the host-side dynamous-content checkout. The host's
       # deploy.sh git-clones / pulls this directory before bringing the new
@@ -122,6 +127,11 @@ services:
       CATALOG_ENABLED: ${CATALOG_ENABLED:-false}
       CATALOG_TIER: ${CATALOG_TIER:-standard}
       CATALOG_CACHE_TTL_SECONDS: ${CATALOG_CACHE_TTL_SECONDS:-3600}
+      # OpenRouter chat model + optional reasoning effort override. Defaults
+      # match the prod baseline; canary deploys override these to test new
+      # models on the inactive blue/green slot before flipping Caddy.
+      CHAT_MODEL: ${CHAT_MODEL:-anthropic/claude-sonnet-4.6}
+      LLM_REASONING_EFFORT: ${LLM_REASONING_EFFORT:-}
     volumes:
       - ${DYNAMOUS_CONTENT_HOST_PATH:-/opt/dynachat/dynamous-content}:/app/content/dynamous:ro
     depends_on:


### PR DESCRIPTION
## Summary

Make the OpenRouter chat model env-configurable (defaults preserved) and add `LLM_REASONING_EFFORT` plumbing. Operational switch: setting the model env var to `google/gemini-3-flash-preview` on the VPS env is what flips production. Anthropic Sonnet 4.6 stays the default for any deploy that doesn't set it.

## Why

Sonnet 4.6 streams ~65 tok/s. Cole asked for tokens/sec optimization; OpenRouter benchmark on the prod VPS, 3 trials each, identical workload:

| Model | Avg TTFT | Avg total turn | Avg tok/s | Speedup |
|---|---|---|---|---|
| Sonnet 4.6 (current) | 0.85s | 9.06s | ~65 tok/s | 1.0x |
| **Gemini 3 Flash** (default reasoning) | 0.90s | **3.82s** | **~195 tok/s** | **3.0x** |
| Gemini 3 Flash (reasoning=minimal) | 1.08s | 3.89s | ~191 tok/s | 2.9x |
| Gemini 2.5 Flash | 0.84s | 4.09s | ~175 tok/s | 2.7x |

Gemini 3 Flash with default reasoning hits 3x the throughput of Sonnet without any TTFT regression on a DynaChat-shaped grounded-answer workload (retrieved chunks + citation markers).

## Changes

- `app/backend/config.py` - read the chat-model slug from env (defaults to `anthropic/claude-sonnet-4.6`); add `LLM_REASONING_EFFORT`.
- `app/backend/llm/openrouter.py` - forward `LLM_REASONING_EFFORT` to OpenRouter via `extra_body.reasoning.effort` when set.
- `deploy/docker-compose.yml` - thread the chat-model and reasoning-effort env vars through to both blue/green services.

## Test plan
- [x] Existing 145 backend tests pass with default (Sonnet 4.6)
- [x] Direct OpenRouter benchmark on the VPS confirms Gemini 3 Flash at ~195 tok/s
- [ ] Post-merge: set the chat-model env var on the VPS, deploy fires, verify a real query end-to-end on chat.dynamous.ai
