### PR TITLE
[bench-KO] review: address self-review findings

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -466,10 +466,7 @@ async def _maybe_set_conversation_title(
         await repository.update_conversation_title(conv_id, user_id=user_id, title=title)
 
 
-# Cited chunks from the same video are merged into one chip only when their
-# start timestamps fall within this many seconds of each other. Moments farther
-# apart in the same video get their own chip (issue #276) so every distinct
-# moment the assistant actually used is shown with its own correct timestamp.
+# Cited moments farther apart than this (seconds) get separate chips (issue #276).
 CITED_CLUSTER_GAP_SECONDS = 60.0
 
 
@@ -505,8 +502,6 @@ def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     cited_entries: list[dict] = []
     for group in _group_by_video(cited).values():
-        # Cluster by start_seconds proximity so nearby moments merge but
-        # distant moments each get their own chip.
         ordered = sorted(group, key=lambda c: c.get("start_seconds") or 0.0)
         cluster: list[dict] = []
         prev_start: float | None = None
@@ -539,11 +534,7 @@ def _group_by_video(chunks: list[dict[str, Any]]) -> dict[str, list[dict]]:
 
 
 def _make_entry(group: list[dict[str, Any]], *, is_cited: bool) -> dict[str, Any]:
-    """Build a single collapsed citation entry from a group of chunks.
-
-    The representative is the earliest-timestamp chunk; ``segment_count``
-    reflects how many chunks were merged.
-    """
+    """Build a collapsed citation entry from a group; earliest chunk is the representative."""
     representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
     entry = dict(representative)
     entry["is_cited"] = is_cited

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -466,43 +466,86 @@ async def _maybe_set_conversation_title(
         await repository.update_conversation_title(conv_id, user_id=user_id, title=title)
 
 
+# Cited chunks from the same video are merged into one chip only when their
+# start timestamps fall within this many seconds of each other. Moments farther
+# apart in the same video get their own chip (issue #276) so every distinct
+# moment the assistant actually used is shown with its own correct timestamp.
+CITED_CLUSTER_GAP_SECONDS = 60.0
+
+
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse multiple chunks from the same video into a single citation entry.
+    """Collapse same-video chunks into citation entries.
 
-    After the ``is_cited`` pass, chunks from the same video are redundant in
-    the UI — the user needs one clickable chip per video, not one per 5-second
-    transcript segment (issue #208).
+    Uncited and cited chunks are handled differently:
 
-    For each ``video_id`` group:
-    - ``is_cited`` is True if ANY chunk in the group was cited by the LLM.
-    - ``start_seconds`` is the earliest timestamp among cited chunks (or among
-      all chunks if none were cited), so the deep-link opens near the most
-      relevant moment.
+    - **Uncited** chunks (``is_cited`` falsey) collapse to one entry per
+      ``video_id`` — they only populate "All sources consulted", where one
+      chip per video keeps the list uncluttered (issue #208).
+    - **Cited** chunks (``is_cited`` truthy) collapse per ``video_id`` *and*
+      time proximity: within a video, chunks whose ``start_seconds`` are
+      within ``CITED_CLUSTER_GAP_SECONDS`` of each other merge into one chip,
+      but moments farther apart become separate chips with their own correct
+      timestamps (issue #276). This prevents two nearby transcript segments
+      about the same topic from spawning duplicate chips while still surfacing
+      every distinct moment the assistant referenced.
+
+    For each resulting entry:
+    - ``start_seconds`` is the earliest timestamp in the cluster, so the
+      deep-link opens at the start of the relevant moment.
     - ``segment_count`` records how many chunks were collapsed so the frontend
       can optionally display "(N segments)".
-    - All other fields are taken from the representative chunk.
+    - All other fields are taken from the representative (earliest) chunk.
 
-    Insertion order of videos is preserved (first-seen wins).
+    Cited entries are returned before uncited ones, preserving the convention
+    that "Sources cited" chips precede "All sources consulted" chips. Within
+    each tier, first-seen video order is preserved.
     """
+    cited = [c for c in chunks if c.get("is_cited")]
+    uncited = [c for c in chunks if not c.get("is_cited")]
+
+    cited_entries: list[dict] = []
+    for group in _group_by_video(cited).values():
+        # Cluster by start_seconds proximity so nearby moments merge but
+        # distant moments each get their own chip.
+        ordered = sorted(group, key=lambda c: c.get("start_seconds") or 0.0)
+        cluster: list[dict] = []
+        prev_start: float | None = None
+        for c in ordered:
+            start = c.get("start_seconds") or 0.0
+            if prev_start is not None and start - prev_start > CITED_CLUSTER_GAP_SECONDS:
+                cited_entries.append(_make_entry(cluster, is_cited=True))
+                cluster = []
+            cluster.append(c)
+            prev_start = start
+        if cluster:
+            cited_entries.append(_make_entry(cluster, is_cited=True))
+
+    uncited_entries: list[dict] = [
+        _make_entry(group, is_cited=False) for group in _group_by_video(uncited).values()
+    ]
+
+    return cited_entries + uncited_entries
+
+
+def _group_by_video(chunks: list[dict[str, Any]]) -> dict[str, list[dict]]:
+    """Group chunks by ``video_id``, preserving first-seen order."""
     seen: dict[str, list[dict]] = {}
     for c in chunks:
         vid = c.get("video_id") or ""
         if vid not in seen:
             seen[vid] = []
         seen[vid].append(c)
+    return seen
 
-    collapsed: list[dict] = []
-    for group in seen.values():
-        cited_in_group = [c for c in group if c.get("is_cited")]
-        if cited_in_group:
-            representative = min(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = True
-        else:
-            representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = False
-        entry = dict(representative)
-        entry["is_cited"] = is_cited
-        entry["segment_count"] = len(group)
-        collapsed.append(entry)
 
-    return collapsed
+def _make_entry(group: list[dict[str, Any]], *, is_cited: bool) -> dict[str, Any]:
+    """Build a single collapsed citation entry from a group of chunks.
+
+    The representative is the earliest-timestamp chunk; ``segment_count``
+    reflects how many chunks were merged.
+    """
+    representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
+    entry = dict(representative)
+    entry["is_cited"] = is_cited
+    entry["segment_count"] = len(group)
+    return entry

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -652,6 +652,94 @@ class TestRefusalSourcesSuppressionNegative:
         assert _is_refusal(text) is False
 
 
+class TestCollapseByVideo:
+    """Tests for _collapse_by_video, the same-video citation collapsing step.
+
+    Cited chunks cluster by video_id AND time proximity so two distinct
+    moments from the same video each get their own chip with the correct
+    timestamp (issue #276), while adjacent chunks still merge so the
+    anti-clutter behaviour from issue #208 is preserved.
+    """
+
+    @staticmethod
+    def _chunk(chunk_id: str, video_id: str, start_seconds: float, *, is_cited: bool) -> dict:
+        return {
+            "chunk_id": chunk_id,
+            "video_id": video_id,
+            "video_title": "Test Video",
+            "video_url": "https://youtube.com/watch?v=abc",
+            "start_seconds": start_seconds,
+            "end_seconds": start_seconds + 10.0,
+            "snippet": f"snippet at {start_seconds}",
+            "is_cited": is_cited,
+        }
+
+    def test_two_distinct_cited_moments_same_video(self) -> None:
+        """Two cited chunks 5 minutes apart in one video produce two chips
+        with their own correct timestamps (regression test for issue #276)."""
+        from backend.routes.messages import _collapse_by_video
+
+        chunks = [
+            self._chunk("c1", "vid1", 0.0, is_cited=True),
+            self._chunk("c2", "vid1", 300.0, is_cited=True),
+        ]
+        result = _collapse_by_video(chunks)
+
+        assert len(result) == 2
+        starts = sorted(entry["start_seconds"] for entry in result)
+        assert starts == [0.0, 300.0]
+        # Both chips are cited and each spans exactly one chunk.
+        assert all(entry["is_cited"] for entry in result)
+        assert all(entry["segment_count"] == 1 for entry in result)
+
+    def test_adjacent_cited_chunks_same_video_still_merge(self) -> None:
+        """Two cited chunks 30 seconds apart merge into one chip
+        (guards against re-introducing issue #208 clutter)."""
+        from backend.routes.messages import _collapse_by_video
+
+        chunks = [
+            self._chunk("c1", "vid1", 0.0, is_cited=True),
+            self._chunk("c2", "vid1", 30.0, is_cited=True),
+        ]
+        result = _collapse_by_video(chunks)
+
+        assert len(result) == 1
+        assert result[0]["start_seconds"] == 0.0
+        assert result[0]["segment_count"] == 2
+        assert result[0]["is_cited"] is True
+
+    def test_uncited_chunks_still_collapse_per_video(self) -> None:
+        """Uncited chunks from one video collapse to a single representative
+        regardless of time gaps (unchanged behaviour for the consulted tier)."""
+        from backend.routes.messages import _collapse_by_video
+
+        chunks = [
+            self._chunk("c1", "vid1", 0.0, is_cited=False),
+            self._chunk("c2", "vid1", 300.0, is_cited=False),
+            self._chunk("c3", "vid1", 600.0, is_cited=False),
+        ]
+        result = _collapse_by_video(chunks)
+
+        assert len(result) == 1
+        assert result[0]["is_cited"] is False
+        assert result[0]["start_seconds"] == 0.0
+        assert result[0]["segment_count"] == 3
+
+    def test_cited_entries_precede_uncited(self) -> None:
+        """Cited chips are emitted before uncited ones in the result list."""
+        from backend.routes.messages import _collapse_by_video
+
+        chunks = [
+            self._chunk("u1", "vid2", 0.0, is_cited=False),
+            self._chunk("c1", "vid1", 0.0, is_cited=True),
+        ]
+        result = _collapse_by_video(chunks)
+
+        assert len(result) == 2
+        assert result[0]["is_cited"] is True
+        assert result[1]["is_cited"] is False
+
+
 class TestExtractTextFromSse:
     """Tests for _extract_text_from_sse helper."""
 


### PR DESCRIPTION
Fixes #276

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `615c0fc6-5d3f-4d06-b91c-8b7b84fdbe46`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.