### PR TITLE
[bench-OK] impl: address issue

### DIFF
--- a/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
@@ -1,9 +1,9 @@
 /**
  * Unit tests for ChatArea.handleCitationClick branching logic (issue #216 fix).
  *
- * Dynamous citations → window.open(lesson_url, '_blank', 'noopener,noreferrer')
- * YouTube citations  → opens CitationModal (setSelectedCitation)
- * Missing lesson_url → does nothing (no blank tab)
+ * Dynamous citations       → window.open(lesson_url, '_blank', 'noopener,noreferrer')
+ * YouTube citations        → opens CitationModal (setSelectedCitation)
+ * Missing lesson_url       → informational toast (no blank tab, no modal)
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -44,8 +44,9 @@ vi.mock('../hooks/useStreamingResponse', () => ({
   }),
 }));
 
+const mockAddToast = vi.fn();
 vi.mock('../hooks/useToast', () => ({
-  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+  useToast: () => ({ addToast: mockAddToast, removeToast: vi.fn() }),
 }));
 
 vi.mock('../hooks/useAuth', () => ({
@@ -146,9 +147,11 @@ describe('handleCitationClick', () => {
     );
     // CitationModal must NOT appear
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+    // No spurious toast on the happy path
+    expect(mockAddToast).not.toHaveBeenCalled();
   });
 
-  it('does nothing when Dynamous citation has no lesson_url', async () => {
+  it('shows a toast when Dynamous citation has no lesson_url', async () => {
     mockMessages = [makeAssistantMessage(dynaCitationNoUrl)];
 
     render(
@@ -166,6 +169,12 @@ describe('handleCitationClick', () => {
     // window.open must NOT be called — no blank tab opened
     expect(openSpy).not.toHaveBeenCalled();
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+    // Informational toast must fire
+    expect(mockAddToast).toHaveBeenCalledTimes(1);
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.stringMatching(/lesson link|not available|no link/i),
+      'info',
+    );
   });
 
   it('opens the citation modal for YouTube citations', async () => {
@@ -189,5 +198,7 @@ describe('handleCitationClick', () => {
     await waitFor(() => {
       expect(screen.getByTitle('YouTube video player')).toBeInTheDocument();
     });
+    // No spurious toast on the YouTube path
+    expect(mockAddToast).not.toHaveBeenCalled();
   });
 });

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -439,16 +439,19 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
 
   // ── Citation click handler ──
   // Dynamous: open lesson URL directly in a new tab — no modal.
+  // Dynamous (no lesson_url): show an informational toast instead of a silent no-op.
   // YouTube: open the embedded player modal as usual.
   const handleCitationClick = useCallback((citation: Citation) => {
     if (citation.source_type === 'dynamous') {
       if (citation.lesson_url) {
         window.open(citation.lesson_url, '_blank', 'noopener,noreferrer');
+      } else {
+        addToast('No lesson link is available for this source.', 'info');
       }
     } else {
       setSelectedCitation(citation);
     }
-  }, []);
+  }, [addToast]);
 
   // ── Send handler ──
   const handleSend = useCallback(


### PR DESCRIPTION
Fixes #247

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `7333cf17-e42d-4194-800f-95409875b1a9`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.