### PR TITLE
[bench-OK] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -276,9 +276,9 @@ async def keyword_search(
         rows = await conn.fetch(
             """
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                   ts_rank(search_vector, plainto_tsquery($4::regconfig, $1)) AS rank
             FROM chunks
-            WHERE search_vector @@ plainto_tsquery($1)
+            WHERE search_vector @@ plainto_tsquery($4::regconfig, $1)
               AND source_type = ANY($3::text[])
             ORDER BY rank DESC
             LIMIT $2
@@ -286,6 +286,7 @@ async def keyword_search(
             query,
             top_k,
             allowed_source_types,
+            language,
         )
     return [dict(r) for r in rows]
 

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -51,9 +51,14 @@ class TestKeywordSearch:
 
         # Verify positional args: query string and top_k
         args = call_args[0]
-        # args is (sql_string, query_string, top_k_int)
+        # args is (sql_string, query_string, top_k_int, allowed_source_types, language)
         assert args[1] == "hello world"
         assert args[2] == 5
+
+        # language is bound as the trailing $4 parameter
+        assert args[4] == "english"
+        # regconfig is passed to both plainto_tsquery calls
+        assert sql.count("plainto_tsquery($4::regconfig, $1)") == 2
 
         # Verify result shape
         assert len(result) == 1
@@ -92,6 +97,22 @@ class TestKeywordSearch:
         assert "LIMIT $2" in sql
         args = call_args[0]
         assert args[2] == 3
+
+    async def test_keyword_search_passes_custom_language(self):
+        """keyword_search wires a custom language through as the trailing arg."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, language="simple")
+
+        call_args = mock_conn.fetch.call_args
+        args = call_args[0]
+        assert args[4] == "simple"
 
 
 class TestVectorSearchPg:


### PR DESCRIPTION
Fixes #242

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `0dc6e95b-d794-4690-9d7e-41f489271112`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.