### PR TITLE
[bench-KK] review: address self-review findings

### DIFF
--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -16,8 +16,9 @@ cosine fallback).
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 from backend.config import HYBRID_K_CONSTANT, HYBRID_OVERFETCH_FACTOR, KEYWORD_LANGUAGE
 from backend.db import repository
@@ -25,7 +26,9 @@ from backend.db import repository
 logger = logging.getLogger(__name__)
 
 # Module-level video metadata cache (populated on demand per chunk result)
-_video_cache: dict[str, dict[str, str]] = {}
+MAX_VIDEO_CACHE_SIZE = 256
+_video_cache: OrderedDict[str, dict[str, str]] = OrderedDict()
+_inflight: dict[str, asyncio.Future[dict[str, str]]] = {}
 
 
 def invalidate_cache() -> None:
@@ -116,29 +119,52 @@ async def retrieve_hybrid(
     results: list[dict] = []
     for chunk in merged:
         video_id = chunk["video_id"]
-        if video_id not in _video_cache:
-            video = await repository.get_video(video_id)
-            if video:
-                _video_cache[video_id] = {
-                    "title": video.get("title", ""),
-                    "url": video.get("url", "") or "",
-                    "source_type": video.get("source_type", "youtube") or "youtube",
-                    "lesson_url": video.get("lesson_url", "") or "",
-                }
-            else:
-                logger.warning(
-                    "Video not found for video_id=%s, chunk_id=%s",
-                    video_id,
-                    chunk.get("id", "?"),
-                )
-                _video_cache[video_id] = {
-                    "title": "Unknown Video",
-                    "url": "",
-                    "source_type": "youtube",
-                    "lesson_url": "",
-                }
 
-        video_meta = _video_cache[video_id]
+        # --- bounded LRU cache with single-flight fetch ---
+        if video_id in _video_cache:
+            # Hit path: promote to most-recently-used (no await)
+            _video_cache.move_to_end(video_id)
+            video_meta = _video_cache[video_id]
+        elif video_id in _inflight:
+            # Wait path: another task is already fetching this video
+            await _inflight[video_id]
+            video_meta = _video_cache[video_id]
+        else:
+            # Miss (leader) path: we are responsible for fetching
+            future: asyncio.Future[dict[str, str]] = asyncio.get_running_loop().create_future()
+            _inflight[video_id] = future
+            try:
+                video = await repository.get_video(video_id)
+                if video:
+                    entry = {
+                        "title": video.get("title", ""),
+                        "url": video.get("url", "") or "",
+                        "source_type": video.get("source_type", "youtube") or "youtube",
+                        "lesson_url": video.get("lesson_url", "") or "",
+                    }
+                else:
+                    logger.warning(
+                        "Video not found for video_id=%s, chunk_id=%s",
+                        video_id,
+                        chunk.get("id", "?"),
+                    )
+                    entry = {
+                        "title": "Unknown Video",
+                        "url": "",
+                        "source_type": "youtube",
+                        "lesson_url": "",
+                    }
+                _video_cache[video_id] = entry
+                _video_cache.move_to_end(video_id)
+                if len(_video_cache) > MAX_VIDEO_CACHE_SIZE:
+                    _video_cache.popitem(last=False)
+                future.set_result(entry)
+                video_meta = entry
+            except Exception as exc:
+                future.set_exception(exc)
+                raise
+            finally:
+                _inflight.pop(video_id, None)
         results.append(
             {
                 "chunk_id": chunk["id"],

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -126,9 +126,10 @@ async def retrieve_hybrid(
             _video_cache.move_to_end(video_id)
             video_meta = _video_cache[video_id]
         elif video_id in _inflight:
-            # Wait path: another task is already fetching this video
-            await _inflight[video_id]
-            video_meta = _video_cache[video_id]
+            # Wait path: another task is already fetching this video; use the
+            # value carried by the future directly so we are not vulnerable to
+            # a concurrent LRU eviction or a mid-wait invalidate_cache() call.
+            video_meta = await _inflight[video_id]
         else:
             # Miss (leader) path: we are responsible for fetching
             future: asyncio.Future[dict[str, str]] = asyncio.get_running_loop().create_future()

--- a/app/backend/tests/conftest.py
+++ b/app/backend/tests/conftest.py
@@ -30,8 +30,10 @@ from backend import rate_limit, signup_rate_limit
 def reset_retriever_hybrid_cache():
     """Ensure the module-level hybrid video cache is clean before and after every test."""
     retriever_hybrid_module._video_cache.clear()
+    retriever_hybrid_module._inflight.clear()
     yield
     retriever_hybrid_module._video_cache.clear()
+    retriever_hybrid_module._inflight.clear()
 
 
 @pytest.fixture

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -9,11 +9,18 @@ Verifies:
   - Hybrid retriever raises clear error when DATABASE_URL is unset
 """
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from backend.rag.retriever_hybrid import _rrf_merge, retrieve_hybrid
+from backend.rag.retriever_hybrid import (
+    MAX_VIDEO_CACHE_SIZE,
+    _inflight,
+    _rrf_merge,
+    _video_cache,
+    retrieve_hybrid,
+)
 
 # Minimal chunk fixtures for RRF testing
 _CHUNK_A = {
@@ -223,3 +230,155 @@ class TestRetrieveHybrid:
 
         result = _rrf_merge(keyword, vector, k=60, top_k=5)
         assert result[0]["id"] == "c_concept"
+
+    async def test_single_flight_concurrent_misses(self):
+        """Concurrent misses for the same video_id result in exactly one DB call."""
+        call_count = 0
+
+        async def slow_get_video(video_id: str):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return {
+                "title": f"Video {video_id}",
+                "url": f"https://youtube.com/watch?v={video_id}",
+            }
+
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+            ) as mock_video,
+        ):
+            chunk = {
+                "id": "c1",
+                "video_id": "v_same",
+                "content": "test",
+                "chunk_index": 0,
+                "start_seconds": 0.0,
+                "end_seconds": 10.0,
+                "snippet": "",
+            }
+            mock_kw.return_value = [chunk]
+            mock_vec.return_value = [chunk]
+            mock_video.side_effect = slow_get_video
+
+            results = await asyncio.gather(
+                retrieve_hybrid("q1", [0.1] * 1536, top_k=5),
+                retrieve_hybrid("q2", [0.1] * 1536, top_k=5),
+            )
+
+            assert call_count == 1
+            assert len(results[0]) == 1
+            assert len(results[1]) == 1
+            assert results[0][0]["video_title"] == results[1][0]["video_title"]
+
+    async def test_cache_bounded_lru_eviction(self):
+        """Cache size is bounded and oldest entries are evicted."""
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+            ) as mock_video,
+        ):
+            call_count = 0
+
+            async def counting_get_video(video_id: str):
+                nonlocal call_count
+                call_count += 1
+                return {
+                    "title": f"Video {video_id}",
+                    "url": f"https://youtube.com/watch?v={video_id}",
+                }
+
+            mock_video.side_effect = counting_get_video
+
+            # Fill cache to exactly MAX_VIDEO_CACHE_SIZE
+            for i in range(MAX_VIDEO_CACHE_SIZE):
+                chunk = {
+                    "id": f"c{i}",
+                    "video_id": f"v{i}",
+                    "content": "test",
+                    "chunk_index": 0,
+                    "start_seconds": 0.0,
+                    "end_seconds": 10.0,
+                    "snippet": "",
+                }
+                mock_kw.return_value = [chunk]
+                mock_vec.return_value = [chunk]
+                await retrieve_hybrid("q", [0.1] * 1536, top_k=5)
+
+            assert len(_video_cache) == MAX_VIDEO_CACHE_SIZE
+
+            # One more distinct video should trigger eviction
+            extra_chunk = {
+                "id": "c_extra",
+                "video_id": "v_extra",
+                "content": "test",
+                "chunk_index": 0,
+                "start_seconds": 0.0,
+                "end_seconds": 10.0,
+                "snippet": "",
+            }
+            mock_kw.return_value = [extra_chunk]
+            mock_vec.return_value = [extra_chunk]
+            await retrieve_hybrid("q", [0.1] * 1536, top_k=5)
+
+            assert len(_video_cache) == MAX_VIDEO_CACHE_SIZE
+            # The oldest key (v0) should have been evicted
+            assert "v0" not in _video_cache
+            assert "v_extra" in _video_cache
+
+    async def test_cache_hit_avoids_second_db_call(self):
+        """A cached video_id does not trigger repository.get_video again."""
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+            ) as mock_video,
+        ):
+            chunk = {
+                "id": "c1",
+                "video_id": "v_cached",
+                "content": "test",
+                "chunk_index": 0,
+                "start_seconds": 0.0,
+                "end_seconds": 10.0,
+                "snippet": "",
+            }
+            mock_kw.return_value = [chunk]
+            mock_vec.return_value = [chunk]
+            mock_video.return_value = {
+                "title": "Cached Video",
+                "url": "https://youtube.com/watch?v=cached",
+            }
+
+            await retrieve_hybrid("q", [0.1] * 1536, top_k=5)
+            assert mock_video.call_count == 1
+
+            await retrieve_hybrid("q", [0.1] * 1536, top_k=5)
+            assert mock_video.call_count == 1


### PR DESCRIPTION
Fixes #227

**Benchmark cell:** `KK` (plan=Kimi, impl=Kimi)
**Source run-id:** `133fe045-4098-4074-a403-043e3409bf76`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.