### PR TITLE
[bench-OK] review: add missing tests and fix broken stubs for video scope (issue #279)

### DIFF
--- a/app/backend/alembic/versions/0006_add_video_filter_to_conversations.py
+++ b/app/backend/alembic/versions/0006_add_video_filter_to_conversations.py
@@ -1,0 +1,33 @@
+"""Add video_filter JSONB to conversations.
+
+Stores an optional array of video_id strings that scopes retrieval
+for the lifetime of a conversation. NULL or omitted = search all videos.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE conversations
+        ADD COLUMN IF NOT EXISTS video_filter JSONB
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS video_filter")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -253,6 +253,7 @@ async def keyword_search(
     top_k: int,
     language: str = "english",
     allowed_source_types: list[str] | None = None,
+    video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
@@ -273,20 +274,38 @@ async def keyword_search(
     if allowed_source_types is None:
         allowed_source_types = ["youtube"]
     async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
-            FROM chunks
-            WHERE search_vector @@ plainto_tsquery($1)
-              AND source_type = ANY($3::text[])
-            ORDER BY rank DESC
-            LIMIT $2
-            """,
-            query,
-            top_k,
-            allowed_source_types,
-        )
+        if video_ids:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                FROM chunks
+                WHERE search_vector @@ plainto_tsquery($1)
+                  AND source_type = ANY($3::text[])
+                  AND video_id = ANY($4::text[])
+                ORDER BY rank DESC
+                LIMIT $2
+                """,
+                query,
+                top_k,
+                allowed_source_types,
+                video_ids,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                FROM chunks
+                WHERE search_vector @@ plainto_tsquery($1)
+                  AND source_type = ANY($3::text[])
+                ORDER BY rank DESC
+                LIMIT $2
+                """,
+                query,
+                top_k,
+                allowed_source_types,
+            )
     return [dict(r) for r in rows]
 
 
@@ -294,6 +313,7 @@ async def vector_search_pg(
     query_embedding: list[float],
     top_k: int,
     allowed_source_types: list[str] | None = None,
+    video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
@@ -320,19 +340,36 @@ async def vector_search_pg(
         allowed_source_types = ["youtube"]
     embedding_json = json.dumps(query_embedding)
     async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   embedding::vector <=> $1::vector AS distance
-            FROM chunks
-            WHERE source_type = ANY($3::text[])
-            ORDER BY distance
-            LIMIT $2
-            """,
-            embedding_json,
-            top_k,
-            allowed_source_types,
-        )
+        if video_ids:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       embedding::vector <=> $1::vector AS distance
+                FROM chunks
+                WHERE source_type = ANY($3::text[])
+                  AND video_id = ANY($4::text[])
+                ORDER BY distance
+                LIMIT $2
+                """,
+                embedding_json,
+                top_k,
+                allowed_source_types,
+                video_ids,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       embedding::vector <=> $1::vector AS distance
+                FROM chunks
+                WHERE source_type = ANY($3::text[])
+                ORDER BY distance
+                LIMIT $2
+                """,
+                embedding_json,
+                top_k,
+                allowed_source_types,
+            )
     return [dict(r) for r in rows]
 
 
@@ -415,18 +452,23 @@ async def replace_chunks_for_video(
 # ---------------------------------------------------------------------------
 
 
-async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict:
+async def create_conversation(
+    *, user_id: str, title: str = "New Conversation", video_filter: list[str] | None = None
+) -> dict:
     conv_id = _new_id()
     now = _now()
+    vf = video_filter or None
+    vf_json = json.dumps(vf) if vf is not None else None
     async with _acquire() as conn:
         await conn.execute(
             """
-            INSERT INTO conversations (id, user_id, title, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO conversations (id, user_id, title, video_filter, created_at, updated_at)
+            VALUES ($1, $2, $3, $4::jsonb, $5, $6)
             """,
             conv_id,
             user_id,
             title,
+            vf_json,
             now,
             now,
         )
@@ -434,6 +476,7 @@ async def create_conversation(*, user_id: str, title: str = "New Conversation") 
         "id": conv_id,
         "user_id": user_id,
         "title": title,
+        "video_filter": vf,
         "created_at": now,
         "updated_at": now,
     }
@@ -447,7 +490,11 @@ async def get_conversation(conv_id: str, user_id: str) -> dict | None:
             conv_id,
             user_id,
         )
-    return dict(row) if row else None
+    if not row:
+        return None
+    d = dict(row)
+    d["video_filter"] = json.loads(d["video_filter"]) if d.get("video_filter") else None
+    return d
 
 
 async def list_conversations(user_id: str) -> list[dict]:
@@ -466,7 +513,12 @@ async def list_conversations(user_id: str) -> list[dict]:
             """,
             user_id,
         )
-    return [dict(r) for r in rows]
+    result = []
+    for r in rows:
+        d = dict(r)
+        d["video_filter"] = json.loads(d["video_filter"]) if d.get("video_filter") else None
+        result.append(d)
+    return result
 
 
 async def update_conversation_title(conv_id: str, user_id: str, title: str) -> bool:

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -40,6 +40,7 @@ async def retrieve_hybrid(
     query_embedding: list[float],
     top_k: int = 5,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -52,6 +53,9 @@ async def retrieve_hybrid(
             = 'dynamous'`) is included alongside the default YouTube content.
             Non-members see YouTube chunks only. The filter is applied at the
             SQL layer — non-member retrieval never touches Dynamous chunks.
+        video_ids: Optional allowlist of video IDs. When provided, only chunks
+            whose video_id is in this list are returned. Intersects with the
+            source_type ACL (is_member) — never replaces it.
 
     Returns:
         A list of dicts (length <= top_k), each containing:
@@ -88,11 +92,13 @@ async def retrieve_hybrid(
         top_k=fetch_k,
         language=KEYWORD_LANGUAGE,
         allowed_source_types=allowed_source_types,
+        video_ids=video_ids,
     )
     vector_task = repository.vector_search_pg(
         query_embedding,
         top_k=fetch_k,
         allowed_source_types=allowed_source_types,
+        video_ids=video_ids,
     )
 
     keyword_hits, vector_hits = await keyword_task, await vector_task

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -410,6 +410,7 @@ async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Hybrid (keyword + semantic via RRF) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -425,7 +426,9 @@ async def execute_search_hybrid(
 
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
+        chunks = await retrieve_hybrid(
+            query, embedding, top_k=top_k, is_member=is_member, video_ids=video_ids
+        )
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -439,6 +442,7 @@ async def execute_search_hybrid(
 async def execute_search_keyword(
     raw_arguments: str | dict,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Keyword-only (tsvector FTS) search."""
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
@@ -459,6 +463,7 @@ async def execute_search_keyword(
             top_k=top_k,
             language=KEYWORD_LANGUAGE,
             allowed_source_types=allowed,
+            video_ids=video_ids,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -475,6 +480,7 @@ async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Semantic-only (pgvector cosine) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -492,7 +498,7 @@ async def execute_search_semantic(
     try:
         embedding = await _embed_query(query, embedding_cache)
         raw = await repository.vector_search_pg(
-            embedding, top_k=top_k, allowed_source_types=allowed
+            embedding, top_k=top_k, allowed_source_types=allowed, video_ids=video_ids
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -603,6 +609,7 @@ async def execute_tool(
     video_id_whitelist: set[str] | None = None,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Dispatch by tool name. Unknown names return an error dict so the
     model sees the refusal and stops calling.
@@ -615,13 +622,21 @@ async def execute_tool(
     """
     if name == "search_videos":
         return await execute_search_hybrid(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_ids=video_ids,
         )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments, is_member=is_member)
+        return await execute_search_keyword(
+            raw_arguments, is_member=is_member, video_ids=video_ids
+        )
     if name == "semantic_search_videos":
         return await execute_search_semantic(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_ids=video_ids,
         )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -19,6 +19,7 @@ router = APIRouter()
 
 class ConversationCreate(BaseModel):
     title: str = "New Conversation"
+    video_filter: list[str] | None = None
 
 
 class ConversationRename(BaseModel):
@@ -37,9 +38,11 @@ async def create_conversation(
 ):
     """Create a new empty conversation. Body is optional; defaults to title='New Conversation'."""
     title = body.title if body else "New Conversation"
+    video_filter = body.video_filter if body else None
     return await repository.create_conversation(
         user_id=str(current_user["id"]),
         title=title,
+        video_filter=video_filter,
     )
 
 

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -144,6 +144,14 @@ async def create_message(
         # turn won't change behavior mid-flight.
         is_member_for_turn = bool(current_user.get("is_member", False))
 
+        # Scope the conversation to specific videos if a filter was set at
+        # creation time. The filter persists server-side for the lifetime of
+        # the conversation — the client never re-sends it.
+        video_filter = conv.get("video_filter") or None
+        if video_filter:
+            filter_set = set(video_filter)
+            video_id_whitelist = {vid for vid in video_id_whitelist if vid in filter_set}
+
         async def _executor(name: str, raw_args: str) -> str:
             # Pass `None` (not empty set) when the whitelist failed to load so
             # the transcript tool falls back to open lookups instead of rejecting
@@ -155,6 +163,7 @@ async def create_message(
                 video_id_whitelist=whitelist,
                 embedding_cache=embedding_cache,
                 is_member=is_member_for_turn,
+                video_ids=video_filter,
             )
             if result.get("ok") and result.get("chunks"):
                 tool_chunks_acc.extend(result["chunks"])

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -191,3 +191,112 @@ class TestVectorSearchPg:
 
         parsed = json.loads(args[1])
         assert parsed == embedding
+
+
+class TestVideoIdsFilter:
+    """Tests for video_ids filter in keyword_search and vector_search_pg (issue #279)."""
+
+    async def test_keyword_search_adds_video_id_clause_when_video_ids_set(self):
+        """keyword_search adds AND video_id = ANY($4::text[]) when video_ids is provided."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, video_ids=["v1", "v2"])
+
+        call_args = mock_conn.fetch.call_args
+        sql, *args = call_args[0]
+        assert "video_id = ANY($4::text[])" in sql
+        assert "source_type = ANY($3::text[])" in sql
+        assert args[3] == ["v1", "v2"]
+
+    async def test_keyword_search_no_video_id_clause_when_video_ids_none(self):
+        """keyword_search does NOT add video_id clause when video_ids is None."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, video_ids=None)
+
+        call_args = mock_conn.fetch.call_args
+        sql, *args = call_args[0]
+        assert "video_id = ANY" not in sql
+        assert len(args) == 3  # query, top_k, allowed_source_types
+
+    async def test_keyword_search_no_video_id_clause_for_empty_list(self):
+        """keyword_search treats empty video_ids same as None — no filter clause."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, video_ids=[])
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        assert "video_id = ANY" not in sql
+
+    async def test_vector_search_pg_adds_video_id_clause_when_video_ids_set(self):
+        """vector_search_pg adds AND video_id = ANY($4::text[]) when video_ids is provided."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5, video_ids=["v1"])
+
+        call_args = mock_conn.fetch.call_args
+        sql, *args = call_args[0]
+        assert "video_id = ANY($4::text[])" in sql
+        assert "source_type = ANY($3::text[])" in sql
+        assert args[3] == ["v1"]
+
+    async def test_vector_search_pg_no_video_id_clause_when_video_ids_none(self):
+        """vector_search_pg does NOT add video_id clause when video_ids is None."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5, video_ids=None)
+
+        call_args = mock_conn.fetch.call_args
+        sql, *args = call_args[0]
+        assert "video_id = ANY" not in sql
+        assert len(args) == 3  # embedding_json, top_k, allowed_source_types
+
+    async def test_source_type_acl_preserved_alongside_video_ids_filter(self):
+        """Both source_type ACL and video_ids filter appear in keyword_search SQL (AND semantics)."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search(
+                "test",
+                top_k=5,
+                allowed_source_types=["youtube"],
+                video_ids=["some_dynamous_id"],
+            )
+
+        call_args = mock_conn.fetch.call_args
+        sql, *args = call_args[0]
+        # Both clauses present — intersection guards non-member from dynamous chunks
+        assert "source_type = ANY($3::text[])" in sql
+        assert "video_id = ANY($4::text[])" in sql
+        assert "youtube" in args[2]
+        assert args[3] == ["some_dynamous_id"]

--- a/app/backend/tests/test_tools.py
+++ b/app/backend/tests/test_tools.py
@@ -96,7 +96,7 @@ _FAKE_CHUNKS = [
 
 @pytest.mark.asyncio
 async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
-    async def fake_retrieve(_q, _emb, top_k=5, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_ids=None):
         assert top_k == 10
         return _FAKE_CHUNKS
 
@@ -112,7 +112,7 @@ async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, video_ids=None):
         return [
             {
                 "id": "c1",
@@ -140,7 +140,7 @@ async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_ids=None):
         return [
             {
                 "id": "c2",
@@ -169,7 +169,7 @@ async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, video_ids=None):
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -257,7 +257,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
         for i in range(6)
     ]
 
-    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, video_ids=None):
         return many_chunks
 
     monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
@@ -273,7 +273,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
 async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_keyword."""
 
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, video_ids=None):
         return [
             {
                 "id": f"c{i}",
@@ -303,7 +303,7 @@ async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> Non
 async def test_execute_search_semantic_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_semantic."""
 
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_ids=None):
         return [
             {
                 "id": f"c{i}",
@@ -591,3 +591,69 @@ async def test_prompt_omits_tool_guidance_when_cap_zero() -> None:
         blocks = await build_system_prompt(max_tool_calls=0)
     prompt = "\n".join(b["text"] for b in blocks)
     assert "search_videos" not in prompt
+
+
+# --- video_ids forwarding (issue #279 — conversation video scope) ----------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_video_ids_to_hybrid_search(monkeypatch) -> None:
+    """execute_tool passes video_ids kwarg through to retrieve_hybrid."""
+    captured: dict = {}
+
+    async def fake_retrieve(query, embedding, top_k=10, is_member=False, video_ids=None):
+        captured["video_ids"] = video_ids
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _: [0.0] * 1536)
+
+    await execute_tool("search_videos", {"query": "test"}, video_ids=["v1", "v2"])
+    assert captured["video_ids"] == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_none_video_ids_to_hybrid_search(monkeypatch) -> None:
+    """execute_tool passes video_ids=None when no scope is active."""
+    captured: dict = {}
+
+    async def fake_retrieve(query, embedding, top_k=10, is_member=False, video_ids=None):
+        captured["video_ids"] = video_ids
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _: [0.0] * 1536)
+
+    await execute_tool("search_videos", {"query": "test"})
+    assert captured["video_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_video_ids_to_keyword_search(monkeypatch) -> None:
+    """execute_tool passes video_ids kwarg through to keyword_search."""
+    captured: dict = {}
+
+    async def fake_keyword(query, top_k=10, language="english", allowed_source_types=None, video_ids=None):
+        captured["video_ids"] = video_ids
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
+
+    await execute_tool("keyword_search_videos", {"query": "test"}, video_ids=["v3"])
+    assert captured["video_ids"] == ["v3"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_video_ids_to_semantic_search(monkeypatch) -> None:
+    """execute_tool passes video_ids kwarg through to vector_search_pg."""
+    captured: dict = {}
+
+    async def fake_vector(embedding, top_k=10, allowed_source_types=None, video_ids=None):
+        captured["video_ids"] = video_ids
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "vector_search_pg", fake_vector)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _: [0.0] * 1536)
+
+    await execute_tool("semantic_search_videos", {"query": "test"}, video_ids=["v4"])
+    assert captured["video_ids"] == ["v4"]

--- a/app/backend/tests/test_video_filter.py
+++ b/app/backend/tests/test_video_filter.py
@@ -1,0 +1,186 @@
+"""
+Tests for video_filter conversation scoping (issue #279).
+
+Verifies create_conversation / get_conversation / list_conversations handle
+the video_filter JSONB column correctly: persistence, deserialization, and
+empty-list normalization.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.db import repository
+
+
+class TestCreateConversationVideoFilter:
+    """video_filter persistence in create_conversation."""
+
+    async def test_normalizes_empty_list_to_none(self):
+        """video_filter=[] is treated as no filter — NULL inserted and None returned."""
+        inserted: dict = {}
+
+        mock_conn = AsyncMock()
+
+        async def capture_execute(sql, *args):
+            inserted["args"] = args
+
+        mock_conn.execute = capture_execute
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.create_conversation(user_id="u1", video_filter=[])
+
+        assert result["video_filter"] is None
+        # args: conv_id, user_id, title, vf_json, now, now
+        assert inserted["args"][3] is None
+
+    async def test_serializes_video_filter_ids(self):
+        """video_filter with IDs is JSON-serialized for DB and returned as a list."""
+        inserted: dict = {}
+
+        mock_conn = AsyncMock()
+
+        async def capture_execute(sql, *args):
+            inserted["args"] = args
+
+        mock_conn.execute = capture_execute
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.create_conversation(
+                user_id="u1", video_filter=["v1", "v2"]
+            )
+
+        assert result["video_filter"] == ["v1", "v2"]
+        vf_json = inserted["args"][3]
+        assert vf_json is not None
+        assert json.loads(vf_json) == ["v1", "v2"]
+
+    async def test_default_none_inserts_null(self):
+        """Default video_filter=None inserts NULL and returns None."""
+        inserted: dict = {}
+
+        mock_conn = AsyncMock()
+
+        async def capture_execute(sql, *args):
+            inserted["args"] = args
+
+        mock_conn.execute = capture_execute
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.create_conversation(user_id="u1")
+
+        assert result["video_filter"] is None
+        assert inserted["args"][3] is None
+
+
+class TestGetConversationVideoFilter:
+    """JSONB deserialization in get_conversation."""
+
+    async def test_deserializes_json_string_to_list(self):
+        """get_conversation parses the JSONB string asyncpg returns into a Python list."""
+        raw_row = {
+            "id": "conv1",
+            "user_id": "u1",
+            "title": "Test",
+            "video_filter": json.dumps(["v1", "v2"]),
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=raw_row)
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.get_conversation("conv1", user_id="u1")
+
+        assert result is not None
+        assert result["video_filter"] == ["v1", "v2"]
+        assert isinstance(result["video_filter"], list)
+
+    async def test_null_video_filter_returns_none(self):
+        """get_conversation returns None for NULL video_filter (no scope)."""
+        raw_row = {
+            "id": "conv1",
+            "user_id": "u1",
+            "title": "Test",
+            "video_filter": None,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=raw_row)
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.get_conversation("conv1", user_id="u1")
+
+        assert result is not None
+        assert result["video_filter"] is None
+
+    async def test_missing_conv_returns_none(self):
+        """get_conversation returns None when the conversation doesn't exist."""
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.get_conversation("nonexistent", user_id="u1")
+
+        assert result is None
+
+
+class TestListConversationsVideoFilter:
+    """JSONB deserialization in list_conversations (for Sidebar badge)."""
+
+    async def test_deserializes_video_filter_in_list(self):
+        """list_conversations parses video_filter JSONB strings in every row."""
+        raw_rows = [
+            {
+                "id": "c1",
+                "user_id": "u1",
+                "title": "Scoped",
+                "video_filter": json.dumps(["v1"]),
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "preview": None,
+            },
+            {
+                "id": "c2",
+                "user_id": "u1",
+                "title": "Unscoped",
+                "video_filter": None,
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "preview": None,
+            },
+        ]
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=raw_rows)
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            results = await repository.list_conversations(user_id="u1")
+
+        assert results[0]["video_filter"] == ["v1"]
+        assert isinstance(results[0]["video_filter"], list)
+        assert results[1]["video_filter"] is None

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -10,6 +10,7 @@ import { exportConversationAsMarkdown } from '../lib/exportMarkdown';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { CitationModal } from './CitationModal';
 import { Message } from './Message';
+import { VideoExplorer } from './VideoExplorer';
 
 function formatResetTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
@@ -325,6 +326,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const pendingUserMsgIdRef = useRef<string | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
+  // Video scope picker state (only for not-yet-created conversations)
+  const [selectedVideoIds, setSelectedVideoIds] = useState<string[]>([]);
+  const [showVideoPicker, setShowVideoPicker] = useState(false);
 
   // ── Auto-scroll logic ──
   // Defer scroll to the next paint cycle so streaming DOM updates are applied first.
@@ -459,7 +463,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       if (!conversationId) {
         if (isStreaming) return;
         try {
-          const conv = await createConversation();
+          const conv = await createConversation(
+            selectedVideoIds.length > 0 ? selectedVideoIds : undefined,
+          );
           navigate(`/c/${conv.id}`, {
             state: { initialMessage: content } satisfies ConvLocationState,
           });
@@ -556,6 +562,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       addToast,
       refreshAuth,
       refreshConversationsRef,
+      selectedVideoIds,
     ],
   );
 
@@ -766,6 +773,79 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           zIndex: 2,
         }}
       >
+        {/* Scope chip for active conversation */}
+        {conversation?.video_filter && conversation.video_filter.length > 0 && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              marginBottom: 8,
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '4px 10px',
+                background: 'rgba(59,130,246,0.15)',
+                border: '1px solid rgba(59,130,246,0.3)',
+                borderRadius: 20,
+                fontSize: 12,
+                color: '#93c5fd',
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <circle cx="5" cy="5" r="4" />
+                <line x1="11" y1="11" x2="8.5" y2="8.5" />
+              </svg>
+              Scoped to {conversation.video_filter.length} video
+              {conversation.video_filter.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+        )}
+
+        {/* Choose-videos affordance for new conversation */}
+        {!conversationId && (
+          <div style={{ marginBottom: 8 }}>
+            <button
+              onClick={() => setShowVideoPicker(true)}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '4px 10px',
+                background: 'transparent',
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 20,
+                fontSize: 12,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                transition: 'background 0.15s, color 0.15s, border-color 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(59,130,246,0.1)';
+                e.currentTarget.style.color = '#93c5fd';
+                e.currentTarget.style.borderColor = 'rgba(59,130,246,0.3)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent';
+                e.currentTarget.style.color = '#94a3b8';
+                e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)';
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <rect x="1" y="2" width="10" height="8" rx="1.5" />
+                <polygon points="4.5,4.5 7.5,6 4.5,7.5" fill="currentColor" stroke="none" />
+              </svg>
+              {selectedVideoIds.length > 0
+                ? `${selectedVideoIds.length} video${selectedVideoIds.length !== 1 ? 's' : ''} selected`
+                : 'Choose videos'}
+            </button>
+          </div>
+        )}
+
         <ChatInput
           ref={chatInputRef}
           onSend={handleSend}
@@ -779,6 +859,20 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       {selectedCitation && (
         <CitationModal citation={selectedCitation} onClose={() => setSelectedCitation(null)} />
       )}
+
+      {/* ── Video scope picker ── */}
+      <VideoExplorer
+        isOpen={showVideoPicker}
+        onClose={() => setShowVideoPicker(false)}
+        selectionMode={true}
+        selectedIds={selectedVideoIds}
+        onToggleSelect={(id) =>
+          setSelectedVideoIds((prev) =>
+            prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id],
+          )
+        }
+        onConfirmSelection={() => setShowVideoPicker(false)}
+      />
     </div>
   );
 }

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -167,6 +167,21 @@ function ConvItem({
           }}
         >
           {highlightMatch(conv.title, searchQuery)}
+          {conv.video_filter && conv.video_filter.length > 0 && (
+            <span
+              title={`Scoped to ${conv.video_filter.length} video${conv.video_filter.length !== 1 ? 's' : ''}`}
+              style={{
+                display: 'inline-block',
+                marginLeft: 6,
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: '#3b82f6',
+                verticalAlign: 'middle',
+                flexShrink: 0,
+              }}
+            />
+          )}
         </div>
       )}
 

--- a/app/frontend/src/components/VideoExplorer.tsx
+++ b/app/frontend/src/components/VideoExplorer.tsx
@@ -33,7 +33,21 @@ function SkeletonCard() {
 }
 
 // ── Video card ───────────────────────────────────────────────────
-function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
+interface VideoCardProps {
+  video: Video;
+  query?: string;
+  selectionMode?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
+}
+
+function VideoCard({
+  video,
+  query = '',
+  selectionMode = false,
+  selected = false,
+  onToggleSelect,
+}: VideoCardProps) {
   const titleHref = video.source_type === 'dynamous' ? (video.lesson_url ?? video.url) : video.url;
 
   return (
@@ -42,6 +56,19 @@ function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
       onMouseEnter={(e) => e.currentTarget.classList.add('video-card-hover')}
       onMouseLeave={(e) => e.currentTarget.classList.remove('video-card-hover')}
     >
+      {/* Checkbox in selection mode */}
+      {selectionMode && (
+        <label className="flex items-center gap-2 mb-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect?.(video.id)}
+            className="accent-blue-500"
+          />
+          <span className="text-xs text-slate-400">Select for scoped chat</span>
+        </label>
+      )}
+
       {/* Title */}
       {titleHref ? (
         <a
@@ -106,6 +133,10 @@ function VideoCard({ video, query = '' }: { video: Video; query?: string }) {
 interface VideoExplorerProps {
   isOpen: boolean;
   onClose: () => void;
+  selectionMode?: boolean;
+  selectedIds?: string[];
+  onToggleSelect?: (id: string) => void;
+  onConfirmSelection?: () => void;
 }
 
 const INGEST_FIELDS = [
@@ -125,7 +156,14 @@ const INGEST_FIELDS = [
   },
 ] as const;
 
-export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
+export function VideoExplorer({
+  isOpen,
+  onClose,
+  selectionMode = false,
+  selectedIds = [],
+  onToggleSelect,
+  onConfirmSelection,
+}: VideoExplorerProps) {
   const { user } = useAuth();
   const [videos, setVideos] = useState<Video[]>([]);
   const [loading, setLoading] = useState(false);
@@ -145,6 +183,10 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
   const closeDialog = () => {
     setIngestOpen(false);
     setIngestError(null);
+  };
+
+  const handleToggleSelect = (id: string) => {
+    onToggleSelect?.(id);
   };
 
   const fetchVideos = useCallback(async () => {
@@ -238,7 +280,9 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-white/10 flex-shrink-0">
           <div>
-            <h2 className="m-0 text-base font-semibold text-slate-100">Video Library</h2>
+            <h2 className="m-0 text-base font-semibold text-slate-100">
+              {selectionMode ? 'Choose Videos' : 'Video Library'}
+            </h2>
             {!loading && videos.length > 0 && (
               <p className="mt-0.5 text-xs text-slate-400">
                 {q
@@ -246,10 +290,15 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
                   : `${videos.length} videos in knowledge base`}
               </p>
             )}
+            {selectionMode && (
+              <p className="mt-0.5 text-xs text-blue-400">
+                {selectedIds.length} video{selectedIds.length !== 1 ? 's' : ''} selected
+              </p>
+            )}
           </div>
           <button
             onClick={onClose}
-            aria-label="Close video library"
+            aria-label={selectionMode ? 'Close video picker' : 'Close video library'}
             className="bg-transparent border border-white/10 rounded-lg text-slate-400 cursor-pointer p-2 flex items-center justify-center transition-colors duration-150 mr-2 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
             onMouseEnter={(e) => {
               e.currentTarget.classList.remove('text-slate-400', 'bg-transparent');
@@ -273,13 +322,23 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
               <line x1="11" y1="3" x2="3" y2="11" />
             </svg>
           </button>
-          {user?.is_admin && (
+          {!selectionMode && user?.is_admin && (
             <button
               onClick={() => setIngestOpen(true)}
               className="px-3 py-1.5 bg-blue-500 border-none rounded-md text-white text-sm cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
               title="Add new video"
             >
               + Add Video
+            </button>
+          )}
+          {selectionMode && (
+            <button
+              onClick={onConfirmSelection}
+              disabled={selectedIds.length === 0}
+              className="px-3 py-1.5 bg-blue-500 border-none rounded-md text-white text-sm cursor-pointer disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+              title="Start scoped chat"
+            >
+              Start scoped chat
             </button>
           )}
         </div>
@@ -350,7 +409,14 @@ export function VideoExplorer({ isOpen, onClose }: VideoExplorerProps) {
           {!loading &&
             !error &&
             filteredVideos.map((video) => (
-              <VideoCard key={video.id} video={video} query={debouncedQuery} />
+              <VideoCard
+                key={video.id}
+                video={video}
+                query={debouncedQuery}
+                selectionMode={selectionMode}
+                selected={selectedIds.includes(video.id)}
+                onToggleSelect={handleToggleSelect}
+              />
             ))}
         </div>
 

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,7 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  video_filter?: string[] | null;
 }
 
 export interface Citation {
@@ -146,8 +147,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const getConversations = () => request<Conversation[]>('/conversations');
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
-export const createConversation = () =>
-  request<Conversation>('/conversations', { method: 'POST', body: '{}' });
+export const createConversation = (videoFilter?: string[]) =>
+  request<Conversation>('/conversations', {
+    method: 'POST',
+    body: JSON.stringify(videoFilter && videoFilter.length ? { video_filter: videoFilter } : {}),
+  });
 export const getConversation = (id: string) =>
   request<ConversationWithMessages>(`/conversations/${id}`);
 export const deleteConversation = (id: string) =>


### PR DESCRIPTION
Fixes #279

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `888cd9ce-ea5b-4d3f-9439-4d9d46e8d038`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.