### PR TITLE
[bench-KO] impl: address issue

### DIFF
--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -64,8 +64,9 @@ async def verify_paid_member(email: str) -> bool:
             member = _extract_member(r.json())
             if member is None:
                 return False
-            if not member.get("active", True):
-                # Inactive members lose access immediately.
+            if not member.get("active", False):
+                # Inactive members — or members whose payload lacks an explicit
+                # active signal — lose access immediately (fail-closed).
                 return False
             member_id = member.get("id")
             if not member_id:

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -110,6 +110,20 @@ async def test_inactive_member_returns_false():
 
 
 @respx.mock
+async def test_member_without_active_field_returns_false():
+    """A member payload lacking an explicit `active` key must fail closed.
+
+    Circle's search-result shape does not reliably include `active`; absence of
+    an explicit active signal must deny access on this paid-content gate.
+    """
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999})
+    )
+
+    assert await circle.verify_paid_member("unknown-status@example.com") is False
+
+
+@respx.mock
 async def test_records_wrapped_response_handled():
     """Some Circle endpoints wrap a single record in `records: [...]`."""
     respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(


### PR DESCRIPTION
Fixes #243

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `b395cb43-916e-47bd-90f9-fb118a181694`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.