### PR TITLE
[bench-KK] impl: address issue

### DIFF
--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -64,7 +64,7 @@ async def verify_paid_member(email: str) -> bool:
             member = _extract_member(r.json())
             if member is None:
                 return False
-            if not member.get("active", True):
+            if not member.get("active", False):
                 # Inactive members lose access immediately.
                 return False
             member_id = member.get("id")

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -110,6 +110,15 @@ async def test_inactive_member_returns_false():
 
 
 @respx.mock
+async def test_member_without_active_field_fails_closed():
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999})
+    )
+
+    assert await circle.verify_paid_member("absent-active@example.com") is False
+
+
+@respx.mock
 async def test_records_wrapped_response_handled():
     """Some Circle endpoints wrap a single record in `records: [...]`."""
     respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(


### PR DESCRIPTION
Fixes #243

**Benchmark cell:** `KK` (plan=Kimi, impl=Kimi)
**Source run-id:** `a9aec468-125b-4cd7-a978-f28adb528ac1`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.