### PR TITLE
[bench-OO] fix(rag): bind language regconfig into keyword_search tsquery calls

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -276,9 +276,9 @@ async def keyword_search(
         rows = await conn.fetch(
             """
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                   ts_rank(search_vector, plainto_tsquery($4::regconfig, $1)) AS rank
             FROM chunks
-            WHERE search_vector @@ plainto_tsquery($1)
+            WHERE search_vector @@ plainto_tsquery($4::regconfig, $1)
               AND source_type = ANY($3::text[])
             ORDER BY rank DESC
             LIMIT $2
@@ -286,6 +286,7 @@ async def keyword_search(
             query,
             top_k,
             allowed_source_types,
+            language,
         )
     return [dict(r) for r in rows]
 

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -60,6 +60,46 @@ class TestKeywordSearch:
         assert result[0]["id"] == "chunk1"
         assert result[0]["rank"] == 0.9
 
+    async def test_keyword_search_binds_language_into_both_tsquery_calls(self):
+        """Both plainto_tsquery calls carry the bound regconfig ($4), none are bare."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("hello world", top_k=5)
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+
+        # The bound-regconfig form must appear in BOTH the ts_rank and WHERE clauses.
+        # Guards against fixing only the @@ clause and forgetting ts_rank (or vice-versa).
+        assert sql.count("plainto_tsquery($4::regconfig, $1)") == 2
+        # No bare plainto_tsquery($1) — that would fall back to the server GUC.
+        assert "plainto_tsquery($1)" not in sql
+
+    async def test_keyword_search_passes_language_arg(self):
+        """language is bound as the 4th positional arg, defaulting to 'english'."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        # Default language
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("hello world", top_k=5)
+        assert mock_conn.fetch.call_args[0][4] == "english"
+
+        # Explicit non-default language is honored, not hardcoded
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("hello world", top_k=5, language="simple")
+        assert mock_conn.fetch.call_args[0][4] == "simple"
+
     async def test_keyword_search_returns_empty_list_when_no_matches(self):
         """keyword_search returns empty list when DB returns no rows."""
         mock_conn = AsyncMock()


### PR DESCRIPTION
Fixes #242

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `24b4b4d4-0751-4ce0-82f0-dd786824c13f`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.