### PR TITLE
feat(citations): drop transcript-excerpt snippet; route Dynamous citations to lesson URL

### DIFF
--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -263,10 +263,7 @@ class TestSseIntegration:
 
     async def test_collapse_uncited_group_picks_earliest_timestamp(self) -> None:
         """All same-video chunks uncited → is_cited=False, earliest start_seconds selected."""
-        chunks = [
-            {**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)}
-            for i in range(3)
-        ]
+        chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)} for i in range(3)]
         # No markers in answer — nothing cited
         body = await _post_message(
             answer_tokens=["Plain answer."],

--- a/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for ChatArea.handleCitationClick branching logic (issue #216 fix).
+ *
+ * Dynamous citations → window.open(lesson_url, '_blank', 'noopener,noreferrer')
+ * YouTube citations  → opens CitationModal (setSelectedCitation)
+ * Missing lesson_url → does nothing (no blank tab)
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArea } from '../components/ChatArea';
+import type { Citation, Message } from '../lib/api';
+
+// ── Shared mocks ──────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// Module-level storage so we can swap messages between tests
+let mockMessages: Message[] = [];
+
+vi.mock('../hooks/useMessages', () => ({
+  useMessages: () => ({
+    messages: mockMessages,
+    setMessages: vi.fn(),
+    loading: false,
+    error: null,
+    notFound: false,
+    conversation: { id: 'conv-1', title: 'Test Chat', created_at: '', updated_at: '' },
+  }),
+}));
+
+vi.mock('../hooks/useStreamingResponse', () => ({
+  useStreamingResponse: () => ({
+    streamingContent: '',
+    streamingSources: [],
+    isStreaming: false,
+    startStream: vi.fn(),
+    abortStream: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user', email: 'test@test.com', is_admin: false },
+    refresh: vi.fn(),
+  }),
+}));
+
+// ── Citation fixtures ─────────────────────────────────────────────────────────
+
+const dynaCitation: Citation = {
+  chunk_id: 'c1',
+  video_id: 'v1',
+  video_title: 'Lesson One',
+  video_url: 'https://community.dynamous.ai/c/module/v1',
+  start_seconds: 0,
+  end_seconds: 10,
+  snippet: '',
+  source_type: 'dynamous',
+  lesson_url: 'https://community.dynamous.ai/c/module-1/lessons/42',
+  is_cited: true,
+};
+
+const dynaCitationNoUrl: Citation = {
+  chunk_id: 'c2',
+  video_id: 'v2',
+  video_title: 'Lesson Two',
+  video_url: 'https://community.dynamous.ai/c/module/v2',
+  start_seconds: 0,
+  end_seconds: 5,
+  snippet: '',
+  source_type: 'dynamous',
+  lesson_url: undefined,
+  is_cited: true,
+};
+
+const ytCitation: Citation = {
+  chunk_id: 'c3',
+  video_id: 'dQw4w9WgXcQ',
+  video_title: 'YouTube Video Title',
+  video_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  start_seconds: 60,
+  end_seconds: 70,
+  snippet: 'A snippet of text.',
+  source_type: 'youtube',
+  is_cited: true,
+};
+
+function makeAssistantMessage(citation: Citation): Message {
+  return {
+    id: 'msg-1',
+    conversation_id: 'conv-1',
+    role: 'assistant',
+    content: 'Here is a source.',
+    created_at: new Date().toISOString(),
+    sources: [citation],
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('handleCitationClick', () => {
+  let openSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    openSpy = vi.fn();
+    vi.stubGlobal('open', openSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockMessages = [];
+  });
+
+  it('opens lesson_url in a new tab for Dynamous citations', async () => {
+    mockMessages = [makeAssistantMessage(dynaCitation)];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    // Wait for the citation chip to render
+    await waitFor(() => {
+      expect(screen.getByText(/Lesson One/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/Lesson One/i));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://community.dynamous.ai/c/module-1/lessons/42',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    // CitationModal must NOT appear
+    expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+  });
+
+  it('does nothing when Dynamous citation has no lesson_url', async () => {
+    mockMessages = [makeAssistantMessage(dynaCitationNoUrl)];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Lesson Two/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/Lesson Two/i));
+
+    // window.open must NOT be called — no blank tab opened
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+  });
+
+  it('opens the citation modal for YouTube citations', async () => {
+    mockMessages = [makeAssistantMessage(ytCitation)];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/YouTube Video Title/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/YouTube Video Title/i));
+
+    // window.open must NOT be called
+    expect(openSpy).not.toHaveBeenCalled();
+    // CitationModal with YouTube iframe must appear
+    await waitFor(() => {
+      expect(screen.getByTitle('YouTube video player')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/frontend/src/__tests__/VideoExplorer.test.tsx
+++ b/app/frontend/src/__tests__/VideoExplorer.test.tsx
@@ -628,7 +628,7 @@ describe('VideoExplorer', () => {
       ]);
       render(<VideoExplorer isOpen={true} onClose={vi.fn()} />);
       await waitFor(() =>
-        expect(screen.getByText('Dynamous Video Without Lesson URL')).toBeInTheDocument()
+        expect(screen.getByText('Dynamous Video Without Lesson URL')).toBeInTheDocument(),
       );
 
       const link = screen.getByRole('link', {

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -347,9 +347,15 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     autoScrollRef.current = distFromBottom < 100;
   }, []);
 
-  // ── Citation click handler (opens modal) ──
+  // ── Citation click handler ──
+  // Dynamous: open lesson URL directly in a new tab — no modal.
+  // YouTube: open the embedded player modal as usual.
   const handleCitationClick = useCallback((citation: Citation) => {
-    setSelectedCitation(citation);
+    if (citation.source_type === 'dynamous') {
+      window.open(citation.lesson_url ?? '', '_blank', 'noopener,noreferrer');
+    } else {
+      setSelectedCitation(citation);
+    }
   }, []);
 
   // ── Send handler ──

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -352,7 +352,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // YouTube: open the embedded player modal as usual.
   const handleCitationClick = useCallback((citation: Citation) => {
     if (citation.source_type === 'dynamous') {
-      window.open(citation.lesson_url ?? '', '_blank', 'noopener,noreferrer');
+      if (citation.lesson_url) {
+        window.open(citation.lesson_url, '_blank', 'noopener,noreferrer');
+      }
     } else {
       setSelectedCitation(citation);
     }

--- a/app/frontend/src/components/CitationModal.test.tsx
+++ b/app/frontend/src/components/CitationModal.test.tsx
@@ -32,16 +32,12 @@ describe('CitationModal', () => {
     expect(iframe.src).toContain('autoplay=1');
   });
 
-  it('shows transcript snippet with heading', () => {
+  it('does not render a transcript snippet section', () => {
     const onClose = vi.fn();
     render(<CitationModal citation={mockCitation} onClose={onClose} />);
 
-    expect(screen.getByText('Transcript Excerpt')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'This is a sample transcript snippet that appears in the video at the cited moment.',
-      ),
-    ).toBeInTheDocument();
+    expect(screen.queryByText('Transcript Excerpt')).not.toBeInTheDocument();
+    expect(screen.queryByText(mockCitation.snippet)).not.toBeInTheDocument();
   });
 
   it('shows external link with correct t param', () => {
@@ -79,18 +75,6 @@ describe('CitationModal', () => {
     const closeButton = screen.getByRole('button', { name: 'Close' });
     fireEvent.click(closeButton);
     expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('truncates long snippets with ellipsis', () => {
-    const longCitation: Citation = {
-      ...mockCitation,
-      snippet: 'A'.repeat(400),
-    };
-    const onClose = vi.fn();
-    render(<CitationModal citation={longCitation} onClose={onClose} />);
-
-    const snippetEl = screen.getByText(/^A{297}…$/);
-    expect(snippetEl).toBeInTheDocument();
   });
 
   it('shows video unavailable when video URL is invalid', () => {

--- a/app/frontend/src/components/CitationModal.tsx
+++ b/app/frontend/src/components/CitationModal.tsx
@@ -14,19 +14,15 @@ export function formatTimestamp(seconds: number): string {
 }
 
 export function CitationModal({ citation, onClose }: CitationModalProps) {
-  // Issue #147: paid Dynamous course / workshop citations render without an
-  // embedded player. Circle doesn't support timestamp deep-links, so we link
-  // straight to the lesson URL with the (MM:SS) shown as text in the header.
-  const isDynamous = citation.source_type === 'dynamous';
+  // Modal is YouTube-only. Dynamous citations are routed directly to lesson_url
+  // by the caller (ChatArea.handleCitationClick) — this component never sees them.
 
   // Extract YouTube video ID from URL (format: https://www.youtube.com/watch?v=<id>)
   let videoId = '';
-  if (!isDynamous) {
-    try {
-      videoId = new URL(citation.video_url).searchParams.get('v') ?? '';
-    } catch {
-      console.warn('[CitationModal] Could not parse video URL:', citation.video_url);
-    }
+  try {
+    videoId = new URL(citation.video_url).searchParams.get('v') ?? '';
+  } catch {
+    console.warn('[CitationModal] Could not parse video URL:', citation.video_url);
   }
 
   const startSeconds = Math.floor(citation.start_seconds);
@@ -35,13 +31,9 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
     ? `https://www.youtube.com/embed/${videoId}?start=${startSeconds}&autoplay=1`
     : '';
 
-  const externalUrl = isDynamous
-    ? (citation.lesson_url ?? '')
-    : videoId
-      ? `https://www.youtube.com/watch?v=${videoId}&t=${startSeconds}s`
-      : '';
-
-  const externalLabel = isDynamous ? 'Open on Dynamous' : 'Open on YouTube';
+  const externalUrl = videoId
+    ? `https://www.youtube.com/watch?v=${videoId}&t=${startSeconds}s`
+    : '';
 
   // Close on ESC key
   useEffect(() => {
@@ -59,10 +51,6 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
       document.body.style.overflow = '';
     };
   }, []);
-
-  // Truncate snippet to max 300 display chars (297 + ellipsis)
-  const snippetDisplay =
-    citation.snippet.length > 300 ? citation.snippet.slice(0, 297) + '…' : citation.snippet;
 
   return (
     <div
@@ -96,34 +84,23 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
           </button>
         </div>
 
-        {/* Content: YouTube iframe (top) + transcript (bottom).
-            Dynamous citations skip the iframe — Circle has no embed/deep-link
-            support, so the snippet + external link is all we render. */}
+        {/* Content: YouTube iframe. Modal is YouTube-only — Dynamous citations
+            go directly to lesson_url (handled in ChatArea before this modal opens). */}
         <div className="flex-1 min-h-0 flex flex-col gap-4 mb-4 overflow-y-auto">
-          {!isDynamous && (
-            <div className="w-full aspect-video">
-              {embedUrl ? (
-                <iframe
-                  src={embedUrl}
-                  allow="autoplay; encrypted-media"
-                  allowFullScreen
-                  title="YouTube video player"
-                  className="w-full h-full rounded-lg"
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center bg-slate-900 rounded-lg text-slate-500 text-sm">
-                  Video unavailable
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Transcript snippet */}
-          <div>
-            <h4 className="text-slate-200 text-sm font-semibold mb-1">Transcript Excerpt</h4>
-            <p className="text-slate-300 text-sm leading-relaxed m-0 whitespace-pre-wrap">
-              {snippetDisplay}
-            </p>
+          <div className="w-full aspect-video">
+            {embedUrl ? (
+              <iframe
+                src={embedUrl}
+                allow="autoplay; encrypted-media"
+                allowFullScreen
+                title="YouTube video player"
+                className="w-full h-full rounded-lg"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center bg-slate-900 rounded-lg text-slate-500 text-sm">
+                Video unavailable
+              </div>
+            )}
           </div>
         </div>
 
@@ -136,7 +113,7 @@ export function CitationModal({ citation, onClose }: CitationModalProps) {
               rel="noopener noreferrer"
               className="text-slate-400 hover:text-slate-200 text-xs flex items-center gap-1 transition-colors"
             >
-              {externalLabel}
+              Open on YouTube
               <svg
                 width="10"
                 height="10"

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -34,8 +34,7 @@ function SkeletonCard() {
 
 // ── Video card ───────────────────────────────────────────────────
 function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
-  const titleHref =
-    video.source_type === 'dynamous' ? (video.lesson_url ?? video.url) : video.url;
+  const titleHref = video.source_type === 'dynamous' ? (video.lesson_url ?? video.url) : video.url;
 
   return (
     <div

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -38,9 +38,6 @@ services:
   # graceful `caddy reload` to swap. Neither publishes a host port — Caddy
   # reaches them via the internal docker network by service name.
   #
-  # Both mount the same named volume (app_data) for the SQLite DB so the
-  # swap preserves state. Brief overlap during swap is fine — SQLite WAL
-  # handles low-volume concurrent access.
   app-blue:
     build:
       context: ..


### PR DESCRIPTION
## Summary

- **Dynamous citations**: clicking a chip now opens `lesson_url` directly in a new tab (`noopener,noreferrer`) — no modal.
- **YouTube citations**: modal still opens with embedded player and *Open on YouTube* link, but the transcript-excerpt snippet block is removed entirely.
- `CitationModal` is now YouTube-only; dead `isDynamous` branching code cleaned up.

## Changes

| File | What changed |
|------|--------------|
| `app/frontend/src/components/ChatArea.tsx` | `handleCitationClick` branches on `source_type === 'dynamous'` → `window.open`; else → modal |
| `app/frontend/src/components/CitationModal.tsx` | Removed `snippetDisplay` variable, "Transcript Excerpt" JSX, `isDynamous`/`externalLabel` dead code; simplified to YouTube-only paths |
| `app/frontend/src/components/CitationModal.test.tsx` | Replaced snippet-present assertions with not-in-DOM assertion; removed truncation test |

## Test plan

- [ ] Click a Dynamous citation chip → `lesson_url` opens in a new tab, no modal appears.
- [ ] Click a YouTube citation chip → modal opens with embedded player at correct timestamp, **no "Transcript Excerpt" section visible**.
- [ ] Modal *Open on YouTube* link has correct `?v=…&t=…s` params.
- [ ] ESC key, backdrop click, and × button all close the YouTube modal.
- [ ] All 143 frontend tests pass (`bun run test`).
- [ ] TypeScript clean (`bun run tsc --noEmit`).

Fixes #216

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>