### PR TITLE
[bench-OO] fix(web): give feedback for Dynamous citation with empty lesson_url

### DIFF
--- a/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
@@ -3,7 +3,7 @@
  *
  * Dynamous citations → window.open(lesson_url, '_blank', 'noopener,noreferrer')
  * YouTube citations  → opens CitationModal (setSelectedCitation)
- * Missing lesson_url → does nothing (no blank tab)
+ * Missing lesson_url → fires an info toast (no blank tab, no modal)
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -44,8 +44,9 @@ vi.mock('../hooks/useStreamingResponse', () => ({
   }),
 }));
 
+const mockAddToast = vi.hoisted(() => vi.fn());
 vi.mock('../hooks/useToast', () => ({
-  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+  useToast: () => ({ addToast: mockAddToast, removeToast: vi.fn() }),
 }));
 
 vi.mock('../hooks/useAuth', () => ({
@@ -146,9 +147,11 @@ describe('handleCitationClick', () => {
     );
     // CitationModal must NOT appear
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+    // No toast for a working lesson link
+    expect(mockAddToast).not.toHaveBeenCalled();
   });
 
-  it('does nothing when Dynamous citation has no lesson_url', async () => {
+  it('shows an info toast when Dynamous citation has no lesson_url', async () => {
     mockMessages = [makeAssistantMessage(dynaCitationNoUrl)];
 
     render(
@@ -166,6 +169,8 @@ describe('handleCitationClick', () => {
     // window.open must NOT be called — no blank tab opened
     expect(openSpy).not.toHaveBeenCalled();
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+    // The user gets feedback instead of a silent dead click
+    expect(mockAddToast).toHaveBeenCalledWith(expect.any(String), 'info');
   });
 
   it('opens the citation modal for YouTube citations', async () => {
@@ -189,5 +194,7 @@ describe('handleCitationClick', () => {
     await waitFor(() => {
       expect(screen.getByTitle('YouTube video player')).toBeInTheDocument();
     });
+    // No toast for the modal path
+    expect(mockAddToast).not.toHaveBeenCalled();
   });
 });

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -438,17 +438,22 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   }, []);
 
   // ── Citation click handler ──
-  // Dynamous: open lesson URL directly in a new tab — no modal.
+  // Dynamous: open lesson URL directly in a new tab — no modal. If the
+  // lesson URL is empty/absent, surface an info toast instead of silently
+  // doing nothing (the citation modal is YouTube-only, so falling through
+  // would render "Video unavailable" for a Dynamous chunk).
   // YouTube: open the embedded player modal as usual.
   const handleCitationClick = useCallback((citation: Citation) => {
     if (citation.source_type === 'dynamous') {
       if (citation.lesson_url) {
         window.open(citation.lesson_url, '_blank', 'noopener,noreferrer');
+      } else {
+        addToast('No lesson link is available for this source.', 'info');
       }
     } else {
       setSelectedCitation(citation);
     }
-  }, []);
+  }, [addToast]);
 
   // ── Send handler ──
   const handleSend = useCallback(


### PR DESCRIPTION
Fixes #247

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `681c1241-3257-4696-a643-53bb2523a317`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.