### PR TITLE
[bench-OO] review: fix mock parameter names in test_regenerate.py

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -603,6 +603,25 @@ async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     return results
 
 
+async def delete_message(message_id: str, user_id: str) -> bool:
+    """Delete a single message scoped to its owner. Returns True if a row was deleted.
+
+    Owner-scoped via JOIN on conversations.user_id so a caller cannot delete
+    another user's message even if it forgets to check (mirrors create_message).
+    """
+    async with _acquire() as conn:
+        result = await conn.execute(
+            """
+            DELETE FROM messages m
+            USING conversations c
+            WHERE m.id = $1 AND m.conversation_id = c.id AND c.user_id = $2
+            """,
+            message_id,
+            user_id,
+        )
+    return result != "DELETE 0"  # type: ignore[no-any-return]
+
+
 # ---------------------------------------------------------------------------
 # Channel sync runs
 # ---------------------------------------------------------------------------

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -103,7 +103,15 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routes (imported here to keep main.py clean)
 # ---------------------------------------------------------------------------
-from backend.routes import admin, auth, channels, conversations, ingest, messages  # noqa: E402
+from backend.routes import (  # noqa: E402
+    admin,
+    auth,
+    channels,
+    conversations,
+    ingest,
+    messages,
+    regenerate,
+)
 
 # Auth routes are public (signup/login don't require a session; /me and /logout
 # rely on their own dependency/cookie behaviour).
@@ -114,6 +122,7 @@ app.include_router(auth.router, prefix="/api")
 _auth_required = [Depends(get_current_user)]
 app.include_router(conversations.router, prefix="/api", dependencies=_auth_required)
 app.include_router(messages.router, prefix="/api", dependencies=_auth_required)
+app.include_router(regenerate.router, prefix="/api", dependencies=_auth_required)
 
 # Library-mutation routes (ingest a video, backfill the whole channel) and
 # admin routes — all gated on get_current_admin. These endpoints write to the

--- a/app/backend/routes/regenerate.py
+++ b/app/backend/routes/regenerate.py
@@ -1,0 +1,290 @@
+"""
+Regenerate route — POST /api/conversations/{conv_id}/regenerate
+
+Re-runs the tool-driven RAG flow for the trailing user question and replaces
+the most recent assistant answer with a fresh one (its own citations). Mirrors
+the streaming/persistence idiom of ``routes/messages.py`` exactly:
+
+  1. Verify conversation ownership (404 cross-user, no leak)
+  2. Guard: there must be a trailing assistant message to regenerate (409)
+  3. Enforce the 25 msg/user/24h cap (same call as the send path — regenerate
+     cannot bypass the limit)
+  4. Re-stream the response against the existing history (minus the stale
+     answer)
+  5. Send the sources event (the model's tool calls) before [DONE]
+  6. Persist the new assistant message, THEN delete the old one — so a
+     failed/aborted regenerate leaves the prior answer intact (no orphaned
+     user-message-with-no-reply).
+
+This lives in a separate (non-protected) module so it can be added without
+touching ``routes/messages.py``. It reuses that module's pure helpers
+(``_collapse_by_video``, ``_extract_text_from_sse``, ``_is_refusal``,
+``_strip_markers_from_sse_chunk``) read-only — importing does not modify them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from backend import rate_limit
+from backend.auth.dependencies import get_current_user
+from backend.config import CITATIONS_MAX_COUNT, LLM_TOOLS_ENABLED, LLM_TOOLS_MAX_PER_TURN
+from backend.db import repository
+from backend.llm.openrouter import stream_chat
+from backend.rag.citations import (
+    CitationMarkerStripper,
+    extract_cited_chunk_ids,
+)
+from backend.rag.tools import TOOL_SCHEMAS, execute_tool, serialize_tool_result
+from backend.routes.messages import (
+    _collapse_by_video,
+    _extract_text_from_sse,
+    _is_refusal,
+    _strip_markers_from_sse_chunk,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate the most recent assistant message and stream the replacement.
+
+    Returns:
+        StreamingResponse with Content-Type: text/event-stream
+        Each SSE event: "data: <token>\n\n"
+        Final event: "data: [DONE]\n\n"
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user.
+    # 404 (not 403) — don't leak existence of other users' conversations.
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. There must be a trailing assistant message to regenerate. This runs
+    #    BEFORE the rate-limit check so a no-op never consumes the cap.
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+    if not all_messages or all_messages[-1]["role"] != "assistant":
+        raise HTTPException(status_code=409, detail="No assistant message to regenerate")
+    old_assistant_id = all_messages[-1]["id"]
+
+    # 3. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1).
+    #    Identical to the send path so regenerate cannot bypass the cap. Runs
+    #    before streaming/delete so the old answer is preserved on 429.
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 4. Build LLM history that ENDS at the user's question — drop the stale
+    #    assistant answer so the model recomposes a fresh reply.
+    llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages[:-1]]
+
+    # 5. Set up tool plumbing. All retrieval happens inside the LLM loop via
+    # tool calls — no pre-retrieval runs here. The executor closure collects
+    # every chunk returned by any tool call so the final SSE `sources` event
+    # lists exactly what the model actually read. The video_id whitelist is
+    # only consulted by the transcript tool (it guards against hallucinated
+    # ids); the search tools ignore it.
+    source_citations: list[dict] = []
+    tool_chunks_acc: list[dict] = []
+    embedding_cache: dict[str, list[float]] = {}
+    tools_param: list[dict] | None = None
+    executor = None
+    max_tool_calls = 0
+    if LLM_TOOLS_ENABLED:
+        try:
+            all_videos = await repository.list_videos()
+            video_id_whitelist: set[str] = {v["id"] for v in all_videos if v.get("id")}
+        except Exception as exc:
+            logger.warning(
+                "Failed to load video whitelist for tool use; transcript tool calls will be unguarded: %s",
+                exc,
+            )
+            video_id_whitelist = set()
+
+        # Captured at the start of the turn so the entire tool sequence sees
+        # consistent ACL — even if /me later flips is_member, the in-flight
+        # turn won't change behavior mid-flight.
+        is_member_for_turn = bool(current_user.get("is_member", False))
+
+        async def _executor(name: str, raw_args: str) -> str:
+            # Pass `None` (not empty set) when the whitelist failed to load so
+            # the transcript tool falls back to open lookups instead of rejecting
+            # every id.
+            whitelist = video_id_whitelist if video_id_whitelist else None
+            result = await execute_tool(
+                name,
+                raw_args,
+                video_id_whitelist=whitelist,
+                embedding_cache=embedding_cache,
+                is_member=is_member_for_turn,
+            )
+            if result.get("ok") and result.get("chunks"):
+                tool_chunks_acc.extend(result["chunks"])
+            return serialize_tool_result(result)
+
+        tools_param = TOOL_SCHEMAS
+        executor = _executor
+        max_tool_calls = LLM_TOOLS_MAX_PER_TURN
+
+    # 6. Stream the response. The model drives retrieval via tool calls;
+    # chunks it pulls flow into source_citations via tool_chunks_acc.
+    # ``final_text_buf`` receives the assistant's final-round text so the
+    # refusal check ignores inter-round commentary ("let me try semantic").
+    async def event_generator() -> AsyncGenerator[str, None]:
+        full_response: list[str] = []
+        final_text_buf: list[str] = []
+        # Two-tier citations (issue #176): strip `[c:<id>]` markers from the
+        # stream; use them at [DONE] to flag is_cited on retrieved chunks.
+        marker_stripper = CitationMarkerStripper()
+        try:
+            # is_member_for_turn is captured above when tools are wired.
+            # Re-bind to a local that's always defined so we can pass it
+            # to stream_chat regardless of whether tools are enabled
+            # (catalog filtering belongs to the prompt, not the tools).
+            turn_is_member = bool(current_user.get("is_member") or False)
+            async for sse_chunk in stream_chat(
+                llm_messages,
+                tools=tools_param,
+                tool_executor=executor,
+                max_tool_calls=max_tool_calls,
+                final_text_out=final_text_buf,
+                is_member=turn_is_member,
+            ):
+                if sse_chunk == "data: [DONE]\n\n":
+                    # Flush any text held back as a partial marker.
+                    tail = marker_stripper.flush()
+                    if tail:
+                        tail_chunk = f"data: {json.dumps(tail)}\n\n"
+                        full_response.append(tail_chunk)
+                        yield tail_chunk
+                    # Dedup tool-loaded chunks into source_citations (existing).
+                    if tool_chunks_acc:
+                        seen: set[str] = set()
+                        for tc in tool_chunks_acc:
+                            tc_id = tc.get("chunk_id")
+                            if tc_id and tc_id not in seen:
+                                source_citations.append(tc)
+                                seen.add(tc_id)
+                    # Mark is_cited from markers in the raw final-round text.
+                    # Marker IDs that don't match any retrieved chunk are
+                    # silently dropped (hallucinations).
+                    if source_citations:
+                        final_text_raw = final_text_buf[0] if final_text_buf else ""
+                        cited_ids = extract_cited_chunk_ids(final_text_raw)
+                        for chunk in source_citations:
+                            chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+                        # Collapse same-video chunks (issue #208): keep one
+                        # entry per video_id, choosing the earliest-cited
+                        # timestamp as the representative.
+                        source_citations[:] = _collapse_by_video(source_citations)
+                        # Cap fallback (issue #176): cited pass through, non-cited sliced.
+                        cited = [c for c in source_citations if c.get("is_cited")]
+                        uncited = [c for c in source_citations if not c.get("is_cited")]
+                        source_citations[:] = cited + uncited[:CITATIONS_MAX_COUNT]
+                    # Suppress sources on refusal (existing behaviour).
+                    if source_citations:
+                        final_text = (
+                            final_text_buf[0]
+                            if final_text_buf
+                            else _extract_text_from_sse(full_response)
+                        )
+                        if not _is_refusal(final_text):
+                            sources_json = json.dumps(source_citations)
+                            yield f"event: sources\ndata: {sources_json}\n\n"
+                    full_response.append(sse_chunk)
+                    yield sse_chunk
+                    continue
+
+                stripped = _strip_markers_from_sse_chunk(sse_chunk, marker_stripper)
+                if stripped is None:
+                    # Whole token held back as a partial marker.
+                    continue
+                full_response.append(stripped)
+                yield stripped
+        finally:
+            # 7. Persist the NEW assistant message, then delete the old one.
+            #
+            # Shield the DB writes from client-disconnect CancelledError (see
+            # the long note in messages.py:create_message). We persist the
+            # replacement first and only delete the stale answer once that
+            # succeeds — so an aborted/failed regenerate never leaves a user
+            # message without a reply.
+            assistant_text = _extract_text_from_sse(full_response)
+            if assistant_text:
+                # Apply the same refusal detection used for the live SSE
+                # `event: sources` suppression so reloading the conversation
+                # later doesn't bring the misleading chip back.
+                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
+                sources_to_persist: list[dict] | None = (
+                    None
+                    if not source_citations or _is_refusal(refusal_check_text)
+                    else source_citations
+                )
+                persisted = None
+                try:
+                    persisted = await asyncio.shield(
+                        repository.create_message(
+                            conversation_id=conv_id,
+                            user_id=user_id,
+                            role="assistant",
+                            content=assistant_text,
+                            sources=sources_to_persist,
+                        )
+                    )
+                except asyncio.CancelledError:
+                    logger.info(
+                        "Client disconnected mid-persist; shielded create_message continues in background"
+                    )
+                except Exception as exc:
+                    logger.error("Failed to persist regenerated assistant message: %s", exc)
+                    raise
+                # Only delete the stale answer once the replacement is saved.
+                # If persistence was cancelled/failed we keep the old message
+                # so the conversation always has a reply.
+                if persisted is not None:
+                    try:
+                        await asyncio.shield(
+                            repository.delete_message(old_assistant_id, user_id)
+                        )
+                    except asyncio.CancelledError:
+                        logger.info(
+                            "Client disconnected before stale-answer delete; shielded delete continues in background"
+                        )
+                    except Exception as exc:
+                        logger.warning("Failed to delete stale assistant message: %s", exc)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -64,8 +64,8 @@ def _user_getter(user_id: str):
 
 
 def _conv_getter(user_id: str, conv_id: str):
-    async def mock_get_conversation(cid, user_id_arg):
-        if cid == conv_id:
+    async def mock_get_conversation(conv_id_arg, user_id):
+        if conv_id_arg == conv_id:
             return {
                 "id": conv_id,
                 "user_id": user_id,
@@ -96,7 +96,7 @@ class TestRegenerateRoute:
         consumed exactly once."""
         user_id, conv_id, token = _user_and_conv()
 
-        async def mock_list_messages(cid, uid):
+        async def mock_list_messages(conversation_id, user_id):
             return [
                 {"id": "u1", "role": "user", "content": "the question"},
                 {"id": "a-old", "role": "assistant", "content": "stale answer"},
@@ -145,7 +145,7 @@ class TestRegenerateRoute:
         """The regenerated answer ships its own citations via event: sources."""
         user_id, conv_id, token = _user_and_conv()
 
-        async def mock_list_messages(cid, uid):
+        async def mock_list_messages(conversation_id, user_id):
             return [
                 {"id": "u1", "role": "user", "content": "the question"},
                 {"id": "a-old", "role": "assistant", "content": "stale answer"},
@@ -194,7 +194,7 @@ class TestRegenerateRoute:
         """A 429 leaves the old answer intact — neither create nor delete runs."""
         user_id, conv_id, token = _user_and_conv()
 
-        async def mock_list_messages(cid, uid):
+        async def mock_list_messages(conversation_id, user_id):
             return [
                 {"id": "u1", "role": "user", "content": "the question"},
                 {"id": "a-old", "role": "assistant", "content": "stale answer"},
@@ -239,7 +239,7 @@ class TestRegenerateRoute:
         """No trailing assistant message → 409 and the cap is NOT consumed."""
         user_id, conv_id, token = _user_and_conv()
 
-        async def mock_list_messages(cid, uid):
+        async def mock_list_messages(conversation_id, user_id):
             return [{"id": "u1", "role": "user", "content": "the question"}]
 
         mock_create = AsyncMock(return_value={"id": "new"})
@@ -269,7 +269,7 @@ class TestRegenerateRoute:
         """A conversation the user doesn't own (get_conversation → None) → 404."""
         user_id, conv_id, token = _user_and_conv()
 
-        async def mock_get_conversation(cid, uid):
+        async def mock_get_conversation(conv_id, user_id):
             return None
 
         with (

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,328 @@
+"""
+Tests for the regenerate route — POST /api/conversations/{conv_id}/regenerate
+(issue #280).
+
+Mirrors the ASGI/httpx + patch integration style of test_sources_event.py.
+Patch targets for the LLM/tool boundary live in `backend.routes.regenerate`
+(stream_chat / execute_tool are imported into that module's namespace);
+repository functions are patched on `backend.db.repository`.
+
+The autouse `patch_rate_limit` fixture (see conftest.py) replaces
+`rate_limit.check_and_record` with an in-memory fake backed by `message_store`,
+so a consumed cap shows up as an appended timestamp there.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend import rate_limit
+from backend.auth.tokens import encode_token
+
+
+def _answer_stream(answer_text: str, *, with_tool: bool):
+    """Build a mock stream_chat that optionally drives a single tool call then
+    streams `answer_text` and [DONE]."""
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if with_tool and tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(answer_text)}\n\n"
+        if final_text_out is not None:
+            final_text_out.append(answer_text)
+        yield "data: [DONE]\n\n"
+
+    return mock_stream_chat
+
+
+def _user_and_conv():
+    user_id = str(uuid4())
+    conv_id = str(uuid4())
+    return user_id, conv_id, encode_token(user_id)
+
+
+def _user_getter(user_id: str):
+    async def mock_get_user_by_id(uid):
+        return {
+            "id": user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    return mock_get_user_by_id
+
+
+def _conv_getter(user_id: str, conv_id: str):
+    async def mock_get_conversation(cid, user_id_arg):
+        if cid == conv_id:
+            return {
+                "id": conv_id,
+                "user_id": user_id,
+                "title": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        return None
+
+    return mock_get_conversation
+
+
+SOURCE_CHUNKS = [
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Test Video",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "Test snippet",
+    }
+]
+
+
+class TestRegenerateRoute:
+    async def test_regenerate_replaces_and_counts(self, message_store) -> None:
+        """Happy path: new assistant message persisted, old one deleted, cap
+        consumed exactly once."""
+        user_id, conv_id, token = _user_and_conv()
+
+        async def mock_list_messages(cid, uid):
+            return [
+                {"id": "u1", "role": "user", "content": "the question"},
+                {"id": "a-old", "role": "assistant", "content": "stale answer"},
+            ]
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+        mock_create = AsyncMock(return_value={"id": str(uuid4())})
+        mock_delete = AsyncMock(return_value=True)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _user_getter(user_id)),
+            patch("backend.db.repository.get_conversation", _conv_getter(user_id, conv_id)),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.db.repository.delete_message", mock_delete),
+            patch(
+                "backend.routes.regenerate.stream_chat",
+                _answer_stream("A fresh answer.", with_tool=False),
+            ),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        output = response.text
+        assert response.status_code == 200
+        assert "A fresh answer." in output
+        assert "data: [DONE]" in output
+
+        # New assistant message persisted.
+        assert mock_create.called
+        assert mock_create.call_args.kwargs["role"] == "assistant"
+        # Old assistant message deleted by id.
+        mock_delete.assert_awaited_once()
+        assert mock_delete.await_args.args[0] == "a-old"
+        # Cap consumed exactly once (autouse fake records to message_store).
+        assert len(message_store[user_id]) == 1
+
+    async def test_regenerate_emits_own_sources(self) -> None:
+        """The regenerated answer ships its own citations via event: sources."""
+        user_id, conv_id, token = _user_and_conv()
+
+        async def mock_list_messages(cid, uid):
+            return [
+                {"id": "u1", "role": "user", "content": "the question"},
+                {"id": "a-old", "role": "assistant", "content": "stale answer"},
+            ]
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
+            return {"ok": True, "text": "context", "chunks": SOURCE_CHUNKS}
+
+        async def mock_create_message(**kwargs):
+            return {"id": str(uuid4()), **kwargs}
+
+        async def mock_delete_message(message_id, user_id_arg):
+            return True
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _user_getter(user_id)),
+            patch("backend.db.repository.get_conversation", _conv_getter(user_id, conv_id)),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.create_message", mock_create_message),
+            patch("backend.db.repository.delete_message", mock_delete_message),
+            patch(
+                "backend.routes.regenerate.stream_chat",
+                _answer_stream("Grounded answer.", with_tool=True),
+            ),
+            patch("backend.routes.regenerate.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        output = response.text
+        assert "event: sources" in output
+        assert "c1" in output
+        assert "data: [DONE]" in output
+
+    async def test_regenerate_rate_limited_preserves_old(self, message_store) -> None:
+        """A 429 leaves the old answer intact — neither create nor delete runs."""
+        user_id, conv_id, token = _user_and_conv()
+
+        async def mock_list_messages(cid, uid):
+            return [
+                {"id": "u1", "role": "user", "content": "the question"},
+                {"id": "a-old", "role": "assistant", "content": "stale answer"},
+            ]
+
+        mock_create = AsyncMock(return_value={"id": "new"})
+        mock_delete = AsyncMock(return_value=True)
+
+        from datetime import UTC, datetime, timedelta
+
+        reset_at = datetime.now(UTC) + timedelta(hours=24)
+
+        async def raising_check(uid):
+            raise rate_limit.RateLimitExceeded(reset_at=reset_at)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _user_getter(user_id)),
+            patch("backend.db.repository.get_conversation", _conv_getter(user_id, conv_id)),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.db.repository.delete_message", mock_delete),
+            patch.object(rate_limit, "check_and_record", raising_check),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+        assert body["window_hours"] == rate_limit.WINDOW_HOURS
+        assert "reset_at" in body
+        # Old answer preserved — no persistence, no delete.
+        assert not mock_create.called
+        assert not mock_delete.called
+
+    async def test_regenerate_409_when_last_is_user(self, message_store) -> None:
+        """No trailing assistant message → 409 and the cap is NOT consumed."""
+        user_id, conv_id, token = _user_and_conv()
+
+        async def mock_list_messages(cid, uid):
+            return [{"id": "u1", "role": "user", "content": "the question"}]
+
+        mock_create = AsyncMock(return_value={"id": "new"})
+        mock_delete = AsyncMock(return_value=True)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _user_getter(user_id)),
+            patch("backend.db.repository.get_conversation", _conv_getter(user_id, conv_id)),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.db.repository.delete_message", mock_delete),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 409
+        # Guard runs before rate-limit, so no cap was consumed.
+        assert len(message_store[user_id]) == 0
+        assert not mock_create.called
+        assert not mock_delete.called
+
+    async def test_regenerate_404_foreign_conversation(self) -> None:
+        """A conversation the user doesn't own (get_conversation → None) → 404."""
+        user_id, conv_id, token = _user_and_conv()
+
+        async def mock_get_conversation(cid, uid):
+            return None
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _user_getter(user_id)),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 404
+
+
+class TestDeleteMessageRepository:
+    """Unit tests for repository.delete_message (owner-scoped DELETE)."""
+
+    @pytest.mark.parametrize(
+        ("execute_result", "expected"),
+        [("DELETE 1", True), ("DELETE 0", False)],
+    )
+    async def test_delete_message_returns_row_deleted(self, execute_result, expected) -> None:
+        from backend.db import repository
+
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value=execute_result)
+
+        class _FakeAcquire:
+            def __await__(self):
+                async def _do():
+                    return mock_conn
+
+                return _do().__await__()
+
+            async def __aenter__(self):
+                return mock_conn
+
+            async def __aexit__(self, *exc):
+                return False
+
+        with patch.object(repository, "_acquire", lambda: _FakeAcquire()):
+            result = await repository.delete_message("msg-1", "user-1")
+
+        assert result is expected
+        # Owner-scoped: parameters are (message_id, user_id) in that order.
+        assert mock_conn.execute.await_args.args[1] == "msg-1"
+        assert mock_conn.execute.await_args.args[2] == "user-1"
+
+
+def _app():
+    # Imported lazily so conftest env/monkeypatches are applied first.
+    from backend.main import app
+
+    return app

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -323,6 +324,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const [failedMessageText, setFailedMessageText] = useState<string | null>(null);
   // Track the temp user message ID so we can remove it on failure
   const pendingUserMsgIdRef = useRef<string | null>(null);
+  // Track the assistant message removed for a regenerate so we can restore it
+  // if the regenerate fails (issue #280).
+  const regenRemovedRef = useRef<MessageType | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
 
@@ -559,6 +563,77 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     ],
   );
 
+  // ── Regenerate handler ──
+  // Re-run the last user question and replace the most recent assistant
+  // answer with a fresh stream (its own citations). Counts against the daily
+  // cap exactly like a send (handled server-side). Mirrors handleSend's
+  // optimistic pattern: remove the stale answer, stream a replacement, and
+  // restore the removed answer on failure (issue #280).
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId || isStreaming) return;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return;
+
+    setInlineError(null);
+    setFailedMessageText(null);
+
+    regenRemovedRef.current = last;
+    setMessages((prev) => prev.slice(0, -1));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await startRegenerate(conversationId, ({ fullText, sources }) => {
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      regenRemovedRef.current = null;
+      // Pull fresh quota counter so the sidebar updates after each regenerate.
+      refreshAuth();
+    } catch (e) {
+      // Restore the removed assistant message so the conversation isn't left
+      // without a reply.
+      if (regenRemovedRef.current) {
+        const restored = regenRemovedRef.current;
+        setMessages((prev) => [...prev, restored]);
+        regenRemovedRef.current = null;
+      }
+
+      // Intentional abort (navigation or user cancel) — no error toast.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate response';
+      setInlineError('Failed to regenerate. Please try again.');
+      addToast(errMsg || 'Network error — could not regenerate', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    startRegenerate,
+    setMessages,
+    scrollToBottom,
+    refreshAuth,
+    addToast,
+  ]);
+
   // Send pending message after conversation is created (post-route-change).
   // We read from `location.state.initialMessage`, which survives the
   // LandingPage → ConversationPage remount. Clear state with `replace`
@@ -708,13 +783,18 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
-              messages.map((msg) => (
+              messages.map((msg, idx) => (
                 <Message
                   key={msg.id}
                   role={msg.role}
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  onRegenerate={
+                    idx === messages.length - 1 && msg.role === 'assistant' && !isStreaming
+                      ? handleRegenerate
+                      : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Citation } from '../lib/api';
 import { Message } from './Message';
@@ -147,5 +147,45 @@ describe('Message — citation chip segment_count label', () => {
       />,
     );
     expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — regenerate button (issue #280)', () => {
+  it('renders the Regenerate button for an assistant message when onRegenerate is set', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." isStreaming={false} onRegenerate={onRegenerate} />,
+    );
+    expect(screen.getByRole('button', { name: 'Regenerate response' })).toBeInTheDocument();
+  });
+
+  it('calls onRegenerate when the button is clicked', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." isStreaming={false} onRegenerate={onRegenerate} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the button while streaming', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." isStreaming={true} onRegenerate={onRegenerate} />,
+    );
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button when onRegenerate is absent', () => {
+    render(<Message role="assistant" content="An answer." isStreaming={false} />);
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button for a user message', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="user" content="A question." isStreaming={false} onRegenerate={onRegenerate} />,
+    );
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,9 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** When provided (last assistant message, not streaming), renders a
+   *  "Regenerate" button that re-runs the last question (issue #280). */
+  onRegenerate?: () => void;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,6 +170,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +208,32 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && !isStreaming && (
+              <div style={{ marginTop: 10 }}>
+                <button
+                  onClick={onRegenerate}
+                  aria-label="Regenerate response"
+                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#94a3b8',
+                    fontSize: 12,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: 0,
+                    fontFamily: 'inherit',
+                    transition: 'color 0.15s',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
+                  onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+                >
+                  ↻ Regenerate
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -9,6 +9,7 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RateLimitError } from '../lib/api';
 import { useStreamingResponse } from './useStreamingResponse';
 
 function makeSseStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -436,6 +437,59 @@ describe('status event SSE parsing — hook state transitions', () => {
     await act(async () => {
       await p;
     });
+  });
+});
+
+describe('startRegenerate (issue #280)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the regenerate endpoint with an empty body and streams the reply', async () => {
+    const sseChunks = ['data: "Fresh answer"\n\n', 'data: [DONE]\n\n'];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(sseChunks),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startRegenerate('conv-1', onComplete);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/conversations/conv-1/regenerate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ fullText: 'Fresh answer' }),
+    );
+  });
+
+  it('surfaces a RateLimitError on a 429 from the regenerate endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ limit: 25, window_hours: 24, reset_at: '2026-01-01T00:00:00Z' }),
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await expect(
+      act(async () => {
+        await result.current.startRegenerate('conv-1', vi.fn());
+      }),
+    ).rejects.toBeInstanceOf(RateLimitError);
   });
 });
 

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -42,10 +42,14 @@ export function useStreamingResponse(conversationId: string | null) {
     }
   }, []);
 
-  const startStream = useCallback(
+  // Shared fetch + SSE-parse loop used by both startStream (send) and
+  // startRegenerate. The only difference between the two flows is the URL
+  // and request body — everything else (status handling, reader loop,
+  // onComplete, finally reset) is identical.
+  const consumeStream = useCallback(
     async (
-      conversationId: string,
-      userMessage: string,
+      url: string,
+      body: object,
       onComplete: (result: StreamResult) => void,
     ): Promise<void> => {
       setIsStreaming(true);
@@ -61,11 +65,11 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+        const res = await fetch(url, {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
+          body: JSON.stringify(body),
           signal: abortController.signal,
         });
 
@@ -218,12 +222,33 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startStream = useCallback(
+    (
+      conversationId: string,
+      userMessage: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> =>
+      consumeStream(`/api/conversations/${conversationId}/messages`, { content: userMessage }, onComplete),
+    [consumeStream],
+  );
+
+  // Regenerate the most recent assistant message. No request body is needed —
+  // the backend re-runs the trailing user question already stored server-side.
+  // 429 handling lives in consumeStream, so regenerate inherits the same
+  // RateLimitError behaviour as a normal send.
+  const startRegenerate = useCallback(
+    (conversationId: string, onComplete: (result: StreamResult) => void): Promise<void> =>
+      consumeStream(`/api/conversations/${conversationId}/regenerate`, {}, onComplete),
+    [consumeStream],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   };
 }


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `a70cd8a1-c0a9-4c0e-8111-5ef94dd9ef42`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.