### PR TITLE
[bench-KO] impl: address issue

### DIFF
--- a/app/backend/rag/chunker.py
+++ b/app/backend/rag/chunker.py
@@ -163,8 +163,8 @@ def chunk_video_timestamped(segments: list[TimestampedSegment]) -> tuple[list[di
             # Distribute timestamps evenly across sub-chunks when HybridChunker
             # splits a segment into multiple pieces (no worse than fallback's
             # proportional timestamps, which are explicitly accepted).
-            if len(sub_chunks) > 1:
-                duration = end_s - start_s
+            duration = end_s - start_s
+            if len(sub_chunks) > 1 and duration > 0:
                 step = duration / len(sub_chunks)
                 for i, sc in enumerate(sub_chunks):
                     sc["start_seconds"] = start_s + i * step

--- a/app/backend/tests/test_chunker_timestamps.py
+++ b/app/backend/tests/test_chunker_timestamps.py
@@ -39,6 +39,28 @@ class TestChunkVideoTimestamped:
         # The snippet should be the raw segment text (up to 300 chars)
         assert chunk["snippet"] == "Original transcript text here"
 
+    def test_zero_duration_segment_keeps_boundary_when_split(self) -> None:
+        """A zero-duration segment that splits into multiple sub-chunks must not
+        collapse every sub-chunk onto a single instant.
+
+        Regression for issue #245: the final transcript segment can have
+        end == start (and Supadata's last segment can carry duration == 0). When
+        such a segment is long enough to split into more than one sub-chunk, the
+        old even-distribution math computed step == 0 and pinned every sub-chunk
+        to start_s. With duration <= 0 we keep the original [start_s, end_s].
+        """
+        # Long text that HybridChunker (max_tokens=512) splits into >1 sub-chunk.
+        long_text = " ".join(
+            f"Sentence number {i} describes a distinct idea about the topic." for i in range(200)
+        )
+        segments = [{"start": 330.0, "end": 330.0, "text": long_text}]
+        result, _ = chunk_video_timestamped(segments)
+
+        assert len(result) > 1
+        for chunk in result:
+            assert chunk["start_seconds"] == 330.0
+            assert chunk["end_seconds"] == 330.0
+
     def test_empty_segments_returns_empty_list(self) -> None:
         """Empty input returns empty list."""
         result, had_errors = chunk_video_timestamped([])


### PR DESCRIPTION
Fixes #245

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `7e8aaa45-3223-4f58-b73d-6ccf9177e83f`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.