### PR TITLE
[bench-KO] impl: address issue

### DIFF
--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -537,6 +537,55 @@ describe('conversationId reset — state clears on navigation', () => {
   });
 });
 
+describe('mid-stream error — partial text is not committed as success', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects, skips onComplete, and still runs finally cleanup on a {"error"} payload', async () => {
+    // A normal token lands first, then the server emits a mid-stream error.
+    // The accumulated partial text must NOT be committed via onComplete.
+    const sseChunks = [
+      'data: "Partial answer"\n\n',
+      'data: {"error":"Mid-stream failure"}\n\n',
+      // A trailing [DONE] that some backends still emit after the error — it
+      // must never re-enable the success path once streamError is set.
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    let caught: unknown;
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hi', onComplete).catch((e) => {
+        caught = e;
+      });
+    });
+
+    // streamError is surfaced to the caller.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('Mid-stream failure');
+
+    // onComplete must NOT fire — the partial text is never committed.
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // finally cleanup still ran exactly once: streaming state is reset.
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.streamingStatus).toBeNull();
+  });
+});
+
 describe('sources event — hook state via renderHook', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -56,6 +56,9 @@ export function useStreamingResponse(conversationId: string | null) {
       let fullText = '';
       let sources: Citation[] = [];
       let streamError: Error | null = null;
+      // Set when a mid-stream error payload arrives so the outer reader loop
+      // exits immediately instead of draining the rest of the stream.
+      let streamAborted = false;
 
       try {
         const abortController = new AbortController();
@@ -184,6 +187,7 @@ export function useStreamingResponse(conversationId: string | null) {
                 // Use default message
               }
               streamError = new Error(errMsg);
+              streamAborted = true;
               break;
             } else if (data) {
               // Tokens are JSON-encoded strings to safely handle newlines/special chars
@@ -201,10 +205,17 @@ export function useStreamingResponse(conversationId: string | null) {
               setStreamingContent(fullText);
             }
           }
+
+          // A mid-stream error aborts the stream — stop reading immediately
+          // instead of looping back to reader.read() and draining the rest.
+          if (streamAborted) break;
         }
 
-        // Stream completed successfully
-        onComplete({ fullText, sources });
+        // Only fire onComplete on a clean stream — never commit partial text
+        // from a mid-stream error as a successful answer.
+        if (!streamError) {
+          onComplete({ fullText, sources });
+        }
       } finally {
         // Always reset streaming state — React 18 batches this with the onComplete
         // state updates, ensuring a seamless transition to the persisted message.


### PR DESCRIPTION
Fixes #244

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `31cde88f-6c6a-4041-8775-0e36620f68c2`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.