### PR TITLE
[bench-OK] impl: address issue

### DIFF
--- a/app/backend/rag/catalog.py
+++ b/app/backend/rag/catalog.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 
-from backend.config import CATALOG_CACHE_TTL_SECONDS
 from backend.db import repository
 
 logger = logging.getLogger(__name__)
@@ -78,7 +77,7 @@ def build_catalog_block(videos: list[dict], tier: str) -> dict:
 
     cache_control: dict = {"type": "ephemeral"}
     if tier == "extended":
-        cache_control["ttl"] = CATALOG_CACHE_TTL_SECONDS  # integer seconds per Anthropic API
+        cache_control["ttl"] = "1h"  # Anthropic accepts only "5m" or "1h" duration strings
 
     return {
         "type": "text",

--- a/app/backend/tests/test_catalog.py
+++ b/app/backend/tests/test_catalog.py
@@ -71,7 +71,7 @@ def test_build_catalog_block_standard() -> None:
 def test_build_catalog_block_extended() -> None:
     videos = [{"id": "vid-abc", "title": "My Video", "url": "https://youtube.com/watch?v=abc"}]
     block = catalog.build_catalog_block(videos, "extended")
-    assert block["cache_control"] == {"type": "ephemeral", "ttl": 3600}
+    assert block["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
 
 def test_build_catalog_block_untitled_fallback() -> None:
@@ -263,13 +263,12 @@ async def test_build_system_prompt_catalog_treats_missing_source_type_as_youtube
 # ---------------------------------------------------------------------------
 
 
-def test_build_catalog_block_extended_ttl_is_integer() -> None:
-    """CATALOG_TIER='extended' must produce an integer ttl, not a string."""
-    with patch("backend.rag.catalog.CATALOG_CACHE_TTL_SECONDS", 3600):
-        videos = [{"id": "v", "title": "Vid", "url": "https://youtu.be/x"}]
-        block = catalog.build_catalog_block(videos, "extended")
-    assert isinstance(block["cache_control"]["ttl"], int)
-    assert block["cache_control"]["ttl"] == 3600
+def test_build_catalog_block_extended_ttl_is_anthropic_duration() -> None:
+    """CATALOG_TIER='extended' must produce a valid Anthropic duration string."""
+    videos = [{"id": "v", "title": "Vid", "url": "https://youtu.be/x"}]
+    block = catalog.build_catalog_block(videos, "extended")
+    assert isinstance(block["cache_control"]["ttl"], str)
+    assert block["cache_control"]["ttl"] == "1h"
 
 
 def test_build_catalog_block_missing_url() -> None:


### PR DESCRIPTION
Fixes #246

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `2ace33bc-14e0-45d9-ab49-2187a385f694`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.