### PR TITLE
[bench-OK] review: fix test that posts to unpatched messages endpoint

### DIFF
--- a/app/backend/alembic/versions/0006_add_conversation_share_token.py
+++ b/app/backend/alembic/versions/0006_add_conversation_share_token.py
@@ -1,0 +1,44 @@
+"""Add share_token and share_created_at to conversations.
+
+Schema changes for issue #278 (shareable read-only conversation links):
+- conversations: share_token (unique, nullable), share_created_at (nullable)
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("share_token", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "conversations",
+        sa.Column("share_created_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_conversations_share_token",
+        "conversations",
+        ["share_token"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_share_token", table_name="conversations")
+    op.drop_column("conversations", "share_created_at")
+    op.drop_column("conversations", "share_token")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -745,3 +745,75 @@ async def list_sync_videos_for_run(sync_run_id: str) -> list[dict]:
             sync_run_id,
         )
     return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Share tokens (issue #278)
+# ---------------------------------------------------------------------------
+
+
+async def set_conversation_share_token(conversation_id: str, user_id: str, token: str) -> bool:
+    """Mint/rotate a share token for a conversation. Returns False if not owner."""
+    async with _acquire() as conn:
+        result = await conn.execute(
+            """
+            UPDATE conversations
+            SET share_token = $1, share_created_at = $2
+            WHERE id = $3 AND user_id = $4
+            """,
+            token,
+            _now(),
+            conversation_id,
+            user_id,
+        )
+        return result != "UPDATE 0"  # type: ignore[no-any-return]
+
+
+async def clear_conversation_share_token(conversation_id: str, user_id: str) -> bool:
+    """Revoke a share token. Returns False if not owner."""
+    async with _acquire() as conn:
+        result = await conn.execute(
+            """
+            UPDATE conversations
+            SET share_token = NULL, share_created_at = NULL
+            WHERE id = $1 AND user_id = $2
+            """,
+            conversation_id,
+            user_id,
+        )
+        return result != "UPDATE 0"  # type: ignore[no-any-return]
+
+
+async def get_conversation_by_share_token(token: str) -> dict | None:
+    """Return the conversation for a share token (no auth; read-only)."""
+    async with _acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, title, created_at, updated_at
+            FROM conversations
+            WHERE share_token = $1
+            """,
+            token,
+        )
+    return dict(row) if row else None
+
+
+async def list_messages_for_share_token(token: str) -> list[dict]:
+    """Return messages for a shared conversation, ordered oldest first."""
+    async with _acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT m.id, m.role, m.content, m.created_at, m.sources
+            FROM messages m
+            JOIN conversations c ON c.id = m.conversation_id
+            WHERE c.share_token = $1
+            ORDER BY m.created_at ASC
+            """,
+            token,
+        )
+    results = []
+    for r in rows:
+        d = dict(r)
+        d["sources"] = json.loads(d["sources"]) if d.get("sources") else None
+        results.append(d)
+    return results

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -103,7 +103,7 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routes (imported here to keep main.py clean)
 # ---------------------------------------------------------------------------
-from backend.routes import admin, auth, channels, conversations, ingest, messages  # noqa: E402
+from backend.routes import admin, auth, channels, conversations, ingest, messages, share  # noqa: E402
 
 # Auth routes are public (signup/login don't require a session; /me and /logout
 # rely on their own dependency/cookie behaviour).
@@ -114,6 +114,8 @@ app.include_router(auth.router, prefix="/api")
 _auth_required = [Depends(get_current_user)]
 app.include_router(conversations.router, prefix="/api", dependencies=_auth_required)
 app.include_router(messages.router, prefix="/api", dependencies=_auth_required)
+app.include_router(share.share_router, prefix="/api", dependencies=_auth_required)
+app.include_router(share.public_share_router, prefix="/api")
 
 # Library-mutation routes (ingest a video, backfill the whole channel) and
 # admin routes — all gated on get_current_admin. These endpoints write to the

--- a/app/backend/routes/share.py
+++ b/app/backend/routes/share.py
@@ -1,0 +1,86 @@
+"""Share-link routes for issue #278.
+
+Two routers are exposed:
+- share_router: owner-scoped create/revoke (auth required).
+- public_share_router: unauthenticated read-only GET (no auth).
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth.dependencies import get_current_user
+from backend.db import repository
+
+share_router = APIRouter()
+public_share_router = APIRouter()
+
+
+class ShareLinkResponse(BaseModel):
+    token: str
+    url_path: str
+
+
+class SharedMessage(BaseModel):
+    id: str
+    role: str
+    content: str
+    sources: list[dict] | None = None
+
+
+class SharedConversation(BaseModel):
+    title: str
+    messages: list[SharedMessage]
+
+
+@share_router.post("/conversations/{conversation_id}/share", response_model=ShareLinkResponse)
+async def create_share_link(
+    conversation_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Mint or rotate a share token for a conversation. Only the owner can call this."""
+    token = secrets.token_urlsafe(32)
+    ok = await repository.set_conversation_share_token(
+        conversation_id, str(current_user["id"]), token
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return {"token": token, "url_path": f"/share/{token}"}
+
+
+@share_router.delete("/conversations/{conversation_id}/share", status_code=204)
+async def revoke_share_link(
+    conversation_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Revoke a share token. Only the owner can call this."""
+    ok = await repository.clear_conversation_share_token(
+        conversation_id, str(current_user["id"])
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+
+@public_share_router.get("/share/{token}", response_model=SharedConversation)
+async def get_shared_conversation(token: str):
+    """Public read-only view of a shared conversation. No auth required."""
+    conv = await repository.get_conversation_by_share_token(token)
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Share link not found")
+    messages = await repository.list_messages_for_share_token(token)
+    return {
+        "title": conv["title"],
+        "messages": [
+            {
+                "id": m["id"],
+                "role": m["role"],
+                "content": m["content"],
+                "sources": m.get("sources"),
+            }
+            for m in messages
+        ],
+    }

--- a/app/backend/tests/test_share.py
+++ b/app/backend/tests/test_share.py
@@ -239,17 +239,21 @@ async def test_owner_can_create_share_link(client):
     assert body["url_path"] == f"/share/{body['token']}"
 
 
-async def test_get_shared_conversation_no_auth_returns_data(client):
+async def test_get_shared_conversation_no_auth_returns_data(client, fake_share_repo):
     await _signup(client, "owner2@example.com")
     r = await client.post("/api/conversations", json={"title": "Shared chat"})
     conv_id = r.json()["id"]
 
-    # Seed a message with sources
-    r_msg = await client.post(
-        f"/api/conversations/{conv_id}/messages",
-        json={"content": "hello"},
-    )
-    assert r_msg.status_code == 200
+    # Seed a message directly into the fake store (avoids the messages endpoint
+    # which calls stream_chat and is not wired up in unit-test infrastructure;
+    # see test_rate_limit.py for the skipped integration tests that need it).
+    fake_share_repo["messages"][conv_id].append({
+        "id": str(uuid4()),
+        "role": "user",
+        "content": "hello",
+        "sources": None,
+        "created_at": "2026-05-31T10:05:00+00:00",
+    })
 
     r_share = await client.post(f"/api/conversations/{conv_id}/share")
     token = r_share.json()["token"]

--- a/app/backend/tests/test_share.py
+++ b/app/backend/tests/test_share.py
@@ -1,0 +1,356 @@
+"""Tests for share-link endpoints (issue #278).
+
+Covers:
+- Owner can create a share link; response carries token and /share/ path.
+- GET /api/share/{token} with no auth cookie returns title + messages + sources.
+- Revoke makes a previously-working token return 404.
+- Unknown/garbage token -> 404.
+- Non-owner cannot create or revoke another user's link -> 404.
+- Re-minting rotates the token and the previous token stops resolving.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+
+@pytest.fixture(autouse=True)
+def fake_users_repo(monkeypatch):
+    """Replace Postgres-backed users_repo with an in-memory dict."""
+    store: dict[str, dict[str, Any]] = {}
+
+    async def create_user(email: str, password_hash: str, **kwargs: Any) -> dict[str, Any]:
+        import asyncpg
+
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                raise asyncpg.UniqueViolationError("duplicate email")
+        uid = str(uuid4())
+        row = {
+            "id": uid,
+            "email": email,
+            "password_hash": password_hash,
+            "created_at": None,
+            "last_login_at": None,
+            "is_member": False,
+            "member_verified_at": None,
+        }
+        store[uid] = row
+        return {k: v for k, v in row.items() if k != "password_hash"}
+
+    async def get_user_by_email(email: str) -> dict[str, Any] | None:
+        email_lower = email.lower()
+        for u in store.values():
+            if str(u["email"]).lower() == email_lower:
+                return dict(u)
+        return None
+
+    async def get_user_by_id(user_id: Any) -> dict[str, Any] | None:
+        u = store.get(str(user_id))
+        if not u:
+            return None
+        return {k: v for k, v in u.items() if k != "password_hash"}
+
+    async def update_last_login(user_id: Any) -> None:
+        u = store.get(str(user_id))
+        if u:
+            u["last_login_at"] = "now"
+
+    from backend.auth import dependencies as auth_deps
+    from backend.db import users_repo
+    from backend.routes import auth as auth_route
+
+    monkeypatch.setattr(users_repo, "create_user", create_user)
+    monkeypatch.setattr(users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(users_repo, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(users_repo, "update_last_login", update_last_login)
+    monkeypatch.setattr(auth_deps.users_repo, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(auth_route.users_repo, "create_user", create_user)
+    monkeypatch.setattr(auth_route.users_repo, "get_user_by_email", get_user_by_email)
+    monkeypatch.setattr(auth_route.users_repo, "update_last_login", update_last_login)
+
+    return store
+
+
+@pytest.fixture(autouse=True)
+def stub_pg_lifecycle(monkeypatch):
+    from backend.db import postgres as pg
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr(pg, "init_pg_pool", noop)
+    monkeypatch.setattr(pg, "close_pg_pool", noop)
+
+
+@pytest.fixture
+async def client():
+    from backend.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://testserver") as c:
+        yield c
+
+
+async def _signup(client: AsyncClient, email: str, password: str = "password123") -> str:
+    r = await client.post("/api/auth/signup", json={"email": email, "password": password})
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Repository fakes for share token logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def fake_share_repo(monkeypatch):
+    """In-memory fake for share-token repository functions."""
+    conversations: dict[str, dict[str, Any]] = {}
+    messages: dict[str, list[dict[str, Any]]] = {}
+    tokens: dict[str, str] = {}  # token -> conversation_id
+
+    async def set_conversation_share_token(conv_id: str, user_id: str, token: str) -> bool:
+        conv = conversations.get(conv_id)
+        if not conv or conv["user_id"] != user_id:
+            return False
+        # rotate: clear old token
+        old_token = conv.get("share_token")
+        if old_token and old_token in tokens:
+            del tokens[old_token]
+        conv["share_token"] = token
+        conv["share_created_at"] = "2026-05-31T12:00:00+00:00"
+        tokens[token] = conv_id
+        return True
+
+    async def clear_conversation_share_token(conv_id: str, user_id: str) -> bool:
+        conv = conversations.get(conv_id)
+        if not conv or conv["user_id"] != user_id:
+            return False
+        old_token = conv.get("share_token")
+        if old_token and old_token in tokens:
+            del tokens[old_token]
+        conv["share_token"] = None
+        conv["share_created_at"] = None
+        return True
+
+    async def get_conversation_by_share_token(token: str) -> dict[str, Any] | None:
+        conv_id = tokens.get(token)
+        if not conv_id:
+            return None
+        conv = conversations.get(conv_id)
+        if not conv:
+            return None
+        return {
+            "id": conv["id"],
+            "title": conv["title"],
+            "created_at": conv["created_at"],
+            "updated_at": conv["updated_at"],
+        }
+
+    async def list_messages_for_share_token(token: str) -> list[dict[str, Any]]:
+        conv_id = tokens.get(token)
+        if not conv_id:
+            return []
+        return messages.get(conv_id, [])
+
+    async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict[str, Any]:
+        conv_id = str(uuid4())
+        conv = {
+            "id": conv_id,
+            "user_id": user_id,
+            "title": title,
+            "created_at": "2026-05-31T10:00:00+00:00",
+            "updated_at": "2026-05-31T10:00:00+00:00",
+            "share_token": None,
+            "share_created_at": None,
+        }
+        conversations[conv_id] = conv
+        messages[conv_id] = []
+        return conv
+
+    async def get_conversation(conv_id: str, user_id: str) -> dict[str, Any] | None:
+        conv = conversations.get(conv_id)
+        if not conv or conv["user_id"] != user_id:
+            return None
+        return conv
+
+    async def list_messages(conv_id: str, user_id: str) -> list[dict[str, Any]]:
+        conv = conversations.get(conv_id)
+        if not conv or conv["user_id"] != user_id:
+            return []
+        return messages.get(conv_id, [])
+
+    async def create_message(
+        *, conversation_id: str, user_id: str, role: str, content: str, sources: list[dict] | None = None
+    ) -> dict[str, Any] | None:
+        conv = conversations.get(conversation_id)
+        if not conv or conv["user_id"] != user_id:
+            return None
+        msg = {
+            "id": str(uuid4()),
+            "conversation_id": conversation_id,
+            "role": role,
+            "content": content,
+            "sources": sources,
+            "created_at": "2026-05-31T10:05:00+00:00",
+        }
+        messages[conversation_id].append(msg)
+        return msg
+
+    from backend.db import repository as repo
+
+    monkeypatch.setattr(repo, "set_conversation_share_token", set_conversation_share_token)
+    monkeypatch.setattr(repo, "clear_conversation_share_token", clear_conversation_share_token)
+    monkeypatch.setattr(repo, "get_conversation_by_share_token", get_conversation_by_share_token)
+    monkeypatch.setattr(repo, "list_messages_for_share_token", list_messages_for_share_token)
+    monkeypatch.setattr(repo, "create_conversation", create_conversation)
+    monkeypatch.setattr(repo, "get_conversation", get_conversation)
+    monkeypatch.setattr(repo, "list_messages", list_messages)
+    monkeypatch.setattr(repo, "create_message", create_message)
+
+    return {"conversations": conversations, "messages": messages, "tokens": tokens}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_owner_can_create_share_link(client):
+    await _signup(client, "owner@example.com")
+    r = await client.post("/api/conversations", json={"title": "Secret chat"})
+    assert r.status_code == 201
+    conv_id = r.json()["id"]
+
+    r_share = await client.post(f"/api/conversations/{conv_id}/share")
+    assert r_share.status_code == 200
+    body = r_share.json()
+    assert "token" in body
+    assert body["url_path"] == f"/share/{body['token']}"
+
+
+async def test_get_shared_conversation_no_auth_returns_data(client):
+    await _signup(client, "owner2@example.com")
+    r = await client.post("/api/conversations", json={"title": "Shared chat"})
+    conv_id = r.json()["id"]
+
+    # Seed a message with sources
+    r_msg = await client.post(
+        f"/api/conversations/{conv_id}/messages",
+        json={"content": "hello"},
+    )
+    assert r_msg.status_code == 200
+
+    r_share = await client.post(f"/api/conversations/{conv_id}/share")
+    token = r_share.json()["token"]
+
+    # Clear cookies to simulate logged-out reader
+    client.cookies.clear()
+    r_public = await client.get(f"/api/share/{token}")
+    assert r_public.status_code == 200
+    body = r_public.json()
+    assert body["title"] == "Shared chat"
+    assert len(body["messages"]) > 0
+    assert body["messages"][0]["role"] == "user"
+    assert body["messages"][0]["content"] == "hello"
+    # Must not include user_id or any owner-identifying field
+    assert "user_id" not in body
+    assert "user_id" not in body["messages"][0]
+
+
+async def test_revoke_makes_token_404(client):
+    await _signup(client, "owner3@example.com")
+    r = await client.post("/api/conversations", json={"title": "Revoke me"})
+    conv_id = r.json()["id"]
+
+    r_share = await client.post(f"/api/conversations/{conv_id}/share")
+    token = r_share.json()["token"]
+
+    # Verify it works before revocation
+    client.cookies.clear()
+    r_before = await client.get(f"/api/share/{token}")
+    assert r_before.status_code == 200
+
+    # Re-auth as owner and revoke
+    await client.post("/api/auth/login", json={"email": "owner3@example.com", "password": "password123"})
+    r_revoke = await client.delete(f"/api/conversations/{conv_id}/share")
+    assert r_revoke.status_code == 204
+
+    # Now the token should 404
+    client.cookies.clear()
+    r_after = await client.get(f"/api/share/{token}")
+    assert r_after.status_code == 404
+
+
+async def test_unknown_token_returns_404(client):
+    r = await client.get("/api/share/totally-fake-token-12345")
+    assert r.status_code == 404
+
+
+async def test_non_owner_cannot_create_or_revoke(client):
+    await _signup(client, "alice@example.com")
+    r = await client.post("/api/conversations", json={"title": "Alice chat"})
+    alice_conv = r.json()["id"]
+
+    # Bob signs up and tries to share Alice's conversation
+    await _signup(client, "bob@example.com")
+    r_create = await client.post(f"/api/conversations/{alice_conv}/share")
+    assert r_create.status_code == 404
+
+    # Alice creates a link first
+    await client.post("/api/auth/login", json={"email": "alice@example.com", "password": "password123"})
+    r_share = await client.post(f"/api/conversations/{alice_conv}/share")
+    assert r_share.status_code == 200
+
+    # Bob tries to revoke it
+    await client.post("/api/auth/login", json={"email": "bob@example.com", "password": "password123"})
+    r_revoke = await client.delete(f"/api/conversations/{alice_conv}/share")
+    assert r_revoke.status_code == 404
+
+
+async def test_re_mint_rotates_token(client):
+    await _signup(client, "rotater@example.com")
+    r = await client.post("/api/conversations", json={"title": "Rotate me"})
+    conv_id = r.json()["id"]
+
+    r1 = await client.post(f"/api/conversations/{conv_id}/share")
+    token1 = r1.json()["token"]
+
+    # Re-mint
+    r2 = await client.post(f"/api/conversations/{conv_id}/share")
+    token2 = r2.json()["token"]
+
+    assert token1 != token2
+
+    # Old token stops resolving
+    client.cookies.clear()
+    r_old = await client.get(f"/api/share/{token1}")
+    assert r_old.status_code == 404
+
+    # New token works
+    r_new = await client.get(f"/api/share/{token2}")
+    assert r_new.status_code == 200
+
+
+async def test_public_share_is_read_only_no_mutations(client):
+    """There is no POST/PUT/PATCH/DELETE under /api/share/{token}."""
+    # Attempting to POST to the share endpoint should 405 (method not allowed)
+    # because only GET is registered.
+    r_post = await client.post("/api/share/some-token", json={"content": "bad"})
+    assert r_post.status_code == 405
+
+    r_delete = await client.delete("/api/share/some-token")
+    assert r_delete.status_code == 405
+
+    r_patch = await client.patch("/api/share/some-token", json={})
+    assert r_patch.status_code == 405

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider, useAuth } from './hooks/useAuth';
 import { AdminVideos } from './pages/AdminVideos';
 import { Login } from './pages/Login';
 import { NotFound } from './pages/NotFound';
+import { SharedConversation } from './pages/SharedConversation';
 import { Signup } from './pages/Signup';
 
 // ── Auth guard ───────────────────────────────────────────────────
@@ -102,6 +103,7 @@ function App() {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
+            <Route path="/share/:token" element={<SharedConversation />} />
             <Route
               path="/"
               element={

--- a/app/frontend/src/__tests__/shareApi.test.ts
+++ b/app/frontend/src/__tests__/shareApi.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, createShareLink, getSharedConversation, revokeShareLink } from '../lib/api';
+
+describe('share API wrappers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('createShareLink POSTs to /conversations/:id/share with credentials', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: 'abc123', url_path: '/share/abc123' }),
+      text: async () => '',
+    });
+
+    const res = await createShareLink('conv-1');
+    expect(res).toEqual({ token: 'abc123', url_path: '/share/abc123' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/share');
+    expect(opts?.method).toBe('POST');
+    expect(opts?.credentials).toBe('include');
+  });
+
+  it('revokeShareLink DELETEs with credentials', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      text: async () => '',
+    });
+
+    await revokeShareLink('conv-1');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/share');
+    expect(opts?.method).toBe('DELETE');
+    expect(opts?.credentials).toBe('include');
+  });
+
+  it('getSharedConversation fetches /api/share/:token without credentials', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        title: 'Test conv',
+        messages: [{ id: 'm1', role: 'user', content: 'hi', sources: null }],
+      }),
+      text: async () => '',
+    });
+
+    const res = await getSharedConversation('tok-1');
+    expect(res.title).toBe('Test conv');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/share/tok-1');
+    // Must not include credentials so anon readers aren't bounced to login
+    expect(opts?.credentials).toBeUndefined();
+  });
+
+  it('getSharedConversation throws ApiError on 404', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => JSON.stringify({ detail: 'Share link not found' }),
+    });
+
+    await expect(getSharedConversation('bad-tok')).rejects.toBeInstanceOf(ApiError);
+    try {
+      await getSharedConversation('bad-tok');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(404);
+    }
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -10,6 +10,7 @@ import { exportConversationAsMarkdown } from '../lib/exportMarkdown';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { CitationModal } from './CitationModal';
 import { Message } from './Message';
+import { ShareDialog } from './ShareDialog';
 
 function formatResetTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
@@ -325,6 +326,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const pendingUserMsgIdRef = useRef<string | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
+  const [shareOpen, setShareOpen] = useState(false);
 
   // ── Auto-scroll logic ──
   // Defer scroll to the next paint cycle so streaming DOM updates are applied first.
@@ -638,53 +640,103 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           position: 'relative',
         }}
       >
-        {/* ── Export button (visible when conversation is active) ── */}
+        {/* ── Export + Share buttons (visible when conversation is active) ── */}
         {conversation && messages.length > 0 && (
-          <button
-            onClick={handleExport}
-            title="Export conversation as Markdown"
+          <div
             style={{
               position: 'absolute',
               top: 12,
               right: 24,
-              background: '#1e293b',
-              border: '1px solid rgba(255,255,255,0.08)',
-              borderRadius: 7,
-              color: '#94a3b8',
-              cursor: 'pointer',
-              padding: '5px 8px',
               display: 'flex',
-              alignItems: 'center',
-              gap: 5,
-              fontSize: 12,
+              gap: 8,
               zIndex: 5,
-              transition: 'background 0.15s, color 0.15s',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = '#1e293b';
-              e.currentTarget.style.color = '#f1f5f9';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = '#1e293b';
-              e.currentTarget.style.color = '#94a3b8';
             }}
           >
-            <svg
-              width="13"
-              height="13"
-              viewBox="0 0 13 13"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+            <button
+              onClick={() => setShareOpen(true)}
+              title="Share conversation"
+              style={{
+                background: '#1e293b',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 7,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                padding: '5px 8px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 5,
+                fontSize: 12,
+                transition: 'background 0.15s, color 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#1e293b';
+                e.currentTarget.style.color = '#f1f5f9';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#1e293b';
+                e.currentTarget.style.color = '#94a3b8';
+              }}
             >
-              <path d="M2,9 L2,11.5 A0.5,0.5 0 0,0 2.5,12 L10.5,12 A0.5,0.5 0 0,0 11,11.5 L11,9" />
-              <polyline points="6.5,1 6.5,8.5" />
-              <polyline points="3.5,5.5 6.5,8.5 9.5,5.5" />
-            </svg>
-            Export
-          </button>
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 13 13"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="4" cy="6.5" r="2.5" />
+                <circle cx="9" cy="3.5" r="2" />
+                <circle cx="9" cy="9.5" r="2" />
+                <line x1="6" y1="5" x2="7.5" y2="4.2" />
+                <line x1="6" y1="8" x2="7.5" y2="8.8" />
+              </svg>
+              Share
+            </button>
+            <button
+              onClick={handleExport}
+              title="Export conversation as Markdown"
+              style={{
+                background: '#1e293b',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 7,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                padding: '5px 8px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 5,
+                fontSize: 12,
+                transition: 'background 0.15s, color 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#1e293b';
+                e.currentTarget.style.color = '#f1f5f9';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#1e293b';
+                e.currentTarget.style.color = '#94a3b8';
+              }}
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 13 13"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M2,9 L2,11.5 A0.5,0.5 0 0,0 2.5,12 L10.5,12 A0.5,0.5 0 0,0 11,11.5 L11,9" />
+                <polyline points="6.5,1 6.5,8.5" />
+                <polyline points="3.5,5.5 6.5,8.5 9.5,5.5" />
+              </svg>
+              Export
+            </button>
+          </div>
         )}
 
         {showEmpty && <EmptyState onStarterClick={handleStarterClick} />}
@@ -778,6 +830,15 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       {/* ── Citation modal ── */}
       {selectedCitation && (
         <CitationModal citation={selectedCitation} onClose={() => setSelectedCitation(null)} />
+      )}
+
+      {/* ── Share dialog ── */}
+      {conversationId && (
+        <ShareDialog
+          conversationId={conversationId}
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+        />
       )}
     </div>
   );

--- a/app/frontend/src/components/ShareDialog.tsx
+++ b/app/frontend/src/components/ShareDialog.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef, useState } from 'react';
+import { createShareLink, revokeShareLink, type ShareLinkResponse } from '../lib/api';
+import { useToast } from '../hooks/useToast';
+
+interface ShareDialogProps {
+  conversationId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ShareDialog({ conversationId, open, onClose }: ShareDialogProps) {
+  const [link, setLink] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const { addToast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setLink(null);
+      setLoading(false);
+      setRevoking(false);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  async function handleCreate() {
+    setLoading(true);
+    try {
+      const res: ShareLinkResponse = await createShareLink(conversationId);
+      const url = `${window.location.origin}${res.url_path}`;
+      setLink(url);
+      addToast('Share link created', 'success');
+      // Auto-select the input so user can Ctrl+C immediately
+      setTimeout(() => {
+        inputRef.current?.select();
+      }, 50);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to create share link';
+      addToast(msg, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!link) return;
+    try {
+      await navigator.clipboard.writeText(link);
+      addToast('Copied to clipboard', 'success');
+    } catch {
+      addToast('Copy failed — select and copy manually', 'error');
+    }
+  }
+
+  async function handleRevoke() {
+    setRevoking(true);
+    try {
+      await revokeShareLink(conversationId);
+      setLink(null);
+      addToast('Share link revoked', 'success');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to revoke share link';
+      addToast(msg, 'error');
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Share conversation"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md bg-[var(--surface-1)] border border-[var(--border)] rounded-lg p-6 space-y-4 shadow-2xl"
+      >
+        <h2 className="text-lg font-semibold">Share conversation</h2>
+        <p className="text-sm text-[var(--text-secondary)]">
+          Anyone with the link can view this conversation read-only. They won&apos;t be able to send
+          messages or see your other chats.
+        </p>
+
+        {!link ? (
+          <button
+            onClick={handleCreate}
+            disabled={loading}
+            className="w-full px-3 py-2 rounded bg-[var(--accent)] text-white font-medium disabled:opacity-50 transition-[filter] duration-150 active:brightness-90 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+          >
+            {loading ? 'Creating…' : 'Create share link'}
+          </button>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex gap-2">
+              <input
+                ref={inputRef}
+                readOnly
+                value={link}
+                className="flex-1 px-3 py-2 rounded bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] text-sm"
+              />
+              <button
+                onClick={handleCopy}
+                className="px-3 py-2 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none text-sm"
+              >
+                Copy
+              </button>
+            </div>
+            <button
+              onClick={handleRevoke}
+              disabled={revoking}
+              className="w-full px-3 py-2 rounded border border-red-500/50 text-red-400 hover:text-red-300 hover:bg-red-500/10 disabled:opacity-50 transition-colors text-sm font-medium focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:outline-none"
+            >
+              {revoking ? 'Revoking…' : 'Revoke link'}
+            </button>
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -180,6 +180,45 @@ export const ingestVideo = (body: IngestVideoBody) =>
     body: JSON.stringify(body),
   });
 
+// Share links (issue #278)
+export interface ShareLinkResponse {
+  token: string;
+  url_path: string;
+}
+
+export interface SharedMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  sources?: Citation[];
+}
+
+export interface SharedConversation {
+  title: string;
+  messages: SharedMessage[];
+}
+
+export const createShareLink = (id: string) =>
+  request<ShareLinkResponse>(`/conversations/${id}/share`, { method: 'POST', body: '{}' });
+
+export const revokeShareLink = async (id: string): Promise<void> => {
+  const res = await fetch(`${BASE}/conversations/${id}/share`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new ApiError(res.status, await parseErrorDetail(res));
+  }
+};
+
+export const getSharedConversation = async (token: string): Promise<SharedConversation> => {
+  const res = await fetch(`/api/share/${token}`);
+  if (!res.ok) {
+    throw new ApiError(res.status, await parseErrorDetail(res));
+  }
+  return res.json() as Promise<SharedConversation>;
+};
+
 // Health
 export const getHealth = () =>
   request<{ status: string; video_count: number; chunk_count: number; db_path: string }>('/health');

--- a/app/frontend/src/pages/SharedConversation.test.tsx
+++ b/app/frontend/src/pages/SharedConversation.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { getSharedConversation } from '../lib/api';
+import { SharedConversation } from './SharedConversation';
+
+vi.mock('../lib/api', () => ({
+  getSharedConversation: vi.fn(),
+}));
+
+describe('SharedConversation', () => {
+  it('renders messages and citations, no ChatInput', async () => {
+    (getSharedConversation as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      title: 'Shared Chat',
+      messages: [
+        { id: 'm1', role: 'user', content: 'Hello?' },
+        {
+          id: 'm2',
+          role: 'assistant',
+          content: 'Hi!',
+          sources: [
+            {
+              chunk_id: 'c1',
+              video_id: 'v1',
+              video_title: 'Demo',
+              video_url: 'https://www.youtube.com/watch?v=abc',
+              start_seconds: 10,
+              end_seconds: 20,
+              snippet: 'snippet',
+              is_cited: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/share/tok-123']}>
+        <Routes>
+          <Route path="/share/:token" element={<SharedConversation />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Shared Chat')).toBeInTheDocument());
+    expect(screen.getByText('Hello?')).toBeInTheDocument();
+    expect(screen.getByText('Hi!')).toBeInTheDocument();
+    // Citation chip should appear
+    expect(screen.getByRole('button', { name: /Demo/ })).toBeInTheDocument();
+    // No chat input in read-only view
+    expect(screen.queryByPlaceholderText(/Ask anything/i)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/Type a message/i)).not.toBeInTheDocument();
+  });
+
+  it('shows unavailable state on 404', async () => {
+    (getSharedConversation as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Share link not found'),
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/share/bad-tok']}>
+        <Routes>
+          <Route path="/share/:token" element={<SharedConversation />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('This link is no longer available')).toBeInTheDocument(),
+    );
+  });
+});

--- a/app/frontend/src/pages/SharedConversation.tsx
+++ b/app/frontend/src/pages/SharedConversation.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { CitationModal } from '../components/CitationModal';
+import { Message } from '../components/Message';
+import { getSharedConversation, type Citation, type SharedConversation as SharedConversationType } from '../lib/api';
+
+export function SharedConversation() {
+  const { token } = useParams<{ token: string }>();
+  const [data, setData] = useState<SharedConversationType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setError('Invalid share link');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    getSharedConversation(token)
+      .then(setData)
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : 'Failed to load conversation');
+      })
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  const handleCitationClick = (citation: Citation) => {
+    if (citation.source_type === 'dynamous') {
+      if (citation.lesson_url) {
+        window.open(citation.lesson_url, '_blank', 'noopener,noreferrer');
+      }
+    } else {
+      setSelectedCitation(citation);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0a0a0f',
+          color: '#94a3b8',
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0a0a0f',
+          color: '#94a3b8',
+          padding: 24,
+          textAlign: 'center',
+        }}
+      >
+        <div>
+          <h1 style={{ margin: '0 0 8px', fontSize: 20, fontWeight: 600, color: '#f1f5f9' }}>
+            This link is no longer available
+          </h1>
+          <p style={{ margin: 0, maxWidth: 400, lineHeight: 1.6 }}>
+            The conversation may have been unshared or the link may be incorrect.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: '#0a0a0f',
+        color: '#f1f5f9',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          padding: '16px 24px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: '#f1f5f9' }}>
+          {data.title}
+        </h1>
+        <span
+          style={{
+            fontSize: 12,
+            color: '#94a3b8',
+            background: 'rgba(148,163,184,0.1)',
+            padding: '4px 10px',
+            borderRadius: 12,
+          }}
+        >
+          Read-only
+        </span>
+      </div>
+
+      {/* Messages */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '24px 24px 80px' }}>
+        {data.messages.map((msg) => (
+          <Message
+            key={msg.id}
+            role={msg.role as 'user' | 'assistant'}
+            content={msg.content}
+            sources={msg.sources}
+            onCitationClick={handleCitationClick}
+          />
+        ))}
+      </div>
+
+      {selectedCitation && (
+        <CitationModal citation={selectedCitation} onClose={() => setSelectedCitation(null)} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #278

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `10ff0626-1e8f-4055-b995-b85429b1b142`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.