### PR TITLE
[bench-KO] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -280,7 +280,7 @@ async def keyword_search(
             FROM chunks
             WHERE search_vector @@ plainto_tsquery($1)
               AND source_type = ANY($3::text[])
-            ORDER BY rank DESC
+            ORDER BY rank DESC, id ASC
             LIMIT $2
             """,
             query,
@@ -326,7 +326,7 @@ async def vector_search_pg(
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
             WHERE source_type = ANY($3::text[])
-            ORDER BY distance
+            ORDER BY distance ASC, id ASC
             LIMIT $2
             """,
             embedding_json,

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -196,5 +196,5 @@ def _rrf_merge(
         if chunk_id not in rows:
             rows[chunk_id] = row
 
-    ranked = sorted(scores, key=scores.__getitem__, reverse=True)[:top_k]
+    ranked = sorted(scores, key=lambda cid: (-scores[cid], cid))[:top_k]
     return [{**rows[cid], "rrf_score": scores[cid]} for cid in ranked]

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -170,7 +170,9 @@ class TestVectorSearchPg:
 
         call_args = mock_conn.fetch.call_args
         sql = call_args[0][0]
-        assert "ORDER BY distance" in sql
+        # Secondary `id ASC` is required so that tied distances are ordered
+        # deterministically (otherwise RRF merge becomes non-deterministic).
+        assert "ORDER BY distance ASC, id ASC" in sql
 
     async def test_vector_search_pg_json_encodes_embedding(self):
         """vector_search_pg JSON-serializes the embedding list before passing to DB."""

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -58,6 +58,29 @@ class TestRRFMerge:
 
         assert [r["id"] for r in result1] == [r["id"] for r in result2]
 
+    def test_rrf_merge_deterministic_with_tied_scores(self):
+        """RRF merge produces deterministic order when two chunks tie on RRF score.
+
+        Two chunks each appearing once at the same rank in different lists will
+        receive identical 1/(k+rank) scores. Without a tiebreaker the final
+        sort order would depend on dict insertion order. The merge must break
+        ties lexicographically by chunk id so identical inputs always yield
+        the same ordering across calls.
+        """
+        # _CHUNK_C ("c3") only in keyword at rank 0 → score = 1/(60+0)
+        # _CHUNK_A ("c1") only in vector  at rank 0 → score = 1/(60+0)
+        # Both tie. Lexicographic id order puts c1 before c3.
+        keyword = [_CHUNK_C]
+        vector = [_CHUNK_A]
+
+        result1 = _rrf_merge(keyword, vector, k=60, top_k=5)
+        result2 = _rrf_merge(keyword, vector, k=60, top_k=5)
+
+        ids1 = [r["id"] for r in result1]
+        ids2 = [r["id"] for r in result2]
+        assert ids1 == ids2
+        assert ids1 == ["c1", "c3"]
+
     def test_rrf_merge_top_k_respected(self):
         """RRF merge returns at most top_k results."""
         keyword = [_CHUNK_A, _CHUNK_B, _CHUNK_C]
@@ -76,7 +99,7 @@ class TestRRFMerge:
         # B is in both lists at ranks (1, 0) → score = 1/(60+1) + 1/(60+0) ≈ 0.0328
         # A is in only keyword at rank 0 → score = 1/(60+0) = 0.0164
         # C is in only vector at rank 1 → score = 1/(60+1) = 0.0164
-        # So B > A = C (tie-break by insertion order)
+        # So B > A = C (ties broken lexicographically by chunk id: c1 < c3)
 
         ids = [r["id"] for r in result]
         assert ids.index("c2") < ids.index("c1")  # B ranks above A


### PR DESCRIPTION
Fixes #229

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `ec25c17e-7669-4615-95b1-2bba8d662624`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.