### PR TITLE
[bench-OO] impl: address issue

### DIFF
--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -64,8 +64,9 @@ async def verify_paid_member(email: str) -> bool:
             member = _extract_member(r.json())
             if member is None:
                 return False
-            if not member.get("active", True):
-                # Inactive members lose access immediately.
+            if not member.get("active", False):
+                # Inactive members — or members whose status is absent/unknown —
+                # lose access immediately (fail-closed per the module contract).
                 return False
             member_id = member.get("id")
             if not member_id:

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -110,6 +110,20 @@ async def test_inactive_member_returns_false():
 
 
 @respx.mock
+async def test_member_missing_active_field_fails_closed():
+    """A member object with no `active` field must be treated as a non-member.
+
+    Circle's search-result shape does not reliably include `active`; a
+    present-but-unknown-status member must NOT be granted access (fail-closed).
+    """
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999})  # no `active` key
+    )
+
+    assert await circle.verify_paid_member("unknown@example.com") is False
+
+
+@respx.mock
 async def test_records_wrapped_response_handled():
     """Some Circle endpoints wrap a single record in `records: [...]`."""
     respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(


### PR DESCRIPTION
Fixes #243

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `2cd12dcd-17d9-43d0-bc67-ec6b7be93e2b`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.