### PR TITLE
[bench-OK] review: fix stale call-site comment for _collapse_by_video

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -211,9 +211,9 @@ async def create_message(
                         cited_ids = extract_cited_chunk_ids(final_text_raw)
                         for chunk in source_citations:
                             chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
-                        # Collapse same-video chunks (issue #208): keep one
-                        # entry per video_id, choosing the earliest-cited
-                        # timestamp as the representative.
+                        # Collapse same-video chunks (issue #208/#276): videos
+                        # with ≥2 cited moments fan out to one chip each;
+                        # single-cited and uncited groups collapse to one entry.
                         source_citations[:] = _collapse_by_video(source_citations)
                         # Cap fallback (issue #176): cited pass through, non-cited sliced.
                         cited = [c for c in source_citations if c.get("is_cited")]

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -467,22 +467,22 @@ async def _maybe_set_conversation_title(
 
 
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse multiple chunks from the same video into a single citation entry.
+    """Collapse multiple chunks from the same video into citation entries.
 
     After the ``is_cited`` pass, chunks from the same video are redundant in
     the UI — the user needs one clickable chip per video, not one per 5-second
     transcript segment (issue #208).
 
     For each ``video_id`` group:
-    - ``is_cited`` is True if ANY chunk in the group was cited by the LLM.
-    - ``start_seconds`` is the earliest timestamp among cited chunks (or among
-      all chunks if none were cited), so the deep-link opens near the most
-      relevant moment.
-    - ``segment_count`` records how many chunks were collapsed so the frontend
-      can optionally display "(N segments)".
-    - All other fields are taken from the representative chunk.
+    - If two or more chunks in the group were cited by the LLM, each cited
+      chunk becomes its own entry so every distinct moment gets a chip
+      (issue #276).  ``segment_count`` is set to 1 for these entries.
+    - If exactly one chunk is cited, that chunk is the representative.
+    - If no chunks are cited, the earliest timestamp is used as the
+      representative (issue #208 anti-flooding).
 
-    Insertion order of videos is preserved (first-seen wins).
+    Insertion order of videos is preserved (first-seen wins).  Intra-group
+    multi-cited entries are ordered by ``start_seconds``.
     """
     seen: dict[str, list[dict]] = {}
     for c in chunks:
@@ -494,15 +494,23 @@ def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     collapsed: list[dict] = []
     for group in seen.values():
         cited_in_group = [c for c in group if c.get("is_cited")]
-        if cited_in_group:
-            representative = min(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = True
+        if len(cited_in_group) >= 2:
+            for c in sorted(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0):
+                entry = dict(c)
+                entry["is_cited"] = True
+                entry["segment_count"] = 1
+                collapsed.append(entry)
+        elif len(cited_in_group) == 1:
+            representative = cited_in_group[0]
+            entry = dict(representative)
+            entry["is_cited"] = True
+            entry["segment_count"] = len(group)
+            collapsed.append(entry)
         else:
             representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = False
-        entry = dict(representative)
-        entry["is_cited"] = is_cited
-        entry["segment_count"] = len(group)
-        collapsed.append(entry)
+            entry = dict(representative)
+            entry["is_cited"] = False
+            entry["segment_count"] = len(group)
+            collapsed.append(entry)
 
     return collapsed

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -275,3 +275,37 @@ class TestSseIntegration:
         assert entry["is_cited"] is False
         assert entry["segment_count"] == 3
         assert entry["start_seconds"] == 0.0  # c0, earliest
+
+    async def test_two_cited_same_video_emit_separate_chips(self) -> None:
+        """Two distinct moments from the same video, both cited → two chips
+        with correct timestamps (issue #276)."""
+        chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)} for i in range(5)]
+        body = await _post_message(
+            answer_tokens=["Answer [c:c1][c:c3]."],
+            retrieved_chunks=chunks,
+        )
+        payload = _parse_sources(body)
+        assert len(payload) == 2
+        assert all(e["video_id"] == "v1" for e in payload)
+        assert all(e["is_cited"] is True for e in payload)
+        assert all(e["segment_count"] == 1 for e in payload)
+        assert {e["start_seconds"] for e in payload} == {10.0, 30.0}
+        assert {e["chunk_id"] for e in payload} == {"c1", "c3"}
+
+    async def test_two_cited_same_video_same_timestamp(self) -> None:
+        """Two cited chunks from the same video with identical start_seconds
+        still produce two chips (dedup is by chunk_id, not timestamp)."""
+        chunks = [
+            {**_chunk("c1", "v1"), "start_seconds": 20.0},
+            {**_chunk("c2", "v1"), "start_seconds": 20.0},
+        ]
+        body = await _post_message(
+            answer_tokens=["Answer [c:c1][c:c2]."],
+            retrieved_chunks=chunks,
+        )
+        payload = _parse_sources(body)
+        assert len(payload) == 2
+        assert {e["chunk_id"] for e in payload} == {"c1", "c2"}
+        assert all(e["start_seconds"] == 20.0 for e in payload)
+        assert all(e["is_cited"] is True for e in payload)
+        assert all(e["segment_count"] == 1 for e in payload)


### PR DESCRIPTION
Fixes #276

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `657e778d-cc5c-42a2-8eaf-cf9fa1b61a29`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.