### PR TITLE
[bench-KO] impl: scope a conversation to specific videos (#279)

### DIFF
--- a/app/backend/alembic/versions/0006_add_scoped_video_ids.py
+++ b/app/backend/alembic/versions/0006_add_scoped_video_ids.py
@@ -1,0 +1,37 @@
+"""Add scoped_video_ids column to conversations (issue #279).
+
+Lets a conversation be restricted to a user-selected subset of videos. When
+`scoped_video_ids` is non-null, retrieval (keyword + vector) only sees chunks
+whose `video_id` is in the list; NULL preserves the existing "search
+everything" behavior. Stored as TEXT[] because video ids are plain text UUIDs.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Nullable with no default — NULL means "no scope set" (search everything),
+    # which is the correct in-place upgrade for every existing conversation.
+    op.execute(
+        """
+        ALTER TABLE conversations
+        ADD COLUMN IF NOT EXISTS scoped_video_ids TEXT[]
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS scoped_video_ids")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -253,6 +253,7 @@ async def keyword_search(
     top_k: int,
     language: str = "english",
     allowed_source_types: list[str] | None = None,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
@@ -265,6 +266,9 @@ async def keyword_search(
             this list are excluded. Defaults to ['youtube'] which is the
             backwards-compatible behavior for callers that don't yet know
             about Dynamous content (issue #147).
+        allowed_video_ids: Conversation scope filter (issue #279) — when
+            non-null, only chunks whose video_id is in this list are returned.
+            ``None`` (the default) means no scope is set: search every video.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -280,12 +284,14 @@ async def keyword_search(
             FROM chunks
             WHERE search_vector @@ plainto_tsquery($1)
               AND source_type = ANY($3::text[])
+              AND ($4::text[] IS NULL OR video_id = ANY($4::text[]))
             ORDER BY rank DESC
             LIMIT $2
             """,
             query,
             top_k,
             allowed_source_types,
+            allowed_video_ids,
         )
     return [dict(r) for r in rows]
 
@@ -294,6 +300,7 @@ async def vector_search_pg(
     query_embedding: list[float],
     top_k: int,
     allowed_source_types: list[str] | None = None,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
@@ -311,6 +318,9 @@ async def vector_search_pg(
             compatibility (issue #147). The pool's `hnsw.iterative_scan =
             relaxed_order` setting (see db/postgres.py) keeps the HNSW index
             usable under this filter.
+        allowed_video_ids: Conversation scope filter (issue #279) — when
+            non-null, only chunks whose video_id is in this list are returned.
+            ``None`` (the default) means no scope is set: search every video.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -326,12 +336,14 @@ async def vector_search_pg(
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
             WHERE source_type = ANY($3::text[])
+              AND ($4::text[] IS NULL OR video_id = ANY($4::text[]))
             ORDER BY distance
             LIMIT $2
             """,
             embedding_json,
             top_k,
             allowed_source_types,
+            allowed_video_ids,
         )
     return [dict(r) for r in rows]
 
@@ -415,18 +427,24 @@ async def replace_chunks_for_video(
 # ---------------------------------------------------------------------------
 
 
-async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict:
+async def create_conversation(
+    *,
+    user_id: str,
+    title: str = "New Conversation",
+    scoped_video_ids: list[str] | None = None,
+) -> dict:
     conv_id = _new_id()
     now = _now()
     async with _acquire() as conn:
         await conn.execute(
             """
-            INSERT INTO conversations (id, user_id, title, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO conversations (id, user_id, title, scoped_video_ids, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
             """,
             conv_id,
             user_id,
             title,
+            scoped_video_ids,
             now,
             now,
         )
@@ -434,6 +452,7 @@ async def create_conversation(*, user_id: str, title: str = "New Conversation") 
         "id": conv_id,
         "user_id": user_id,
         "title": title,
+        "scoped_video_ids": scoped_video_ids,
         "created_at": now,
         "updated_at": now,
     }
@@ -475,6 +494,27 @@ async def update_conversation_title(conv_id: str, user_id: str, title: str) -> b
         result = await conn.execute(
             "UPDATE conversations SET title = $1, updated_at = $2 WHERE id = $3 AND user_id = $4",
             title,
+            _now(),
+            conv_id,
+            user_id,
+        )
+        return result != "UPDATE 0"  # type: ignore[no-any-return]
+
+
+async def update_conversation_scope(
+    conv_id: str, user_id: str, scoped_video_ids: list[str] | None
+) -> bool:
+    """Set (or clear) the video scope for a conversation.
+
+    Passing ``None`` clears the scope (search everything); a list restricts
+    retrieval to those video ids. Returns False if the conversation does not
+    belong to the user.
+    """
+    async with _acquire() as conn:
+        result = await conn.execute(
+            "UPDATE conversations SET scoped_video_ids = $1, updated_at = $2 "
+            "WHERE id = $3 AND user_id = $4",
+            scoped_video_ids,
             _now(),
             conv_id,
             user_id,

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -40,6 +40,7 @@ async def retrieve_hybrid(
     query_embedding: list[float],
     top_k: int = 5,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -52,6 +53,10 @@ async def retrieve_hybrid(
             = 'dynamous'`) is included alongside the default YouTube content.
             Non-members see YouTube chunks only. The filter is applied at the
             SQL layer — non-member retrieval never touches Dynamous chunks.
+        allowed_video_ids: Conversation scope filter (issue #279) — when
+            non-null, both keyword and vector search only return chunks whose
+            video_id is in this list. ``None`` means no scope: search all
+            videos (the default, today's behavior).
 
     Returns:
         A list of dicts (length <= top_k), each containing:
@@ -88,11 +93,13 @@ async def retrieve_hybrid(
         top_k=fetch_k,
         language=KEYWORD_LANGUAGE,
         allowed_source_types=allowed_source_types,
+        allowed_video_ids=allowed_video_ids,
     )
     vector_task = repository.vector_search_pg(
         query_embedding,
         top_k=fetch_k,
         allowed_source_types=allowed_source_types,
+        allowed_video_ids=allowed_video_ids,
     )
 
     keyword_hits, vector_hits = await keyword_task, await vector_task

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -410,8 +410,13 @@ async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Hybrid (keyword + semantic via RRF) search."""
+    """Hybrid (keyword + semantic via RRF) search.
+
+    ``allowed_video_ids`` scopes retrieval to a conversation's selected videos
+    (issue #279); ``None`` searches the whole library.
+    """
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
     from backend.rag.retriever_hybrid import retrieve_hybrid
 
@@ -425,7 +430,13 @@ async def execute_search_hybrid(
 
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
+        chunks = await retrieve_hybrid(
+            query,
+            embedding,
+            top_k=top_k,
+            is_member=is_member,
+            allowed_video_ids=allowed_video_ids,
+        )
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -439,8 +450,13 @@ async def execute_search_hybrid(
 async def execute_search_keyword(
     raw_arguments: str | dict,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Keyword-only (tsvector FTS) search."""
+    """Keyword-only (tsvector FTS) search.
+
+    ``allowed_video_ids`` scopes retrieval to a conversation's selected videos
+    (issue #279); ``None`` searches the whole library.
+    """
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
 
     args = _parse_args(raw_arguments)
@@ -459,6 +475,7 @@ async def execute_search_keyword(
             top_k=top_k,
             language=KEYWORD_LANGUAGE,
             allowed_source_types=allowed,
+            allowed_video_ids=allowed_video_ids,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -475,8 +492,13 @@ async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Semantic-only (pgvector cosine) search."""
+    """Semantic-only (pgvector cosine) search.
+
+    ``allowed_video_ids`` scopes retrieval to a conversation's selected videos
+    (issue #279); ``None`` searches the whole library.
+    """
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
 
     args = _parse_args(raw_arguments)
@@ -492,7 +514,10 @@ async def execute_search_semantic(
     try:
         embedding = await _embed_query(query, embedding_cache)
         raw = await repository.vector_search_pg(
-            embedding, top_k=top_k, allowed_source_types=allowed
+            embedding,
+            top_k=top_k,
+            allowed_source_types=allowed,
+            allowed_video_ids=allowed_video_ids,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -603,6 +628,7 @@ async def execute_tool(
     video_id_whitelist: set[str] | None = None,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Dispatch by tool name. Unknown names return an error dict so the
     model sees the refusal and stops calling.
@@ -612,16 +638,29 @@ async def execute_tool(
 
     ``is_member`` controls retrieval ACL: True surfaces both YouTube and
     Dynamous (paid) chunks; False sees YouTube only.
+
+    ``allowed_video_ids`` is the conversation scope (issue #279): when non-null,
+    the search tools only return chunks from those videos. ``None`` searches
+    the whole library. The transcript tool ignores it — the video_id_whitelist
+    already guards that path.
     """
     if name == "search_videos":
         return await execute_search_hybrid(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            allowed_video_ids=allowed_video_ids,
         )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments, is_member=is_member)
+        return await execute_search_keyword(
+            raw_arguments, is_member=is_member, allowed_video_ids=allowed_video_ids
+        )
     if name == "semantic_search_videos":
         return await execute_search_semantic(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            allowed_video_ids=allowed_video_ids,
         )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -19,10 +19,19 @@ router = APIRouter()
 
 class ConversationCreate(BaseModel):
     title: str = "New Conversation"
+    # Optional video scope (issue #279). None/absent = search the whole library;
+    # a list restricts this conversation's retrieval to those video ids.
+    scoped_video_ids: list[str] | None = None
 
 
 class ConversationRename(BaseModel):
     title: str
+
+
+class ConversationScope(BaseModel):
+    # None clears the scope (search everything); a list restricts retrieval to
+    # the given video ids. An empty list is allowed but yields no results.
+    scoped_video_ids: list[str] | None = None
 
 
 @router.get("/conversations")
@@ -37,9 +46,11 @@ async def create_conversation(
 ):
     """Create a new empty conversation. Body is optional; defaults to title='New Conversation'."""
     title = body.title if body else "New Conversation"
+    scoped_video_ids = body.scoped_video_ids if body else None
     return await repository.create_conversation(
         user_id=str(current_user["id"]),
         title=title,
+        scoped_video_ids=scoped_video_ids,
     )
 
 
@@ -92,6 +103,27 @@ async def rename_conversation(
         raise HTTPException(status_code=404, detail="Conversation not found")
     conv = await repository.get_conversation(conv_id, user_id=str(current_user["id"]))
     return conv
+
+
+@router.patch("/conversations/{conv_id}/scope")
+async def update_conversation_scope(
+    conv_id: str,
+    body: ConversationScope,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Set or clear the video scope for a conversation (issue #279).
+
+    Once set, the assistant's answers and citations in this conversation only
+    draw from the chosen videos. Pass `scoped_video_ids: null` to clear the
+    scope and go back to searching the whole library.
+    """
+    user_id = str(current_user["id"])
+    updated = await repository.update_conversation_scope(
+        conv_id, user_id=user_id, scoped_video_ids=body.scoped_video_ids
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return await repository.get_conversation(conv_id, user_id=user_id)
 
 
 @router.get("/videos")

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -80,6 +80,11 @@ async def create_message(
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    # Conversation scope (issue #279): if the user restricted this conversation
+    # to a subset of videos, every search tool call below only sees chunks from
+    # those videos. NULL/absent means no scope — search the whole library.
+    scoped_video_ids: list[str] | None = conv.get("scoped_video_ids")
+
     # 2. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1).
     #    Must run BEFORE any LLM or DB write so a rate-limited user cannot
     #    consume OpenRouter budget or leave an orphan user-message row. The
@@ -155,6 +160,7 @@ async def create_message(
                 video_id_whitelist=whitelist,
                 embedding_cache=embedding_cache,
                 is_member=is_member_for_turn,
+                allowed_video_ids=scoped_video_ids,
             )
             if result.get("ok") and result.get("chunks"):
                 tool_chunks_acc.extend(result["chunks"])

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -117,7 +117,12 @@ async def _post_message(*, answer_tokens: list[str], retrieved_chunks: list[dict
         yield "data: [DONE]\n\n"
 
     async def mock_execute_tool(
-        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        name,
+        raw_args,
+        video_id_whitelist=None,
+        embedding_cache=None,
+        is_member=False,
+        allowed_video_ids=None,
     ):
         return {"ok": True, "text": "ctx", "chunks": retrieved_chunks}
 

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -152,10 +152,17 @@ class TestRetrieveHybrid:
 
             # Verify correct arguments passed (over-fetch factor applied)
             mock_kw.assert_called_once_with(
-                "test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"]
+                "test query",
+                top_k=fetch_k,
+                language="english",
+                allowed_source_types=["youtube"],
+                allowed_video_ids=None,
             )
             mock_vec.assert_called_once_with(
-                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"]
+                [0.1] * 1536,
+                top_k=fetch_k,
+                allowed_source_types=["youtube"],
+                allowed_video_ids=None,
             )
 
             # Verify result shape has all required citation fields

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -767,7 +767,12 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            allowed_video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -871,7 +876,12 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            allowed_video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -976,7 +986,12 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            allowed_video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -1091,7 +1106,12 @@ class TestChunkExpansionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            allowed_video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 

--- a/app/backend/tests/test_tools.py
+++ b/app/backend/tests/test_tools.py
@@ -96,7 +96,7 @@ _FAKE_CHUNKS = [
 
 @pytest.mark.asyncio
 async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
-    async def fake_retrieve(_q, _emb, top_k=5, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, allowed_video_ids=None):
         assert top_k == 10
         return _FAKE_CHUNKS
 
@@ -112,7 +112,9 @@ async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None
+    ):
         return [
             {
                 "id": "c1",
@@ -140,7 +142,7 @@ async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, allowed_video_ids=None):
         return [
             {
                 "id": "c2",
@@ -169,7 +171,9 @@ async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None
+    ):
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -257,7 +261,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
         for i in range(6)
     ]
 
-    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, allowed_video_ids=None):
         return many_chunks
 
     monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
@@ -273,7 +277,9 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
 async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_keyword."""
 
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None
+    ):
         return [
             {
                 "id": f"c{i}",
@@ -303,7 +309,7 @@ async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> Non
 async def test_execute_search_semantic_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_semantic."""
 
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, allowed_video_ids=None):
         return [
             {
                 "id": f"c{i}",

--- a/app/backend/tests/test_video_scope.py
+++ b/app/backend/tests/test_video_scope.py
@@ -1,0 +1,220 @@
+"""Tests for conversation video-scoping (issue #279).
+
+A conversation can be restricted to a subset of videos. When a scope is set,
+both keyword and vector search must filter chunks to `video_id = ANY(scope)`;
+when it's None, retrieval searches the whole library (today's behavior).
+
+The test DB is mocked (no real Postgres in this environment — see
+test_repository_hybrid_search.py for the same pattern), so these assert SQL
+construction, parameter binding, and pass-through wiring rather than real
+query results.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.db import repository
+from backend.rag import tools as tools_module
+
+
+def _mock_acquire(mock_conn: AsyncMock) -> AsyncMock:
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+    return mock_acquire
+
+
+# ---------------------------------------------------------------------------
+# Repository: keyword_search / vector_search_pg scope filter
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordSearchScope:
+    async def test_scope_filter_in_sql_and_bound_as_param4(self):
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            await repository.keyword_search("hello", top_k=5, allowed_video_ids=["vid-a", "vid-b"])
+        sql, *args = mock_conn.fetch.call_args[0]
+        # The scope guard is injected and parameterized as $4.
+        assert "$4::text[] IS NULL OR video_id = ANY($4::text[])" in sql
+        # args: (query, top_k, allowed_source_types, allowed_video_ids)
+        assert args[3] == ["vid-a", "vid-b"]
+
+    async def test_no_scope_binds_none(self):
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            await repository.keyword_search("hello", top_k=5)
+        # Positional args: (sql, query/embedding, top_k, source_types, video_ids).
+        # $4 is None → the SQL guard short-circuits to "search everything".
+        assert mock_conn.fetch.call_args[0][4] is None
+
+
+class TestVectorSearchScope:
+    async def test_scope_filter_in_sql_and_bound_as_param4(self):
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5, allowed_video_ids=["vid-a"])
+        sql, *args = mock_conn.fetch.call_args[0]
+        assert "$4::text[] IS NULL OR video_id = ANY($4::text[])" in sql
+        # args: (embedding_json, top_k, allowed_source_types, allowed_video_ids)
+        assert args[3] == ["vid-a"]
+
+    async def test_no_scope_binds_none(self):
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5)
+        assert mock_conn.fetch.call_args[0][4] is None
+
+
+# ---------------------------------------------------------------------------
+# Repository: create_conversation + update_conversation_scope
+# ---------------------------------------------------------------------------
+
+
+class TestConversationScopePersistence:
+    async def test_create_conversation_inserts_scope(self):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value=None)
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            result = await repository.create_conversation(
+                user_id="u1", title="t", scoped_video_ids=["vid-a"]
+            )
+        sql, *args = mock_conn.execute.call_args[0]
+        assert "scoped_video_ids" in sql
+        # The scope list is bound and echoed back in the returned dict.
+        assert ["vid-a"] in args
+        assert result["scoped_video_ids"] == ["vid-a"]
+
+    async def test_create_conversation_defaults_scope_none(self):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value=None)
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            result = await repository.create_conversation(user_id="u1")
+        assert result["scoped_video_ids"] is None
+
+    async def test_update_scope_issues_scoped_update(self):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="UPDATE 1")
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            ok = await repository.update_conversation_scope(
+                "c1", user_id="u1", scoped_video_ids=["vid-a", "vid-b"]
+            )
+        assert ok is True
+        sql, *args = mock_conn.execute.call_args[0]
+        assert "UPDATE conversations SET scoped_video_ids" in sql
+        # Owner scoping is preserved — user_id is part of the WHERE clause.
+        assert "user_id" in sql
+        assert ["vid-a", "vid-b"] in args
+        assert "c1" in args
+        assert "u1" in args
+
+    async def test_update_scope_clear_passes_none(self):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="UPDATE 1")
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            await repository.update_conversation_scope("c1", user_id="u1", scoped_video_ids=None)
+        args = mock_conn.execute.call_args[0]
+        assert None in args
+
+    async def test_update_scope_returns_false_when_not_owner(self):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="UPDATE 0")
+        with patch.object(repository, "_acquire", return_value=_mock_acquire(mock_conn)):
+            ok = await repository.update_conversation_scope(
+                "c1", user_id="other", scoped_video_ids=["vid-a"]
+            )
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Tools: search executors forward the scope to the repository / retriever
+# ---------------------------------------------------------------------------
+
+
+class TestToolsForwardScope:
+    async def test_hybrid_forwards_scope_to_retriever(self):
+        scope = ["vid-a", "vid-b"]
+        with (
+            patch.object(tools_module, "_embed_query", AsyncMock(return_value=[0.1] * 4)),
+            patch(
+                "backend.rag.retriever_hybrid.retrieve_hybrid",
+                AsyncMock(return_value=[]),
+            ) as mock_retrieve,
+        ):
+            result = await tools_module.execute_search_hybrid(
+                {"query": "q"}, allowed_video_ids=scope
+            )
+        assert result["ok"] is True
+        assert mock_retrieve.call_args.kwargs["allowed_video_ids"] == scope
+
+    async def test_keyword_forwards_scope_to_repository(self):
+        scope = ["vid-a"]
+        with (
+            patch.object(
+                tools_module.repository, "keyword_search", AsyncMock(return_value=[])
+            ) as mock_kw,
+            patch.object(tools_module, "_hydrate_chunks", AsyncMock(return_value=[])),
+        ):
+            result = await tools_module.execute_search_keyword(
+                {"query": "q"}, allowed_video_ids=scope
+            )
+        assert result["ok"] is True
+        assert mock_kw.call_args.kwargs["allowed_video_ids"] == scope
+
+    async def test_semantic_forwards_scope_to_repository(self):
+        scope = ["vid-a"]
+        with (
+            patch.object(tools_module, "_embed_query", AsyncMock(return_value=[0.1] * 4)),
+            patch.object(
+                tools_module.repository, "vector_search_pg", AsyncMock(return_value=[])
+            ) as mock_vec,
+            patch.object(tools_module, "_hydrate_chunks", AsyncMock(return_value=[])),
+        ):
+            result = await tools_module.execute_search_semantic(
+                {"query": "q"}, allowed_video_ids=scope
+            )
+        assert result["ok"] is True
+        assert mock_vec.call_args.kwargs["allowed_video_ids"] == scope
+
+    async def test_dispatcher_forwards_scope(self):
+        scope = ["vid-a"]
+        with patch.object(
+            tools_module, "execute_search_hybrid", AsyncMock(return_value={"ok": True})
+        ) as mock_hybrid:
+            await tools_module.execute_tool(
+                "search_videos", {"query": "q"}, allowed_video_ids=scope
+            )
+        assert mock_hybrid.call_args.kwargs["allowed_video_ids"] == scope
+
+
+# ---------------------------------------------------------------------------
+# Retriever: retrieve_hybrid forwards scope to both search functions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retrieve_hybrid_forwards_scope_to_both_searches(monkeypatch):
+    from backend import config
+    from backend.rag import retriever_hybrid
+
+    # retrieve_hybrid does a local `from backend.config import DATABASE_URL`,
+    # so the truthiness check reads backend.config at call time. conftest
+    # already sets a test URL, but pin it here so the test is self-contained.
+    monkeypatch.setattr(config, "DATABASE_URL", "postgresql://test", raising=False)
+    mock_kw = AsyncMock(return_value=[])
+    mock_vec = AsyncMock(return_value=[])
+    monkeypatch.setattr(retriever_hybrid.repository, "keyword_search", mock_kw)
+    monkeypatch.setattr(retriever_hybrid.repository, "vector_search_pg", mock_vec)
+
+    scope = ["vid-a", "vid-b"]
+    await retriever_hybrid.retrieve_hybrid("q", [0.1] * 4, top_k=5, allowed_video_ids=scope)
+
+    assert mock_kw.call_args.kwargs["allowed_video_ids"] == scope
+    assert mock_vec.call_args.kwargs["allowed_video_ids"] == scope

--- a/app/frontend/src/__tests__/ChatArea-scope.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-scope.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the conversation video-scope UI in ChatArea (issue #279).
+ *
+ * - The Scope button reflects the conversation's current scope ("Scope: All"
+ *   vs "Scope: N").
+ * - Opening the picker, selecting videos, and saving calls
+ *   updateConversationScope with the chosen ids.
+ * - Clearing the selection saves `null` (search everything).
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArea } from '../components/ChatArea';
+import type { Conversation, Video } from '../lib/api';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// Mutable conversation so each test can set its starting scope.
+let mockConversation: Conversation = {
+  id: 'conv-1',
+  title: 'Test Chat',
+  created_at: '',
+  updated_at: '',
+  scoped_video_ids: null,
+};
+const setConversation = vi.fn();
+
+vi.mock('../hooks/useMessages', () => ({
+  useMessages: () => ({
+    messages: [],
+    setMessages: vi.fn(),
+    loading: false,
+    error: null,
+    notFound: false,
+    conversation: mockConversation,
+    setConversation,
+  }),
+}));
+
+vi.mock('../hooks/useStreamingResponse', () => ({
+  useStreamingResponse: () => ({
+    streamingContent: '',
+    streamingSources: [],
+    streamingStatus: undefined,
+    isStreaming: false,
+    startStream: vi.fn(),
+    abortStream: vi.fn(),
+  }),
+}));
+
+const addToast = vi.fn();
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ addToast, removeToast: vi.fn() }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user', email: 'test@test.com', is_admin: false },
+    refresh: vi.fn(),
+  }),
+}));
+
+const videos: Video[] = [
+  { id: 'v1', title: 'Subagents 101', description: '', url: '', created_at: '' },
+  { id: 'v2', title: 'Agent Teams', description: '', url: '', created_at: '' },
+];
+
+const getVideos = vi.fn(async () => videos);
+const updateConversationScope = vi.fn(async (_id: string, ids: string[] | null) => ({
+  ...mockConversation,
+  scoped_video_ids: ids,
+}));
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    getVideos: (...args: unknown[]) => getVideos(...(args as [])),
+    updateConversationScope: (id: string, ids: string[] | null) =>
+      updateConversationScope(id, ids),
+  };
+});
+
+describe('ChatArea conversation scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    mockConversation = {
+      id: 'conv-1',
+      title: 'Test Chat',
+      created_at: '',
+      updated_at: '',
+      scoped_video_ids: null,
+    };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows "Scope: All" when no scope is set', () => {
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Scope: All')).toBeInTheDocument();
+  });
+
+  it('shows the scoped count when a scope is set', () => {
+    mockConversation.scoped_video_ids = ['v1', 'v2'];
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Scope: 2')).toBeInTheDocument();
+  });
+
+  it('opens the picker, selects a video, and saves the scope', async () => {
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Scope: All'));
+
+    // Modal loads videos
+    await waitFor(() => {
+      expect(screen.getByText('Subagents 101')).toBeInTheDocument();
+    });
+
+    // Check the first video then save.
+    fireEvent.click(screen.getByText('Subagents 101'));
+    fireEvent.click(screen.getByText('Save scope'));
+
+    await waitFor(() => {
+      expect(updateConversationScope).toHaveBeenCalledWith('conv-1', ['v1']);
+    });
+  });
+
+  it('saves null when the user clears the selection', async () => {
+    mockConversation.scoped_video_ids = ['v1'];
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Scope: 1'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Subagents 101')).toBeInTheDocument();
+    });
+
+    // Pre-checked v1 → clear scope → save.
+    fireEvent.click(screen.getByText('Clear scope'));
+    fireEvent.click(screen.getByText('Save scope'));
+
+    await waitFor(() => {
+      expect(updateConversationScope).toHaveBeenCalledWith('conv-1', null);
+    });
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -5,11 +5,12 @@ import { useMessages } from '../hooks/useMessages';
 import { useStreamingResponse } from '../hooks/useStreamingResponse';
 import { useToast } from '../hooks/useToast';
 import type { Citation, Message as MessageType } from '../lib/api';
-import { RateLimitError, createConversation } from '../lib/api';
+import { RateLimitError, createConversation, updateConversationScope } from '../lib/api';
 import { exportConversationAsMarkdown } from '../lib/exportMarkdown';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { CitationModal } from './CitationModal';
 import { Message } from './Message';
+import { ScopePickerModal } from './ScopePickerModal';
 
 function formatResetTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
@@ -292,9 +293,8 @@ interface ConvLocationState {
 export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaProps) {
   const navigate = useNavigate();
   const location = useLocation() as Location & { state: ConvLocationState | null };
-  const { messages, setMessages, loading, error, notFound, conversation } = useMessages(
-    conversationId || null,
-  );
+  const { messages, setMessages, loading, error, notFound, conversation, setConversation } =
+    useMessages(conversationId || null);
   const {
     streamingContent,
     streamingSources,
@@ -325,6 +325,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const pendingUserMsgIdRef = useRef<string | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
+  // Scope picker modal state (issue #279)
+  const [scopeModalOpen, setScopeModalOpen] = useState(false);
+  const [savingScope, setSavingScope] = useState(false);
 
   // ── Auto-scroll logic ──
   // Defer scroll to the next paint cycle so streaming DOM updates are applied first.
@@ -602,6 +605,37 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const showEmptyInConversation =
     messages.length === 0 && !inlineError && !isStreaming && !location.state?.initialMessage;
 
+  // ── Scope save handler ──
+  // Persist the chosen scope, then update local conversation state so the
+  // badge reflects it immediately and subsequent sends respect it.
+  const handleScopeConfirm = useCallback(
+    async (videoIds: string[] | null) => {
+      if (!conversationId) return;
+      setSavingScope(true);
+      try {
+        const updated = await updateConversationScope(conversationId, videoIds);
+        setConversation((prev) =>
+          prev ? { ...prev, scoped_video_ids: updated.scoped_video_ids ?? null } : prev,
+        );
+        setScopeModalOpen(false);
+        addToast(
+          videoIds && videoIds.length > 0
+            ? `Scoped to ${videoIds.length} video${videoIds.length === 1 ? '' : 's'}.`
+            : 'Scope cleared — searching all videos.',
+          'success',
+        );
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Failed to update scope';
+        addToast(msg, 'error');
+      } finally {
+        setSavingScope(false);
+      }
+    },
+    [conversationId, setConversation, addToast],
+  );
+
+  const scopeCount = conversation?.scoped_video_ids?.length ?? 0;
+
   const handleExport = useCallback(() => {
     try {
       if (conversation) {
@@ -638,6 +672,49 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           position: 'relative',
         }}
       >
+        {/* ── Scope button (visible when conversation is active) ── */}
+        {conversation && (
+          <button
+            onClick={() => setScopeModalOpen(true)}
+            title={
+              scopeCount > 0
+                ? `Conversation scoped to ${scopeCount} video${scopeCount === 1 ? '' : 's'}`
+                : 'Scope this conversation to specific videos'
+            }
+            style={{
+              position: 'absolute',
+              top: 12,
+              right: 110,
+              background: scopeCount > 0 ? 'rgba(59,130,246,0.15)' : '#1e293b',
+              border: `1px solid ${scopeCount > 0 ? 'rgba(59,130,246,0.4)' : 'rgba(255,255,255,0.08)'}`,
+              borderRadius: 7,
+              color: scopeCount > 0 ? '#93c5fd' : '#94a3b8',
+              cursor: 'pointer',
+              padding: '5px 8px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              fontSize: 12,
+              zIndex: 5,
+              transition: 'background 0.15s, color 0.15s',
+            }}
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 13 13"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M1,2 H12 L8,7 V11 L5,12 V7 Z" />
+            </svg>
+            {scopeCount > 0 ? `Scope: ${scopeCount}` : 'Scope: All'}
+          </button>
+        )}
+
         {/* ── Export button (visible when conversation is active) ── */}
         {conversation && messages.length > 0 && (
           <button
@@ -778,6 +855,17 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       {/* ── Citation modal ── */}
       {selectedCitation && (
         <CitationModal citation={selectedCitation} onClose={() => setSelectedCitation(null)} />
+      )}
+
+      {/* ── Scope picker modal ── */}
+      {scopeModalOpen && (
+        <ScopePickerModal
+          currentScope={conversation?.scoped_video_ids ?? null}
+          onConfirm={handleScopeConfirm}
+          onCancel={() => {
+            if (!savingScope) setScopeModalOpen(false);
+          }}
+        />
       )}
     </div>
   );

--- a/app/frontend/src/components/ScopePickerModal.tsx
+++ b/app/frontend/src/components/ScopePickerModal.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type Video, getVideos } from '../lib/api';
+
+// ── Scope picker modal ────────────────────────────────────────────
+// Lets a user restrict a conversation to a subset of videos (issue #279).
+// `currentScope` is the conversation's existing scope (null = all videos);
+// pre-checks matching items. `onConfirm` receives the selected ids, or `null`
+// when the user clears the scope (no videos selected → search everything).
+interface ScopePickerModalProps {
+  currentScope: string[] | null;
+  onConfirm: (videoIds: string[] | null) => void;
+  onCancel: () => void;
+}
+
+export function ScopePickerModal({ currentScope, onConfirm, onCancel }: ScopePickerModalProps) {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set(currentScope ?? []));
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getVideos()
+      .then((data) => {
+        if (!cancelled) setVideos(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load videos');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const q = query.trim().toLowerCase();
+  const filtered = useMemo(
+    () =>
+      q
+        ? videos.filter((v) =>
+            [v.title, v.channel_title, v.description]
+              .filter(Boolean)
+              .join(' ')
+              .toLowerCase()
+              .includes(q),
+          )
+        : videos,
+    [videos, q],
+  );
+
+  const handleConfirm = () => {
+    // No selection → clear the scope (search everything). Otherwise restrict.
+    onConfirm(selected.size === 0 ? null : Array.from(selected));
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-label="Scope conversation to videos"
+        aria-modal="true"
+        className="bg-slate-800 border border-white/10 rounded-xl w-[460px] max-w-[calc(100vw-48px)] max-h-[80vh] flex flex-col shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between px-5 py-4 border-b border-white/10">
+          <div>
+            <h3 className="text-slate-100 text-base font-semibold m-0">Scope to videos</h3>
+            <p className="mt-1 text-xs text-slate-400 leading-relaxed">
+              The assistant will only answer using the selected videos. Select none to search the
+              whole library.
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            aria-label="Close"
+            className="bg-none border-none text-slate-400 cursor-pointer text-lg leading-none ml-3 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Search + selection summary */}
+        <div className="px-5 py-3 border-b border-white/10 flex items-center gap-3">
+          <input
+            type="search"
+            placeholder="Search videos…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="flex-1 p-2 bg-slate-900 border border-white/10 rounded-md text-slate-100 text-sm box-border outline-none focus:border-blue-500 transition-colors"
+            aria-label="Search videos"
+          />
+          <button
+            onClick={() => setSelected(new Set())}
+            disabled={selected.size === 0}
+            className="text-xs text-slate-400 whitespace-nowrap cursor-pointer bg-transparent border-none disabled:opacity-40 hover:text-slate-200"
+          >
+            Clear scope
+          </button>
+        </div>
+
+        {/* Video list */}
+        <div className="flex-1 overflow-y-auto px-5 py-3 flex flex-col gap-2">
+          {loading && <p className="text-slate-400 text-sm py-4 text-center">Loading videos…</p>}
+          {!loading && error && (
+            <p className="text-red-400 text-sm py-4 text-center">{error}</p>
+          )}
+          {!loading && !error && videos.length === 0 && (
+            <p className="text-slate-500 text-sm py-4 text-center">
+              No videos in the knowledge base yet.
+            </p>
+          )}
+          {!loading &&
+            !error &&
+            filtered.map((video) => {
+              const checked = selected.has(video.id);
+              return (
+                <label
+                  key={video.id}
+                  className="flex items-start gap-3 p-2.5 rounded-lg border border-white/10 bg-slate-900 cursor-pointer hover:border-blue-500/40 transition-colors"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggle(video.id)}
+                    className="mt-0.5 cursor-pointer accent-blue-500"
+                  />
+                  <span className="flex flex-col min-w-0">
+                    <span className="text-sm text-slate-100 leading-tight truncate">
+                      {video.title}
+                    </span>
+                    {video.channel_title && (
+                      <span className="text-xs text-slate-500 mt-0.5 truncate">
+                        {video.channel_title}
+                      </span>
+                    )}
+                  </span>
+                </label>
+              );
+            })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 py-4 border-t border-white/10">
+          <span className="text-xs text-slate-400">
+            {selected.size === 0 ? 'All videos' : `${selected.size} selected`}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={onCancel}
+              className="px-4 py-2 bg-transparent border border-white/20 rounded-md text-slate-300 text-sm cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              className="px-4 py-2 bg-blue-500 border-none rounded-md text-white text-sm cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            >
+              Save scope
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/hooks/useMessages.ts
+++ b/app/frontend/src/hooks/useMessages.ts
@@ -30,6 +30,7 @@ export function useMessages(conversationId: string | null) {
           title: data.title,
           created_at: data.created_at,
           updated_at: data.updated_at,
+          scoped_video_ids: data.scoped_video_ids ?? null,
         });
       })
       .catch((e) => {
@@ -43,5 +44,5 @@ export function useMessages(conversationId: string | null) {
       .finally(() => setLoading(false));
   }, [conversationId]);
 
-  return { messages, setMessages, loading, error, notFound, conversation };
+  return { messages, setMessages, loading, error, notFound, conversation, setConversation };
 }

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,12 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  /**
+   * Video scope (issue #279). `null` (or absent) means the conversation
+   * searches the whole library; a list restricts the assistant's answers and
+   * citations to those video ids for the rest of the conversation.
+   */
+  scoped_video_ids?: string[] | null;
 }
 
 export interface Citation {
@@ -146,8 +152,13 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const getConversations = () => request<Conversation[]>('/conversations');
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
-export const createConversation = () =>
-  request<Conversation>('/conversations', { method: 'POST', body: '{}' });
+export const createConversation = (scopedVideoIds?: string[] | null) =>
+  request<Conversation>('/conversations', {
+    method: 'POST',
+    body: JSON.stringify(
+      scopedVideoIds !== undefined ? { scoped_video_ids: scopedVideoIds } : {},
+    ),
+  });
 export const getConversation = (id: string) =>
   request<ConversationWithMessages>(`/conversations/${id}`);
 export const deleteConversation = (id: string) =>
@@ -156,6 +167,16 @@ export const renameConversation = (id: string, title: string) =>
   request<Conversation>(`/conversations/${id}`, {
     method: 'PATCH',
     body: JSON.stringify({ title }),
+  });
+/**
+ * Set or clear a conversation's video scope (issue #279). Pass `null` to clear
+ * the scope (search everything); pass a list to restrict retrieval + citations
+ * to those videos.
+ */
+export const updateConversationScope = (id: string, scopedVideoIds: string[] | null) =>
+  request<Conversation>(`/conversations/${id}/scope`, {
+    method: 'PATCH',
+    body: JSON.stringify({ scoped_video_ids: scopedVideoIds }),
   });
 
 // Videos


### PR DESCRIPTION
Fixes #279

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `0c157926-d88b-4eac-82ff-20c90106a2a1`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.