### PR TITLE
[bench-OO] impl: address issue

### DIFF
--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -16,23 +16,82 @@ cosine fallback).
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 from backend.config import HYBRID_K_CONSTANT, HYBRID_OVERFETCH_FACTOR, KEYWORD_LANGUAGE
 from backend.db import repository
 
 logger = logging.getLogger(__name__)
 
-# Module-level video metadata cache (populated on demand per chunk result)
-_video_cache: dict[str, dict[str, str]] = {}
+# Why: bound the cache so long-running processes don't grow it without limit.
+MAX_VIDEO_CACHE_SIZE = 1024
+
+# Module-level video metadata cache (populated on demand per chunk result).
+# OrderedDict gives O(1) LRU touch via move_to_end + popitem(last=False).
+_video_cache: OrderedDict[str, dict[str, str]] = OrderedDict()
+
+# Single-flight coordination: while a video_id's metadata is being fetched, the
+# first task stores a Future here; concurrent misses await that same Future
+# instead of issuing a duplicate repository.get_video() call.
+_inflight: dict[str, asyncio.Future[dict[str, str]]] = {}
 
 
 def invalidate_cache() -> None:
-    """Clear the video metadata cache."""
-    global _video_cache
+    """Clear the video metadata cache (and any in-flight lookups)."""
     _video_cache.clear()
+    # Waiters already holding a reference to an in-flight Future still receive
+    # its result — that's fine (stale but valid). New lookups simply miss.
+    _inflight.clear()
     logger.info("Hybrid retriever video cache invalidated.")
+
+
+async def _get_video_meta(video_id: str) -> dict[str, str]:
+    """Single-flight, LRU-bounded lookup of video metadata for `video_id`.
+
+    Cache hit: O(1) move_to_end + return (no awaits).
+    Cache miss with no in-flight peer: create a Future, fetch, populate cache,
+        evict if over bound, resolve Future, return.
+    Cache miss with in-flight peer: await the existing Future (no duplicate fetch).
+    """
+    if video_id in _video_cache:
+        _video_cache.move_to_end(video_id)
+        return _video_cache[video_id]
+
+    existing = _inflight.get(video_id)
+    if existing is not None:
+        return await existing
+
+    fut: asyncio.Future[dict[str, str]] = asyncio.get_running_loop().create_future()
+    _inflight[video_id] = fut
+    try:
+        video = await repository.get_video(video_id)
+        if video:
+            meta = {
+                "title": video.get("title", ""),
+                "url": video.get("url", "") or "",
+                "source_type": video.get("source_type", "youtube") or "youtube",
+                "lesson_url": video.get("lesson_url", "") or "",
+            }
+        else:
+            logger.warning("Video not found for video_id=%s", video_id)
+            meta = {
+                "title": "Unknown Video",
+                "url": "",
+                "source_type": "youtube",
+                "lesson_url": "",
+            }
+        _video_cache[video_id] = meta
+        if len(_video_cache) > MAX_VIDEO_CACHE_SIZE:
+            _video_cache.popitem(last=False)
+        fut.set_result(meta)
+        return meta
+    except Exception as exc:
+        fut.set_exception(exc)
+        raise
+    finally:
+        _inflight.pop(video_id, None)
 
 
 async def retrieve_hybrid(
@@ -116,29 +175,7 @@ async def retrieve_hybrid(
     results: list[dict] = []
     for chunk in merged:
         video_id = chunk["video_id"]
-        if video_id not in _video_cache:
-            video = await repository.get_video(video_id)
-            if video:
-                _video_cache[video_id] = {
-                    "title": video.get("title", ""),
-                    "url": video.get("url", "") or "",
-                    "source_type": video.get("source_type", "youtube") or "youtube",
-                    "lesson_url": video.get("lesson_url", "") or "",
-                }
-            else:
-                logger.warning(
-                    "Video not found for video_id=%s, chunk_id=%s",
-                    video_id,
-                    chunk.get("id", "?"),
-                )
-                _video_cache[video_id] = {
-                    "title": "Unknown Video",
-                    "url": "",
-                    "source_type": "youtube",
-                    "lesson_url": "",
-                }
-
-        video_meta = _video_cache[video_id]
+        video_meta = await _get_video_meta(video_id)
         results.append(
             {
                 "chunk_id": chunk["id"],

--- a/app/backend/tests/conftest.py
+++ b/app/backend/tests/conftest.py
@@ -29,9 +29,9 @@ from backend import rate_limit, signup_rate_limit
 @pytest.fixture(autouse=True)
 def reset_retriever_hybrid_cache():
     """Ensure the module-level hybrid video cache is clean before and after every test."""
-    retriever_hybrid_module._video_cache.clear()
+    retriever_hybrid_module.invalidate_cache()
     yield
-    retriever_hybrid_module._video_cache.clear()
+    retriever_hybrid_module.invalidate_cache()
 
 
 @pytest.fixture

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -7,12 +7,15 @@ Verifies:
   - A rare exact term ranks higher via hybrid than pure cosine
   - A conceptual query with no exact-term overlap still returns relevant results
   - Hybrid retriever raises clear error when DATABASE_URL is unset
+  - The video-metadata cache is single-flight and LRU-bounded
 """
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import backend.rag.retriever_hybrid as retriever_hybrid_module
 from backend.rag.retriever_hybrid import _rrf_merge, retrieve_hybrid
 
 # Minimal chunk fixtures for RRF testing
@@ -223,3 +226,142 @@ class TestRetrieveHybrid:
 
         result = _rrf_merge(keyword, vector, k=60, top_k=5)
         assert result[0]["id"] == "c_concept"
+
+
+class TestVideoCacheSingleFlight:
+    """Regression tests for the single-flight + LRU-bounded video metadata cache."""
+
+    async def test_single_flight_concurrent_misses_call_get_video_once(self):
+        """N concurrent retrieve_hybrid() calls on the same uncached video_id
+        result in exactly one repository.get_video() call (single-flight).
+        """
+        release = asyncio.Event()
+
+        async def gated_get_video(_video_id: str) -> dict:
+            await release.wait()
+            return {
+                "title": "T",
+                "url": "U",
+                "source_type": "youtube",
+                "lesson_url": "",
+            }
+
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+                side_effect=gated_get_video,
+            ) as mock_video,
+        ):
+            mock_kw.return_value = [_CHUNK_A]
+            mock_vec.return_value = [_CHUNK_A]
+
+            async def kick() -> list[dict]:
+                return await retrieve_hybrid("q", [0.0] * 1536, top_k=1)
+
+            tasks = [asyncio.create_task(kick()) for _ in range(5)]
+            # Yield so all tasks reach the gated get_video before we release.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            release.set()
+            results = await asyncio.gather(*tasks)
+
+            assert mock_video.call_count == 1
+            assert len(results) == 5
+            for r in results:
+                assert r[0]["video_title"] == "T"
+
+    async def test_lru_eviction_bounds_cache_size(self, monkeypatch):
+        """Cache size never exceeds MAX_VIDEO_CACHE_SIZE; oldest entry is evicted first."""
+        monkeypatch.setattr(retriever_hybrid_module, "MAX_VIDEO_CACHE_SIZE", 2)
+
+        def chunk_for(video_id: str) -> dict:
+            return {
+                "id": f"c-{video_id}",
+                "video_id": video_id,
+                "content": "x",
+                "chunk_index": 0,
+                "start_seconds": 0.0,
+                "end_seconds": 1.0,
+                "snippet": "",
+            }
+
+        async def fake_get_video(video_id: str) -> dict:
+            return {"title": f"title-{video_id}", "url": f"url-{video_id}"}
+
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+                side_effect=fake_get_video,
+            ),
+        ):
+            for vid in ("va", "vb", "vc"):
+                mock_kw.return_value = [chunk_for(vid)]
+                mock_vec.return_value = [chunk_for(vid)]
+                await retrieve_hybrid("q", [0.0] * 1536, top_k=1)
+
+            assert len(retriever_hybrid_module._video_cache) == 2
+            # Oldest insert (va) should have been evicted; vb and vc remain.
+            assert "va" not in retriever_hybrid_module._video_cache
+            assert "vb" in retriever_hybrid_module._video_cache
+            assert "vc" in retriever_hybrid_module._video_cache
+
+    async def test_get_video_exception_clears_inflight_for_retry(self):
+        """A failed get_video() must clear the in-flight entry so the next call retries."""
+        call_count = {"n": 0}
+
+        async def flaky_get_video(_video_id: str) -> dict:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("boom")
+            return {
+                "title": "OK",
+                "url": "U",
+                "source_type": "youtube",
+                "lesson_url": "",
+            }
+
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+                side_effect=flaky_get_video,
+            ),
+        ):
+            mock_kw.return_value = [_CHUNK_A]
+            mock_vec.return_value = [_CHUNK_A]
+
+            with pytest.raises(RuntimeError, match="boom"):
+                await retrieve_hybrid("q", [0.0] * 1536, top_k=1)
+
+            # Second call should retry get_video and succeed.
+            result = await retrieve_hybrid("q", [0.0] * 1536, top_k=1)
+            assert result[0]["video_title"] == "OK"
+            assert call_count["n"] == 2
+            # No leaked in-flight entry.
+            assert "v1" not in retriever_hybrid_module._inflight


### PR DESCRIPTION
Fixes #227

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `9eeae813-8665-4725-9d96-10efaaf9646b`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.