### PR TITLE
[bench-OO] fix(rag): make hybrid retrieval deterministic on tied scores

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -280,7 +280,7 @@ async def keyword_search(
             FROM chunks
             WHERE search_vector @@ plainto_tsquery($1)
               AND source_type = ANY($3::text[])
-            ORDER BY rank DESC
+            ORDER BY rank DESC, id ASC
             LIMIT $2
             """,
             query,
@@ -326,7 +326,7 @@ async def vector_search_pg(
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
             WHERE source_type = ANY($3::text[])
-            ORDER BY distance
+            ORDER BY distance ASC, id ASC
             LIMIT $2
             """,
             embedding_json,

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -196,5 +196,5 @@ def _rrf_merge(
         if chunk_id not in rows:
             rows[chunk_id] = row
 
-    ranked = sorted(scores, key=scores.__getitem__, reverse=True)[:top_k]
+    ranked = sorted(scores, key=lambda cid: (-scores[cid], cid))[:top_k]
     return [{**rows[cid], "rrf_score": scores[cid]} for cid in ranked]

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -93,6 +93,22 @@ class TestKeywordSearch:
         args = call_args[0]
         assert args[2] == 3
 
+    async def test_keyword_search_orders_by_rank_descending_with_tiebreaker(self):
+        """keyword_search SQL orders by ts_rank descending, with id ASC tiebreaker."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5)
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        assert "ORDER BY rank DESC, id ASC" in sql
+
 
 class TestVectorSearchPg:
     """Tests for vector_search_pg() SQL execution."""
@@ -157,7 +173,7 @@ class TestVectorSearchPg:
         assert result == []
 
     async def test_vector_search_pg_orders_by_distance_ascending(self):
-        """vector_search_pg SQL orders by cosine distance ascending (nearest first)."""
+        """vector_search_pg SQL orders by cosine distance ascending, with id ASC tiebreaker."""
         mock_conn = AsyncMock()
         mock_conn.fetch = AsyncMock(return_value=[])
 
@@ -170,7 +186,7 @@ class TestVectorSearchPg:
 
         call_args = mock_conn.fetch.call_args
         sql = call_args[0][0]
-        assert "ORDER BY distance" in sql
+        assert "ORDER BY distance ASC, id ASC" in sql
 
     async def test_vector_search_pg_json_encodes_embedding(self):
         """vector_search_pg JSON-serializes the embedding list before passing to DB."""

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -76,10 +76,27 @@ class TestRRFMerge:
         # B is in both lists at ranks (1, 0) → score = 1/(60+1) + 1/(60+0) ≈ 0.0328
         # A is in only keyword at rank 0 → score = 1/(60+0) = 0.0164
         # C is in only vector at rank 1 → score = 1/(60+1) = 0.0164
-        # So B > A = C (tie-break by insertion order)
+        # So B > A = C (tie-break by chunk_id ascending)
 
         ids = [r["id"] for r in result]
         assert ids.index("c2") < ids.index("c1")  # B ranks above A
+
+    def test_rrf_merge_breaks_ties_deterministically(self):
+        """Tied RRF scores resolve by chunk_id ASC and are stable across input permutations."""
+        # A and C both appear only in keyword at rank 0 / vector at rank 0 respectively,
+        # giving identical RRF scores: 1/(60+0) = 0.01639...
+        # B does not appear; the tie is between A (id="c1") and C (id="c3").
+        # Determinism requires "c1" before "c3" regardless of input permutation.
+        result1 = _rrf_merge([_CHUNK_A], [_CHUNK_C], k=60, top_k=5)
+        result2 = _rrf_merge([_CHUNK_C], [_CHUNK_A], k=60, top_k=5)
+
+        ids1 = [r["id"] for r in result1]
+        ids2 = [r["id"] for r in result2]
+
+        # Both orderings of identical-score chunks resolve to the same id order.
+        assert ids1 == ids2
+        # Tiebreak is lexicographic by chunk_id ascending.
+        assert ids1 == ["c1", "c3"]
 
     def test_rrf_merge_empty_keyword_returns_vector_ranked(self):
         """Empty keyword list returns vector results sorted by vector rank."""


### PR DESCRIPTION
Fixes #229

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `ef0a8938-31c6-407c-9766-05660d827243`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.