### PR TITLE
[bench-OO] fix(web): stop stream drain on mid-stream error before onComplete

### DIFF
--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -439,6 +439,55 @@ describe('status event SSE parsing — hook state transitions', () => {
   });
 });
 
+describe('mid-stream error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops draining and rejects without calling onComplete on a {"error"} payload', async () => {
+    // Tokens flow, then the server emits a mid-stream error. The trailing token and
+    // [DONE] must never be processed — proving the outer reader loop stopped promptly.
+    const sseChunks = [
+      'data: "Partial answer"\n\n',
+      'data: {"error": "Overloaded"}\n\n',
+      'data: " should never be appended"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    let caught: Error | null = null;
+    await act(async () => {
+      try {
+        await result.current.startStream('conv-1', 'hi', onComplete);
+      } catch (e) {
+        caught = e as Error;
+      }
+    });
+
+    // streamError is surfaced to the caller...
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught?.message).toBe('Overloaded');
+    // ...and the partial answer was never committed as a success.
+    expect(onComplete).not.toHaveBeenCalled();
+    // The finally block still reset all streaming state exactly once.
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.streamingSources).toHaveLength(0);
+    expect(result.current.streamingStatus).toBeNull();
+  });
+});
+
 describe('abortStream', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -108,6 +108,9 @@ export function useStreamingResponse(conversationId: string | null) {
         let buffer = '';
 
         while (true) {
+          // A mid-stream {"error"} payload only breaks the inner for-loop below; stop
+          // draining the reader promptly here so onComplete never fires with partial text.
+          if (streamError) break;
           const { done, value } = await reader.read();
           if (done) break;
 
@@ -203,8 +206,10 @@ export function useStreamingResponse(conversationId: string | null) {
           }
         }
 
-        // Stream completed successfully
-        onComplete({ fullText, sources });
+        // Stream completed successfully — but not if a mid-stream error aborted it
+        if (!streamError) {
+          onComplete({ fullText, sources });
+        }
       } finally {
         // Always reset streaming state — React 18 batches this with the onComplete
         // state updates, ensuring a seamless transition to the persisted message.


### PR DESCRIPTION
Fixes #244

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `777cce92-9c9c-4da5-842b-19168656ffb6`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.