### PR TITLE
[bench-OK] impl: address issue

### DIFF
--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -64,8 +64,9 @@ async def verify_paid_member(email: str) -> bool:
             member = _extract_member(r.json())
             if member is None:
                 return False
-            if not member.get("active", True):
-                # Inactive members lose access immediately.
+            if not member.get("active", False):
+                # Inactive members, or members whose status is absent/unknown,
+                # lose access (fail-closed).
                 return False
             member_id = member.get("id")
             if not member_id:

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -110,6 +110,26 @@ async def test_inactive_member_returns_false():
 
 
 @respx.mock
+async def test_member_missing_active_field_returns_false():
+    """A member object without an explicit active key must be denied (fail-closed)."""
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999})
+    )
+
+    assert await circle.verify_paid_member("unknown@example.com") is False
+
+
+@respx.mock
+async def test_records_wrapped_missing_active_field_returns_false():
+    """Records-wrapped shape with absent active key must also deny."""
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"records": [{"id": 999}]})
+    )
+
+    assert await circle.verify_paid_member("unknown@example.com") is False
+
+
+@respx.mock
 async def test_records_wrapped_response_handled():
     """Some Circle endpoints wrap a single record in `records: [...]`."""
     respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(


### PR DESCRIPTION
Fixes #243

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `1a3a22e7-c337-453f-b8ad-f824e4e0128c`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.