### PR TITLE
[bench-OK] impl: address issue

### DIFF
--- a/app/backend/rag/chunker.py
+++ b/app/backend/rag/chunker.py
@@ -165,10 +165,14 @@ def chunk_video_timestamped(segments: list[TimestampedSegment]) -> tuple[list[di
             # proportional timestamps, which are explicitly accepted).
             if len(sub_chunks) > 1:
                 duration = end_s - start_s
-                step = duration / len(sub_chunks)
-                for i, sc in enumerate(sub_chunks):
-                    sc["start_seconds"] = start_s + i * step
-                    sc["end_seconds"] = start_s + (i + 1) * step
+                if duration > 0:
+                    step = duration / len(sub_chunks)
+                    for i, sc in enumerate(sub_chunks):
+                        sc["start_seconds"] = start_s + i * step
+                        sc["end_seconds"] = start_s + (i + 1) * step
+                # else: zero-width/inverted segment (e.g. final _parse_segments
+                # segment where end == start) — even distribution is meaningless,
+                # so each sub-chunk keeps the original [start_s, end_s] boundary.
 
             results.extend(sub_chunks)
         except Exception as exc:

--- a/app/backend/tests/test_chunker_timestamps.py
+++ b/app/backend/tests/test_chunker_timestamps.py
@@ -55,6 +55,47 @@ class TestChunkVideoTimestamped:
         # Should not produce any chunks from the empty segment
         assert all("Real content" in c["content"] or "Real content" in c["snippet"] for c in result)
 
+    def test_zero_duration_segment_does_not_collapse_timestamps(self) -> None:
+        """A zero-width segment that splits into multiple sub-chunks keeps the
+        original [start_s, end_s] boundary on every sub-chunk instead of
+        distributing a zero step and pinning every chunk to start_s."""
+        text = " ".join(
+            [
+                f"Sentence {i} of this transcript segment provides more content for the chunker."
+                for i in range(100)
+            ]
+        )
+        segments = [{"start": 100.0, "end": 100.0, "text": text}]
+        result, _ = chunk_video_timestamped(segments)
+
+        # We need the segment to have actually split to prove the guard ran.
+        assert len(result) >= 1
+        for chunk in result:
+            assert chunk["start_seconds"] == 100.0
+            assert chunk["end_seconds"] == 100.0
+            assert chunk["end_seconds"] >= chunk["start_seconds"]
+
+    def test_positive_duration_still_distributes(self) -> None:
+        """Normal positive-duration segments continue to spread timestamps evenly."""
+        text = " ".join(
+            [
+                f"Sentence {i} of this transcript segment provides more content for the chunker."
+                for i in range(100)
+            ]
+        )
+        segments = [{"start": 0.0, "end": 60.0, "text": text}]
+        result, _ = chunk_video_timestamped(segments)
+
+        assert len(result) > 1
+        starts = [c["start_seconds"] for c in result]
+        assert starts == sorted(starts)
+        assert starts[0] == 0.0
+        assert result[-1]["end_seconds"] == 60.0
+        for chunk in result:
+            assert chunk["start_seconds"] >= 0.0
+            assert chunk["end_seconds"] <= 60.0
+            assert chunk["end_seconds"] >= chunk["start_seconds"]
+
 
 class TestChunkVideoFallback:
     def test_produces_monotonic_timestamps(self) -> None:


### PR DESCRIPTION
Fixes #245

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `a85dce75-8b20-4be9-8cb0-7ce3b5f83c1c`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.