### PR TITLE
[bench-KO] review: address self-review findings

### DIFF
--- a/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
@@ -172,7 +172,7 @@ describe('handleCitationClick', () => {
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
     // ...instead the user gets an info toast rather than a silent dead click
     expect(mockAddToast).toHaveBeenCalledTimes(1);
-    expect(mockAddToast).toHaveBeenCalledWith({ message: expect.any(String), type: 'info' });
+    expect(mockAddToast).toHaveBeenCalledWith(expect.any(String), 'info');
   });
 
   it('opens the citation modal for YouTube citations', async () => {

--- a/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-handleCitationClick.test.tsx
@@ -15,6 +15,9 @@ import type { Citation, Message } from '../lib/api';
 // ── Shared mocks ──────────────────────────────────────────────────────────────
 
 const mockNavigate = vi.fn();
+// Captured at module scope (mock-prefixed so vi.mock hoisting allows the
+// reference) so tests can assert on the toast surfaced by handleCitationClick.
+const mockAddToast = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return { ...actual, useNavigate: () => mockNavigate };
@@ -45,7 +48,7 @@ vi.mock('../hooks/useStreamingResponse', () => ({
 }));
 
 vi.mock('../hooks/useToast', () => ({
-  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+  useToast: () => ({ addToast: mockAddToast, removeToast: vi.fn() }),
 }));
 
 vi.mock('../hooks/useAuth', () => ({
@@ -148,7 +151,7 @@ describe('handleCitationClick', () => {
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
   });
 
-  it('does nothing when Dynamous citation has no lesson_url', async () => {
+  it('shows an info toast when Dynamous citation has no lesson_url', async () => {
     mockMessages = [makeAssistantMessage(dynaCitationNoUrl)];
 
     render(
@@ -165,7 +168,11 @@ describe('handleCitationClick', () => {
 
     // window.open must NOT be called — no blank tab opened
     expect(openSpy).not.toHaveBeenCalled();
+    // ...and the YouTube-only modal must NOT open for a Dynamous source
     expect(screen.queryByTitle('YouTube video player')).not.toBeInTheDocument();
+    // ...instead the user gets an info toast rather than a silent dead click
+    expect(mockAddToast).toHaveBeenCalledTimes(1);
+    expect(mockAddToast).toHaveBeenCalledWith({ message: expect.any(String), type: 'info' });
   });
 
   it('opens the citation modal for YouTube citations', async () => {

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -440,15 +440,23 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // ── Citation click handler ──
   // Dynamous: open lesson URL directly in a new tab — no modal.
   // YouTube: open the embedded player modal as usual.
-  const handleCitationClick = useCallback((citation: Citation) => {
-    if (citation.source_type === 'dynamous') {
-      if (citation.lesson_url) {
-        window.open(citation.lesson_url, '_blank', 'noopener,noreferrer');
+  const handleCitationClick = useCallback(
+    (citation: Citation) => {
+      if (citation.source_type === 'dynamous') {
+        if (citation.lesson_url) {
+          window.open(citation.lesson_url, '_blank', 'noopener,noreferrer');
+        } else {
+          // No lesson URL on this Dynamous source and the citation modal is
+          // YouTube-only (would show "video unavailable"), so surface a toast
+          // instead of a silent dead click.
+          addToast({ message: 'No lesson URL available for this citation.', type: 'info' });
+        }
+      } else {
+        setSelectedCitation(citation);
       }
-    } else {
-      setSelectedCitation(citation);
-    }
-  }, []);
+    },
+    [addToast],
+  );
 
   // ── Send handler ──
   const handleSend = useCallback(

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -449,7 +449,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           // No lesson URL on this Dynamous source and the citation modal is
           // YouTube-only (would show "video unavailable"), so surface a toast
           // instead of a silent dead click.
-          addToast({ message: 'No lesson URL available for this citation.', type: 'info' });
+          addToast('No lesson URL available for this citation.', 'info');
         }
       } else {
         setSelectedCitation(citation);


### PR DESCRIPTION
Fixes #247

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `8fba76cd-aa55-4c18-a502-82f7cf296c2a`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.