### PR TITLE
[bench-KO] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -276,9 +276,9 @@ async def keyword_search(
         rows = await conn.fetch(
             """
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                   ts_rank(search_vector, plainto_tsquery($4::regconfig, $1)) AS rank
             FROM chunks
-            WHERE search_vector @@ plainto_tsquery($1)
+            WHERE search_vector @@ plainto_tsquery($4::regconfig, $1)
               AND source_type = ANY($3::text[])
             ORDER BY rank DESC
             LIMIT $2
@@ -286,6 +286,7 @@ async def keyword_search(
             query,
             top_k,
             allowed_source_types,
+            language,
         )
     return [dict(r) for r in rows]
 

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -51,14 +51,42 @@ class TestKeywordSearch:
 
         # Verify positional args: query string and top_k
         args = call_args[0]
-        # args is (sql_string, query_string, top_k_int)
+        # args is (sql_string, query_string, top_k_int, allowed_source_types, language)
         assert args[1] == "hello world"
         assert args[2] == 5
+
+        # Both plainto_tsquery calls must bind the language regconfig ($4) so
+        # query-side tokenization matches the index, regardless of the session
+        # default_text_search_config GUC (issue #242).
+        assert sql.count("plainto_tsquery($4::regconfig, $1)") == 2
+        assert "plainto_tsquery($1)" not in sql
+        # language defaults to "english" and is bound as the fourth arg
+        assert args[4] == "english"
 
         # Verify result shape
         assert len(result) == 1
         assert result[0]["id"] == "chunk1"
         assert result[0]["rank"] == 0.9
+
+    async def test_keyword_search_binds_language_regconfig(self):
+        """keyword_search binds its language param into both plainto_tsquery calls."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, language="spanish")
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        args = call_args[0]
+        # Both ts_rank and WHERE @@ clauses bind $4::regconfig for the language
+        assert sql.count("plainto_tsquery($4::regconfig, $1)") == 2
+        # The language value is bound as the fourth positional argument
+        assert args[4] == "spanish"
 
     async def test_keyword_search_returns_empty_list_when_no_matches(self):
         """keyword_search returns empty list when DB returns no rows."""


### PR DESCRIPTION
Fixes #242

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `35ad30bf-34c7-4fef-9dae-4a9760733d3a`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.