### PR TITLE
[bench-KK] impl: address issue

### DIFF
--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -135,6 +135,13 @@ RETRIEVAL_MAX_PER_VIDEO: int = int(os.environ.get("RETRIEVAL_MAX_PER_VIDEO", "3"
 # Cap on non-cited citations (issue #176); cited chunks always pass through.
 CITATIONS_MAX_COUNT: int = int(os.environ.get("CITATIONS_MAX_COUNT", "10"))
 
+# Time-proximity window for collapsing same-video chunks into one citation.
+# Chunks whose start times are within this many seconds merge into a single
+# chip; farther apart remain separate (issue #276).
+CITATION_COLLAPSE_PROXIMITY_SECONDS: int = int(
+    os.environ.get("CITATION_COLLAPSE_PROXIMITY_SECONDS", "30")
+)
+
 # RAG tool-based retrieval — the LLM drives retrieval via tool calls
 # (search_videos, keyword_search_videos, semantic_search_videos,
 # get_video_transcript) rather than receiving pre-retrieved chunks. Disabled

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -28,7 +28,12 @@ from pydantic import BaseModel, Field, field_validator
 
 from backend import rate_limit
 from backend.auth.dependencies import get_current_user
-from backend.config import CITATIONS_MAX_COUNT, LLM_TOOLS_ENABLED, LLM_TOOLS_MAX_PER_TURN
+from backend.config import (
+    CITATION_COLLAPSE_PROXIMITY_SECONDS,
+    CITATIONS_MAX_COUNT,
+    LLM_TOOLS_ENABLED,
+    LLM_TOOLS_MAX_PER_TURN,
+)
 from backend.db import repository
 from backend.llm.openrouter import stream_chat
 from backend.rag.citations import (
@@ -467,42 +472,67 @@ async def _maybe_set_conversation_title(
 
 
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse multiple chunks from the same video into a single citation entry.
+    """Collapse nearby chunks from the same video into a single citation entry.
 
-    After the ``is_cited`` pass, chunks from the same video are redundant in
-    the UI — the user needs one clickable chip per video, not one per 5-second
-    transcript segment (issue #208).
+    Chunks that are within ``CITATION_COLLAPSE_PROXIMITY_SECONDS`` of each
+    other (measured from the current cluster's end time) merge into one chip.
+    Distinct moments that are farther apart remain separate citations so each
+    gets its own correct deep-link timestamp (issue #276).
 
-    For each ``video_id`` group:
-    - ``is_cited`` is True if ANY chunk in the group was cited by the LLM.
+    Within each cluster:
+    - ``is_cited`` is True if ANY chunk in the cluster was cited by the LLM.
     - ``start_seconds`` is the earliest timestamp among cited chunks (or among
       all chunks if none were cited), so the deep-link opens near the most
       relevant moment.
-    - ``segment_count`` records how many chunks were collapsed so the frontend
-      can optionally display "(N segments)".
+    - ``segment_count`` records how many chunks were collapsed.
     - All other fields are taken from the representative chunk.
 
     Insertion order of videos is preserved (first-seen wins).
     """
-    seen: dict[str, list[dict]] = {}
+    # Group by video_id while preserving first-seen order
+    groups: dict[str, list[dict]] = {}
+    group_order: list[str] = []
     for c in chunks:
         vid = c.get("video_id") or ""
-        if vid not in seen:
-            seen[vid] = []
-        seen[vid].append(c)
+        if vid not in groups:
+            groups[vid] = []
+            group_order.append(vid)
+        groups[vid].append(c)
 
     collapsed: list[dict] = []
-    for group in seen.values():
-        cited_in_group = [c for c in group if c.get("is_cited")]
-        if cited_in_group:
-            representative = min(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = True
-        else:
-            representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = False
-        entry = dict(representative)
-        entry["is_cited"] = is_cited
-        entry["segment_count"] = len(group)
-        collapsed.append(entry)
+    for vid in group_order:
+        group = sorted(groups[vid], key=lambda c: c.get("start_seconds") or 0.0)
+
+        clusters: list[list[dict]] = []
+        cluster_ends: list[float] = []
+        for chunk in group:
+            start = chunk.get("start_seconds") or 0.0
+            end = chunk.get("end_seconds") or start
+            if not clusters:
+                clusters.append([chunk])
+                cluster_ends.append(end)
+                continue
+            if start <= cluster_ends[-1] + CITATION_COLLAPSE_PROXIMITY_SECONDS:
+                clusters[-1].append(chunk)
+                if end > cluster_ends[-1]:
+                    cluster_ends[-1] = end
+            else:
+                clusters.append([chunk])
+                cluster_ends.append(end)
+
+        for cluster in clusters:
+            cited_in_cluster = [c for c in cluster if c.get("is_cited")]
+            if cited_in_cluster:
+                representative = min(
+                    cited_in_cluster, key=lambda c: c.get("start_seconds") or 0.0
+                )
+                is_cited = True
+            else:
+                representative = min(cluster, key=lambda c: c.get("start_seconds") or 0.0)
+                is_cited = False
+            entry = dict(representative)
+            entry["is_cited"] = is_cited
+            entry["segment_count"] = len(cluster)
+            collapsed.append(entry)
 
     return collapsed

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -226,8 +226,8 @@ class TestSseIntegration:
     async def test_same_video_chunks_collapsed_to_one_citation(self) -> None:
         """Multiple chunks from the same video collapse into a single citation
         entry (issue #208). segment_count reflects the original chunk count."""
-        chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)} for i in range(5)]
-        # Only c2 (start_seconds=20.0) is cited
+        chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 5)} for i in range(5)]
+        # Only c2 (start_seconds=10.0) is cited
         body = await _post_message(
             answer_tokens=["Answer [c:c2]."],
             retrieved_chunks=chunks,
@@ -238,8 +238,38 @@ class TestSseIntegration:
         assert entry["video_id"] == "v1"
         assert entry["is_cited"] is True
         assert entry["segment_count"] == 5
-        # Representative picks earliest cited chunk → c2 at 20.0s
-        assert entry["start_seconds"] == 20.0
+        # Representative picks earliest cited chunk → c2 at 10.0s
+        assert entry["start_seconds"] == 10.0
+
+    def test_nearby_same_video_chunks_emit_separate_citations(self) -> None:
+        """Two same-video chunks beyond the proximity threshold produce two
+        distinct citation entries, each with its own correct timestamp (issue #276)."""
+        from backend.config import CITATION_COLLAPSE_PROXIMITY_SECONDS
+        from backend.routes.messages import _collapse_by_video
+
+        gap = CITATION_COLLAPSE_PROXIMITY_SECONDS + 10
+        chunks = [
+            {
+                **_chunk("c1", "v1"),
+                "start_seconds": 0.0,
+                "end_seconds": 5.0,
+                "is_cited": True,
+            },
+            {
+                **_chunk("c2", "v1"),
+                "start_seconds": float(gap),
+                "end_seconds": float(gap + 5.0),
+                "is_cited": True,
+            },
+        ]
+        result = _collapse_by_video(chunks)
+        assert len(result) == 2
+        starts = {c["start_seconds"] for c in result}
+        assert starts == {0.0, float(gap)}
+        for c in result:
+            assert c["video_id"] == "v1"
+            assert c["is_cited"] is True
+            assert c["segment_count"] == 1
 
     async def test_collapse_two_videos_preserves_both(self) -> None:
         """Chunks from two different videos collapse to two entries, each with


### PR DESCRIPTION
Fixes #276

**Benchmark cell:** `KK` (plan=Kimi, impl=Kimi)
**Source run-id:** `3635c07e-bf00-4e86-ab7f-dcba2f970604`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.