### PR TITLE
[bench-OO] impl: address issue

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -211,9 +211,9 @@ async def create_message(
                         cited_ids = extract_cited_chunk_ids(final_text_raw)
                         for chunk in source_citations:
                             chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
-                        # Collapse same-video chunks (issue #208): keep one
-                        # entry per video_id, choosing the earliest-cited
-                        # timestamp as the representative.
+                        # Collapse same-video chunks: each cited chunk gets its
+                        # own chronological chip (issue #276); uncited chunks for
+                        # a video still collapse to one consulted chip (#208).
                         source_citations[:] = _collapse_by_video(source_citations)
                         # Cap fallback (issue #176): cited pass through, non-cited sliced.
                         cited = [c for c in source_citations if c.get("is_cited")]
@@ -467,22 +467,26 @@ async def _maybe_set_conversation_title(
 
 
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse multiple chunks from the same video into a single citation entry.
+    """Collapse same-video chunks into citation entries, tier by tier.
 
-    After the ``is_cited`` pass, chunks from the same video are redundant in
-    the UI — the user needs one clickable chip per video, not one per 5-second
-    transcript segment (issue #208).
+    Chunks from the same video are grouped by ``video_id``. How each group is
+    emitted depends on whether the LLM actually cited any of its chunks:
 
-    For each ``video_id`` group:
-    - ``is_cited`` is True if ANY chunk in the group was cited by the LLM.
-    - ``start_seconds`` is the earliest timestamp among cited chunks (or among
-      all chunks if none were cited), so the deep-link opens near the most
-      relevant moment.
-    - ``segment_count`` records how many chunks were collapsed so the frontend
-      can optionally display "(N segments)".
-    - All other fields are taken from the representative chunk.
+    - **Cited chunks (issue #276):** every distinct cited chunk becomes its own
+      citation entry, ordered chronologically by ``start_seconds``. When an
+      answer draws on two nearby moments from the same video, both moments get
+      their own correctly-timestamped chip instead of being merged into one
+      (which previously dropped the later moment). Each cited entry keeps its
+      own chunk's fields and has ``segment_count == 1``. Uncited chunks in a
+      cited video are absorbed (no separate consulted entry for that video).
+    - **Uncited chunks (issue #208):** when no chunk in the group was cited,
+      the group collapses to a single consulted entry — the user needs one
+      clickable chip per video, not one per 5-second transcript segment. The
+      representative is the earliest chunk by ``start_seconds`` and
+      ``segment_count`` records how many chunks were collapsed.
 
-    Insertion order of videos is preserved (first-seen wins).
+    Insertion order of videos is preserved (first-seen wins); cited entries
+    within a video are ordered chronologically.
     """
     seen: dict[str, list[dict]] = {}
     for c in chunks:
@@ -495,14 +499,16 @@ def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for group in seen.values():
         cited_in_group = [c for c in group if c.get("is_cited")]
         if cited_in_group:
-            representative = min(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = True
+            for chunk in sorted(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0):
+                entry = dict(chunk)
+                entry["is_cited"] = True
+                entry["segment_count"] = 1
+                collapsed.append(entry)
         else:
             representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = False
-        entry = dict(representative)
-        entry["is_cited"] = is_cited
-        entry["segment_count"] = len(group)
-        collapsed.append(entry)
+            entry = dict(representative)
+            entry["is_cited"] = False
+            entry["segment_count"] = len(group)
+            collapsed.append(entry)
 
     return collapsed

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -224,8 +224,9 @@ class TestSseIntegration:
         assert len(payload) == 2 + CITATIONS_MAX_COUNT
 
     async def test_same_video_chunks_collapsed_to_one_citation(self) -> None:
-        """Multiple chunks from the same video collapse into a single citation
-        entry (issue #208). segment_count reflects the original chunk count."""
+        """When only one chunk from a video is cited, the uncited siblings are
+        absorbed and a single cited chip remains (issue #208 / #276). A cited
+        chip represents one chunk, so segment_count is 1."""
         chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)} for i in range(5)]
         # Only c2 (start_seconds=20.0) is cited
         body = await _post_message(
@@ -237,9 +238,36 @@ class TestSseIntegration:
         entry = payload[0]
         assert entry["video_id"] == "v1"
         assert entry["is_cited"] is True
-        assert entry["segment_count"] == 5
-        # Representative picks earliest cited chunk → c2 at 20.0s
+        assert entry["segment_count"] == 1
+        # The single cited chunk keeps its own timestamp → c2 at 20.0s
         assert entry["start_seconds"] == 20.0
+
+    async def test_two_nearby_cited_moments_same_video_get_separate_chips(self) -> None:
+        """Two distinct cited moments from one video, close together in the
+        timeline, each get their own correctly-timestamped chip (issue #276).
+        Citing the *later* moment must not be dropped in favour of the earlier."""
+        # Three nearby chunks; cite the first and third (incl. the later one).
+        chunks = [
+            {**_chunk("c0", "v1"), "start_seconds": 100.0},
+            {**_chunk("c1", "v1"), "start_seconds": 105.0},
+            {**_chunk("c2", "v1"), "start_seconds": 110.0},
+        ]
+        body = await _post_message(
+            answer_tokens=["First moment [c:c0]. Later moment [c:c2]."],
+            retrieved_chunks=chunks,
+        )
+        payload = _parse_sources(body)
+        cited = [c for c in payload if c["is_cited"]]
+        # Both cited moments survive as distinct chips.
+        assert len(cited) == 2
+        assert {c["chunk_id"] for c in cited} == {"c0", "c2"}
+        # The later moment is present (not dropped for the earlier one).
+        cited_starts = [c["start_seconds"] for c in cited]
+        assert 100.0 in cited_starts
+        assert 110.0 in cited_starts
+        # Cited chips are ordered chronologically and each is a single segment.
+        assert cited_starts == sorted(cited_starts)
+        assert all(c["segment_count"] == 1 for c in cited)
 
     async def test_collapse_two_videos_preserves_both(self) -> None:
         """Chunks from two different videos collapse to two entries, each with
@@ -255,10 +283,10 @@ class TestSseIntegration:
         assert len(payload) == 2
         by_vid = {e["video_id"]: e for e in payload}
         assert by_vid["v1"]["is_cited"] is True
-        assert by_vid["v1"]["segment_count"] == 3
+        assert by_vid["v1"]["segment_count"] == 1
         assert by_vid["v1"]["start_seconds"] == 5.0  # v1c1
         assert by_vid["v2"]["is_cited"] is True
-        assert by_vid["v2"]["segment_count"] == 3
+        assert by_vid["v2"]["segment_count"] == 1
         assert by_vid["v2"]["start_seconds"] == 0.0  # v2c0
 
     async def test_collapse_uncited_group_picks_earliest_timestamp(self) -> None:


### PR DESCRIPTION
Fixes #276

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `73797838-98ad-4578-b8d9-cbdc14a5d980`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.