### PR TITLE
[bench-OO] fix(rag): guard timestamp distribution for zero-duration segments

### DIFF
--- a/app/backend/rag/chunker.py
+++ b/app/backend/rag/chunker.py
@@ -162,9 +162,12 @@ def chunk_video_timestamped(segments: list[TimestampedSegment]) -> tuple[list[di
 
             # Distribute timestamps evenly across sub-chunks when HybridChunker
             # splits a segment into multiple pieces (no worse than fallback's
-            # proportional timestamps, which are explicitly accepted).
-            if len(sub_chunks) > 1:
-                duration = end_s - start_s
+            # proportional timestamps, which are explicitly accepted). When the
+            # segment has zero or negative duration (e.g. the final Supadata
+            # segment with no explicit end), even distribution is meaningless, so
+            # leave each sub-chunk on the original [start_s, end_s] boundary.
+            duration = end_s - start_s
+            if len(sub_chunks) > 1 and duration > 0:
                 step = duration / len(sub_chunks)
                 for i, sc in enumerate(sub_chunks):
                     sc["start_seconds"] = start_s + i * step

--- a/app/backend/tests/test_chunker_timestamps.py
+++ b/app/backend/tests/test_chunker_timestamps.py
@@ -8,7 +8,18 @@ Verifies:
   - chunk_video_fallback evenly distributes estimated duration across chunks
 """
 
+import pytest
+
 from backend.rag.chunker import chunk_video_fallback, chunk_video_timestamped
+
+
+def _long_splittable_text() -> str:
+    """Text well over HybridChunker's 512-token limit with sentence boundaries,
+    so a single segment splits into more than one sub-chunk."""
+    return " ".join(
+        f"This is sentence number {i} describing some part of the video content."
+        for i in range(160)
+    )
 
 
 class TestChunkVideoTimestamped:
@@ -54,6 +65,55 @@ class TestChunkVideoTimestamped:
         result, _ = chunk_video_timestamped(segments)
         # Should not produce any chunks from the empty segment
         assert all("Real content" in c["content"] or "Real content" in c["snippet"] for c in result)
+
+    def test_zero_duration_segment_does_not_redistribute(self) -> None:
+        """A zero-duration segment (end == start) that splits into multiple
+        sub-chunks keeps each sub-chunk on the original boundary instead of
+        running the meaningless even-distribution (step = 0) over it."""
+        segments = [{"start": 100.0, "end": 100.0, "text": _long_splittable_text()}]
+        result, _ = chunk_video_timestamped(segments)
+
+        # The branch must be reachable: the segment actually split.
+        assert len(result) > 1
+        # Distribution did not run: every sub-chunk keeps the preserved
+        # [start_s, end_s] boundary (both 100.0), not a step-derived span.
+        for chunk in result:
+            assert chunk["start_seconds"] == 100.0
+            assert chunk["end_seconds"] == 100.0
+
+    def test_negative_duration_segment_does_not_redistribute(self) -> None:
+        """A negative-duration segment (end < start) that splits into multiple
+        sub-chunks keeps the original [start_s, end_s] boundary rather than
+        producing distributed (decreasing) spans from a negative step."""
+        segments = [{"start": 100.0, "end": 50.0, "text": _long_splittable_text()}]
+        result, _ = chunk_video_timestamped(segments)
+
+        # The branch must be reachable: the segment actually split.
+        assert len(result) > 1
+        # Distribution did not run: all sub-chunks retain the original boundary.
+        for chunk in result:
+            assert chunk["start_seconds"] == 100.0
+            assert chunk["end_seconds"] == 50.0
+
+    def test_positive_duration_segment_distributes_evenly(self) -> None:
+        """A normal positive-duration segment that splits into multiple
+        sub-chunks still gets evenly-distributed, increasing timestamps."""
+        segments = [{"start": 0.0, "end": 100.0, "text": _long_splittable_text()}]
+        result, _ = chunk_video_timestamped(segments)
+
+        # The branch must be reachable: the segment actually split.
+        n = len(result)
+        assert n > 1
+
+        step = 100.0 / n
+        for i, chunk in enumerate(result):
+            assert chunk["start_seconds"] == pytest.approx(i * step)
+            assert chunk["end_seconds"] == pytest.approx((i + 1) * step)
+        # Timestamps are strictly increasing and span the full segment.
+        for i in range(1, n):
+            assert result[i]["start_seconds"] > result[i - 1]["start_seconds"]
+        assert result[0]["start_seconds"] == 0.0
+        assert result[-1]["end_seconds"] == pytest.approx(100.0)
 
 
 class TestChunkVideoFallback:


### PR DESCRIPTION
Fixes #245

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `e69d91df-8d99-420f-a043-b694ffd6c6df`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.