### PR TITLE
fix(chat): force scrollTop past paddingBottom to clear 139px end-of-stream gap

### DIFF
--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -331,6 +331,22 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // Without rAF, scroll fires before React's DOM reconciliation completes (issue #76).
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     bottomRef.current?.scrollIntoView({ behavior, block: 'end' });
+    // scrollIntoView({block:'end'}) on the bottom-ref sentinel does NOT
+    // account for the scroll container's paddingBottom — the sentinel's
+    // viewport edge stops short of the absolute bottom by exactly the
+    // padding amount (140px in the current layout, observed as the
+    // 139px end-of-stream gap in production E2E). Force scrollTop to
+    // max to cover the padding offset. try/catch guards jsdom which
+    // exposes scrollTop as a getter-only property.
+    const container = scrollContainerRef.current;
+    if (container) {
+      try {
+        container.scrollTop = container.scrollHeight;
+      } catch {
+        // jsdom test environment — the scrollIntoView spy above is the
+        // observable behaviour the tests assert against.
+      }
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Real root cause of the 139px gap: scroll container's paddingBottom:140px wraps the bottomRef sentinel; scrollIntoView({block:'end'}) stops at the sentinel's viewport edge, leaving scrollTop short by exactly the padding. Fix: set scrollTop=scrollHeight directly after scrollIntoView. try/catch protects jsdom. All 148 tests pass.