### PR TITLE
[bench-OO] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -276,9 +276,9 @@ async def keyword_search(
         rows = await conn.fetch(
             """
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                   ts_rank(search_vector, plainto_tsquery($4::regconfig, $1)) AS rank
             FROM chunks
-            WHERE search_vector @@ plainto_tsquery($1)
+            WHERE search_vector @@ plainto_tsquery($4::regconfig, $1)
               AND source_type = ANY($3::text[])
             ORDER BY rank DESC
             LIMIT $2
@@ -286,6 +286,7 @@ async def keyword_search(
             query,
             top_k,
             allowed_source_types,
+            language,
         )
     return [dict(r) for r in rows]
 

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -49,16 +49,44 @@ class TestKeywordSearch:
         assert "search_vector" in sql
         assert "@@" in sql  # tsvector match operator
 
+        # Both plainto_tsquery calls must carry the regconfig parameter so
+        # query-side tokenization matches the index-side to_tsvector('english').
+        assert sql.count("plainto_tsquery") == 2
+        assert sql.count("plainto_tsquery($4::regconfig, $1)") == 2
+
         # Verify positional args: query string and top_k
         args = call_args[0]
-        # args is (sql_string, query_string, top_k_int)
+        # args is (sql, query, top_k, allowed_source_types, language)
         assert args[1] == "hello world"
         assert args[2] == 5
+        # language binds to $4 with its default value
+        assert args[4] == "english"
 
         # Verify result shape
         assert len(result) == 1
         assert result[0]["id"] == "chunk1"
         assert result[0]["rank"] == 0.9
+
+    async def test_keyword_search_passes_language_to_both_tsquery_calls(self):
+        """A non-default language binds to $4 and reaches both plainto_tsquery calls."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, language="simple")
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        # Guard against the partial fix: ts_rank AND WHERE must both get the regconfig.
+        assert sql.count("plainto_tsquery") == 2
+        assert sql.count("plainto_tsquery($4::regconfig, $1)") == 2
+
+        args = call_args[0]
+        assert args[4] == "simple"
 
     async def test_keyword_search_returns_empty_list_when_no_matches(self):
         """keyword_search returns empty list when DB returns no rows."""


### PR DESCRIPTION
Fixes #242

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `38770889-3c70-42e9-8439-ff8795da32a9`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.