### PR TITLE
[bench-KO] impl: finalize sources consistently after interrupted responses

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -122,7 +122,6 @@ async def create_message(
     # lists exactly what the model actually read. The video_id whitelist is
     # only consulted by the transcript tool (it guards against hallucinated
     # ids); the search tools ignore it.
-    source_citations: list[dict] = []
     tool_chunks_acc: list[dict] = []
     embedding_cache: dict[str, list[float]] = {}
     tools_param: list[dict] | None = None
@@ -195,40 +194,16 @@ async def create_message(
                         tail_chunk = f"data: {json.dumps(tail)}\n\n"
                         full_response.append(tail_chunk)
                         yield tail_chunk
-                    # Dedup tool-loaded chunks into source_citations (existing).
-                    if tool_chunks_acc:
-                        seen: set[str] = set()
-                        for tc in tool_chunks_acc:
-                            tc_id = tc.get("chunk_id")
-                            if tc_id and tc_id not in seen:
-                                source_citations.append(tc)
-                                seen.add(tc_id)
-                    # Mark is_cited from markers in the raw final-round text.
-                    # Marker IDs that don't match any retrieved chunk are
-                    # silently dropped (hallucinations).
+                    # Compute the finalized source list deterministically from
+                    # the raw tool chunks (dedup → is_cited → collapse → cap →
+                    # refusal check). The very same helper runs in the finally
+                    # block below, so the persisted sources always match what we
+                    # emit here — even if the stream is later interrupted before
+                    # the save (issue #277).
+                    final_text_raw = final_text_buf[0] if final_text_buf else ""
+                    source_citations = _finalize_sources(tool_chunks_acc, final_text_raw) or []
                     if source_citations:
-                        final_text_raw = final_text_buf[0] if final_text_buf else ""
-                        cited_ids = extract_cited_chunk_ids(final_text_raw)
-                        for chunk in source_citations:
-                            chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
-                        # Collapse same-video chunks (issue #208): keep one
-                        # entry per video_id, choosing the earliest-cited
-                        # timestamp as the representative.
-                        source_citations[:] = _collapse_by_video(source_citations)
-                        # Cap fallback (issue #176): cited pass through, non-cited sliced.
-                        cited = [c for c in source_citations if c.get("is_cited")]
-                        uncited = [c for c in source_citations if not c.get("is_cited")]
-                        source_citations[:] = cited + uncited[:CITATIONS_MAX_COUNT]
-                    # Suppress sources on refusal (existing behaviour).
-                    if source_citations:
-                        final_text = (
-                            final_text_buf[0]
-                            if final_text_buf
-                            else _extract_text_from_sse(full_response)
-                        )
-                        if not _is_refusal(final_text):
-                            sources_json = json.dumps(source_citations)
-                            yield f"event: sources\ndata: {sources_json}\n\n"
+                        yield f"event: sources\ndata: {json.dumps(source_citations)}\n\n"
                     full_response.append(sse_chunk)
                     yield sse_chunk
                     continue
@@ -267,11 +242,7 @@ async def create_message(
                 # renders the chip based on the stored field, so dropping
                 # it here keeps the reload UX consistent with the stream.
                 refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
-                sources_to_persist: list[dict] | None = (
-                    None
-                    if not source_citations or _is_refusal(refusal_check_text)
-                    else source_citations
-                )
+                sources_to_persist = _finalize_sources(tool_chunks_acc, refusal_check_text)
                 try:
                     await asyncio.shield(
                         repository.create_message(
@@ -464,6 +435,58 @@ async def _maybe_set_conversation_title(
         else:
             title = first_user_message.strip()
         await repository.update_conversation_title(conv_id, user_id=user_id, title=title)
+
+
+def _finalize_sources(tool_chunks: list[dict], answer_text: str) -> list[dict] | None:
+    """Deterministically compute the finalized source-citation list.
+
+    This is the single source of truth for the sources that accompany an
+    answer. Both the live SSE ``event: sources`` emission (in the ``[DONE]``
+    branch) and the post-stream DB persist (in the ``finally`` block) call it
+    with the same inputs, so the saved message always matches what the user saw
+    live — even when the stream was interrupted or errored mid-flight (issue
+    #277). It computes from the raw ``tool_chunks`` each time rather than
+    reading a list that some earlier branch mutated in place.
+
+    Pipeline: dedup by ``chunk_id`` → flag ``is_cited`` from ``[c:<id>]``
+    markers in ``answer_text`` → collapse same-video chunks (issue #208) →
+    cited-first cap (issue #176) → suppress entirely on refusal (issue #158).
+
+    Returns ``None`` when there are no usable sources or the answer is a
+    refusal, so callers can treat ``None`` as "emit/persist nothing".
+    """
+    if not tool_chunks:
+        return None
+    # Dedup tool-loaded chunks by chunk_id. Copy each dict so the is_cited flag
+    # set below never mutates the caller's accumulator.
+    seen: set[str] = set()
+    deduped: list[dict] = []
+    for tc in tool_chunks:
+        tc_id = tc.get("chunk_id")
+        if tc_id and tc_id not in seen:
+            deduped.append(dict(tc))
+            seen.add(tc_id)
+    if not deduped:
+        return None
+    # Mark is_cited from markers in the raw final-round text. Marker IDs that
+    # don't match any retrieved chunk are silently dropped (hallucinations).
+    cited_ids = extract_cited_chunk_ids(answer_text)
+    for chunk in deduped:
+        chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+    # Collapse same-video chunks (issue #208): keep one entry per video_id,
+    # choosing the earliest-cited timestamp as the representative.
+    collapsed = _collapse_by_video(deduped)
+    # Cap fallback (issue #176): cited pass through, non-cited sliced.
+    cited = [c for c in collapsed if c.get("is_cited")]
+    uncited = [c for c in collapsed if not c.get("is_cited")]
+    finalized = cited + uncited[:CITATIONS_MAX_COUNT]
+    if not finalized:
+        return None
+    # Suppress sources on refusal so a reload doesn't resurrect a misleading
+    # "Sources (N)" chip on an answer that actually declined to answer.
+    if _is_refusal(answer_text):
+        return None
+    return finalized
 
 
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -1038,6 +1038,235 @@ class TestRefusalSourcesSuppressionIntegration:
         assert "data: [DONE]" in output
 
 
+class TestInterruptedStreamSourcesConsistency:
+    """Regression tests for issue #277 — the sources persisted with an answer
+    must match what the live stream emitted, whether the answer completed
+    cleanly or was interrupted mid-flight.
+
+    The fix routes both the live SSE ``event: sources`` emission and the
+    post-stream DB persist through the single ``_finalize_sources`` helper, so
+    they can never diverge (no more reliance on a list mutated in place inside
+    the ``[DONE]`` branch).
+    """
+
+    async def test_error_mid_stream_persists_no_sources(self) -> None:
+        """If the stream errors before ``[DONE]`` (no tool chunks accumulated),
+        the persisted assistant row must have ``sources=None`` — matching the
+        live view, which never received a sources event."""
+        import json
+        from unittest.mock import AsyncMock, patch
+        from uuid import uuid4
+
+        from httpx import ASGITransport, AsyncClient
+
+        from backend.auth.tokens import encode_token
+        from backend.main import app
+
+        partial_text = "Here is the start of an answer"
+        partial_chunk = f"data: {json.dumps(partial_text)}\n\n"
+        error_chunk = 'data: {"error": "upstream model flaked"}\n\n'
+
+        async def mock_stream_chat(
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
+        ):
+            # Some tokens stream, then the upstream errors — no [DONE], and the
+            # final-text buffer is never populated.
+            yield partial_chunk
+            yield error_chunk
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        async def mock_get_user_by_id(user_id):
+            return {
+                "id": test_user_id,
+                "email": "test@example.com",
+                "password_hash": "hashed",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {
+                "id": test_conv_id,
+                "user_id": test_user_id,
+                "title": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+
+        async def mock_list_messages(conv_id, user_id):
+            return []
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages",
+                    json={"content": "a question"},
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        output = response.text
+        # No [DONE] reached → no sources event ever emitted live.
+        assert "event: sources" not in output, f"unexpected sources event in: {output}"
+
+        # User msg, then assistant msg in finally.
+        assert mock_create.call_count == 2, f"expected 2 calls, got {mock_create.call_count}"
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] is None, (
+            f"interrupted stream with no tool chunks must persist sources=None; "
+            f"got {assistant_kwargs['sources']!r}"
+        )
+
+    async def test_persisted_sources_match_emitted_after_done(self) -> None:
+        """When the stream reaches ``[DONE]`` and the tool chunks contain
+        duplicate same-video entries, the sources persisted to the DB must
+        deep-equal the deduped/collapsed/capped list emitted in the live
+        ``event: sources`` payload — not the raw uncollapsed accumulator."""
+        import json
+        from unittest.mock import AsyncMock, patch
+        from uuid import uuid4
+
+        from httpx import ASGITransport, AsyncClient
+
+        from backend.auth.tokens import encode_token
+        from backend.main import app
+
+        answer_text = "The video explains how this works in detail."
+        answer_chunk = f"data: {json.dumps(answer_text)}\n\n"
+        done_chunk = "data: [DONE]\n\n"
+
+        # Two chunks from the SAME video — collapse-by-video must reduce these
+        # to a single chip both live and in the persisted row.
+        tool_chunks = [
+            {
+                "chunk_id": "c1",
+                "video_id": "v1",
+                "video_title": "Test Video",
+                "video_url": "https://youtube.com/watch?v=abc",
+                "start_seconds": 10.0,
+                "end_seconds": 20.0,
+                "snippet": "First segment",
+            },
+            {
+                "chunk_id": "c2",
+                "video_id": "v1",
+                "video_title": "Test Video",
+                "video_url": "https://youtube.com/watch?v=abc",
+                "start_seconds": 30.0,
+                "end_seconds": 40.0,
+                "snippet": "Second segment",
+            },
+        ]
+
+        async def mock_stream_chat(
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
+        ):
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "test"}))
+            yield answer_chunk
+            if final_text_out is not None:
+                final_text_out.append(answer_text)
+            yield done_chunk
+
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
+            return {"ok": True, "text": "context", "chunks": tool_chunks}
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        async def mock_get_user_by_id(user_id):
+            return {
+                "id": test_user_id,
+                "email": "test@example.com",
+                "password_hash": "hashed",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {
+                "id": test_conv_id,
+                "user_id": test_user_id,
+                "title": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+
+        async def mock_list_messages(conv_id, user_id):
+            return []
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "https://youtube.com/watch?v=abc"}]
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages",
+                    json={"content": "question about video"},
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        output = response.text
+
+        # Extract the JSON payload from the live `event: sources` SSE block.
+        emitted_sources = None
+        for block in output.split("\n\n"):
+            lines = block.split("\n")
+            if lines and lines[0] == "event: sources":
+                data_line = next(line for line in lines if line.startswith("data: "))
+                emitted_sources = json.loads(data_line[len("data: ") :])
+                break
+
+        assert emitted_sources is not None, f"no sources event emitted: {output}"
+        # Collapse-by-video reduced the two same-video chunks to one chip.
+        assert len(emitted_sources) == 1, f"expected one collapsed chip, got {emitted_sources}"
+
+        # The persisted assistant row must carry exactly the emitted list.
+        assert mock_create.call_count == 2, f"expected 2 calls, got {mock_create.call_count}"
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] == emitted_sources, (
+            f"persisted sources must match live-emitted sources; "
+            f"persisted={assistant_kwargs['sources']!r} emitted={emitted_sources!r}"
+        )
+
+
 class TestChunkExpansionIntegration:
     """Integration tests for chunk expansion in the SSE streaming path.
 

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -323,6 +323,10 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const [failedMessageText, setFailedMessageText] = useState<string | null>(null);
   // Track the temp user message ID so we can remove it on failure
   const pendingUserMsgIdRef = useRef<string | null>(null);
+  // Track the temp assistant message ID added by onComplete so a failed send
+  // can remove it too — otherwise a ghost assistant bubble with stream-only
+  // sources lingers in the live view but never gets persisted (issue #277).
+  const pendingAssistantMsgIdRef = useRef<string | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
 
@@ -505,9 +509,11 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             created_at: new Date().toISOString(),
             sources: sources.length > 0 ? sources : undefined,
           };
+          pendingAssistantMsgIdRef.current = assistantMsg.id;
           setMessages((prev) => [...prev, assistantMsg]);
         });
         pendingUserMsgIdRef.current = null;
+        pendingAssistantMsgIdRef.current = null;
         // Pull fresh quota counter so the sidebar updates after each send.
         refreshAuth();
         // Refresh conversations list so sidebar shows auto-generated title.
@@ -518,6 +524,15 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           const removedId = pendingUserMsgIdRef.current;
           setMessages((prev) => prev.filter((m) => m.id !== removedId));
           pendingUserMsgIdRef.current = null;
+        }
+
+        // Remove any ghost assistant message added by onComplete. On a clean
+        // stream onComplete runs before the throw, so this clears the bubble
+        // whose stream-only sources would otherwise disagree with reload (#277).
+        if (pendingAssistantMsgIdRef.current) {
+          const removedAssistId = pendingAssistantMsgIdRef.current;
+          setMessages((prev) => prev.filter((m) => m.id !== removedAssistId));
+          pendingAssistantMsgIdRef.current = null;
         }
 
         // Intentional abort (navigation or user cancel) — no error toast

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -203,8 +203,16 @@ export function useStreamingResponse(conversationId: string | null) {
           }
         }
 
-        // Stream completed successfully
-        onComplete({ fullText, sources });
+        // Only finalize the assistant message when the stream completed
+        // cleanly. On a mid-stream error the inner loop sets `streamError` and
+        // breaks the parts loop, but the outer reader still drains to
+        // `done: true`; calling onComplete here would inject a ghost assistant
+        // bubble whose sources disagree with what the saved message has on
+        // reload (issue #277). The `if (streamError) throw` below propagates
+        // the error to ChatArea's catch so it can clean up the optimistic rows.
+        if (!streamError) {
+          onComplete({ fullText, sources });
+        }
       } finally {
         // Always reset streaming state — React 18 batches this with the onComplete
         // state updates, ensuring a seamless transition to the persisted message.


### PR DESCRIPTION
Fixes #277

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `dd3a065f-e0b9-4db8-b98e-550db60f3539`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.