### PR TITLE
[bench-KK] review: add missing tests for regenerate endpoint

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -577,6 +577,43 @@ async def create_message(
     }
 
 
+async def get_message(message_id: str, user_id: str) -> dict | None:
+    """Return a single message only if its conversation belongs to the user."""
+    async with _acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT m.*
+            FROM messages m
+            JOIN conversations c ON c.id = m.conversation_id
+            WHERE m.id = $1 AND c.user_id = $2
+            """,
+            message_id,
+            user_id,
+        )
+    if not row:
+        return None
+    d = dict(row)
+    d["sources"] = json.loads(d["sources"]) if d.get("sources") else None
+    return d
+
+
+async def delete_message(message_id: str, user_id: str) -> bool:
+    """Delete a message. Returns False if it does not belong to the user."""
+    async with _acquire() as conn:
+        result = await conn.execute(
+            """
+            DELETE FROM messages
+            USING conversations
+            WHERE messages.id = $1
+              AND conversations.id = messages.conversation_id
+              AND conversations.user_id = $2
+            """,
+            message_id,
+            user_id,
+        )
+    return result != "DELETE 0"  # type: ignore[no-any-return]
+
+
 async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     """Return messages only if the conversation belongs to the given user."""
     async with _acquire() as conn:

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -308,6 +308,209 @@ async def create_message(
 
 
 # ---------------------------------------------------------------------------
+# POST /api/messages/{message_id}/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/messages/{message_id}/regenerate")
+async def regenerate_message(
+    message_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate the last assistant message in a conversation.
+
+    Re-runs the RAG pipeline from the immediately preceding user message,
+    streams a fresh response, and atomically replaces the old assistant
+    message with the new one. Counts against the user's daily rate limit.
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Fetch the target message; 404 if absent.
+    target_msg = await repository.get_message(message_id, user_id)
+    if not target_msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    # 2. Verify role and ownership.
+    if target_msg["role"] != "assistant":
+        raise HTTPException(status_code=403, detail="Can only regenerate assistant messages")
+
+    conv_id = target_msg["conversation_id"]
+
+    # 3. Load full conversation history.
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+
+    # 4. Target must be the last message.
+    if not all_messages or all_messages[-1]["id"] != message_id:
+        raise HTTPException(status_code=400, detail="Can only regenerate the last message")
+
+    # 5. Find the immediately preceding user message.
+    preceding_user_msg: dict | None = None
+    for msg in reversed(all_messages[:-1]):
+        if msg["role"] == "user":
+            preceding_user_msg = msg
+            break
+    if not preceding_user_msg:
+        raise HTTPException(status_code=400, detail="No preceding user message found")
+
+    # 6. Rate limit — same cap as a normal send.
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 7. Build history up to and including the preceding user message.
+    preceding_idx = next(
+        i for i, m in enumerate(all_messages) if m["id"] == preceding_user_msg["id"]
+    )
+    llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages[: preceding_idx + 1]]
+
+    # 8. Set up tool plumbing (mirror create_message).
+    source_citations: list[dict] = []
+    tool_chunks_acc: list[dict] = []
+    embedding_cache: dict[str, list[float]] = {}
+    tools_param: list[dict] | None = None
+    executor = None
+    max_tool_calls = 0
+    if LLM_TOOLS_ENABLED:
+        try:
+            all_videos = await repository.list_videos()
+            video_id_whitelist: set[str] = {v["id"] for v in all_videos if v.get("id")}
+        except Exception as exc:
+            logger.warning(
+                "Failed to load video whitelist for tool use; transcript tool calls will be unguarded: %s",
+                exc,
+            )
+            video_id_whitelist = set()
+
+        is_member_for_turn = bool(current_user.get("is_member", False))
+
+        async def _executor(name: str, raw_args: str) -> str:
+            whitelist = video_id_whitelist if video_id_whitelist else None
+            result = await execute_tool(
+                name,
+                raw_args,
+                video_id_whitelist=whitelist,
+                embedding_cache=embedding_cache,
+                is_member=is_member_for_turn,
+            )
+            if result.get("ok") and result.get("chunks"):
+                tool_chunks_acc.extend(result["chunks"])
+            return serialize_tool_result(result)
+
+        tools_param = TOOL_SCHEMAS
+        executor = _executor
+        max_tool_calls = LLM_TOOLS_MAX_PER_TURN
+
+    # 9. Stream the response.
+    async def event_generator() -> AsyncGenerator[str, None]:
+        full_response: list[str] = []
+        final_text_buf: list[str] = []
+        marker_stripper = CitationMarkerStripper()
+        try:
+            turn_is_member = bool(current_user.get("is_member") or False)
+            async for sse_chunk in stream_chat(
+                llm_messages,
+                tools=tools_param,
+                tool_executor=executor,
+                max_tool_calls=max_tool_calls,
+                final_text_out=final_text_buf,
+                is_member=turn_is_member,
+            ):
+                if sse_chunk == "data: [DONE]\n\n":
+                    tail = marker_stripper.flush()
+                    if tail:
+                        tail_chunk = f"data: {json.dumps(tail)}\n\n"
+                        full_response.append(tail_chunk)
+                        yield tail_chunk
+                    if tool_chunks_acc:
+                        seen: set[str] = set()
+                        for tc in tool_chunks_acc:
+                            tc_id = tc.get("chunk_id")
+                            if tc_id and tc_id not in seen:
+                                source_citations.append(tc)
+                                seen.add(tc_id)
+                    if source_citations:
+                        final_text_raw = final_text_buf[0] if final_text_buf else ""
+                        cited_ids = extract_cited_chunk_ids(final_text_raw)
+                        for chunk in source_citations:
+                            chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+                        source_citations[:] = _collapse_by_video(source_citations)
+                        cited = [c for c in source_citations if c.get("is_cited")]
+                        uncited = [c for c in source_citations if not c.get("is_cited")]
+                        source_citations[:] = cited + uncited[:CITATIONS_MAX_COUNT]
+                    if source_citations:
+                        final_text = (
+                            final_text_buf[0]
+                            if final_text_buf
+                            else _extract_text_from_sse(full_response)
+                        )
+                        if not _is_refusal(final_text):
+                            sources_json = json.dumps(source_citations)
+                            yield f"event: sources\ndata: {sources_json}\n\n"
+                    full_response.append(sse_chunk)
+                    yield sse_chunk
+                    continue
+
+                stripped = _strip_markers_from_sse_chunk(sse_chunk, marker_stripper)
+                if stripped is None:
+                    continue
+                full_response.append(stripped)
+                yield stripped
+        finally:
+            assistant_text = _extract_text_from_sse(full_response)
+            if assistant_text:
+                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
+                sources_to_persist: list[dict] | None = (
+                    None
+                    if not source_citations or _is_refusal(refusal_check_text)
+                    else source_citations
+                )
+                try:
+                    await asyncio.shield(
+                        repository.create_message(
+                            conversation_id=conv_id,
+                            user_id=user_id,
+                            role="assistant",
+                            content=assistant_text,
+                            sources=sources_to_persist,
+                        )
+                    )
+                except asyncio.CancelledError:
+                    logger.info(
+                        "Client disconnected mid-persist; shielded create_message continues in background"
+                    )
+                except Exception as exc:
+                    logger.error("Failed to persist assistant message: %s", exc)
+                    raise
+                try:
+                    await asyncio.shield(
+                        repository.delete_message(message_id, user_id)
+                    )
+                except asyncio.CancelledError:
+                    logger.info(
+                        "Client disconnected mid-delete; shielded delete_message continues in background"
+                    )
+                except Exception as exc:
+                    logger.error("Failed to delete old assistant message: %s", exc)
+                    raise
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,310 @@
+"""Tests for POST /api/messages/{message_id}/regenerate (issue #280).
+
+Covers:
+- Repository ownership invariant (structural, no DB hit)
+- Happy path: streams a new response, calls create_message and delete_message,
+  increments the rate-limit counter
+- Error paths: 404 (not found), 403 (not an assistant), 400 (not last / no
+  preceding user message), 429 (rate limit exceeded)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from backend.auth.dependencies import get_current_user
+from backend.main import app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_user() -> dict[str, Any]:
+    return {"id": str(uuid4()), "email": "test@example.com", "is_member": False}
+
+
+@pytest.fixture
+def bypass_auth(fake_user: dict[str, Any]):
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    yield fake_user
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(role: str = "assistant", conv_id: str | None = None) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "conversation_id": conv_id or str(uuid4()),
+        "role": role,
+        "content": "some content",
+        "sources": None,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+
+async def _drain(body_iter) -> list[str]:
+    """Collect all chunks from a StreamingResponse body iterator."""
+    chunks: list[str] = []
+    async for chunk in body_iter:
+        chunks.append(chunk)
+    return chunks
+
+
+async def _fake_stream(*args: Any, **kwargs: Any):
+    final_text_out = kwargs.get("final_text_out")
+    for token in ("Hello", " world"):
+        yield f"data: {json.dumps(token)}\n\n"
+    if final_text_out is not None:
+        final_text_out.append("Hello world")
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Repository unit tests — ownership invariants
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_message_requires_user_id():
+    """delete_message must accept a user_id param — the ownership guard."""
+    import inspect
+
+    from backend.db import repository
+
+    params = inspect.signature(repository.delete_message).parameters
+    assert "user_id" in params
+
+
+async def test_get_message_requires_user_id():
+    """get_message must accept a user_id param — the ownership guard."""
+    import inspect
+
+    from backend.db import repository
+
+    params = inspect.signature(repository.get_message).parameters
+    assert "user_id" in params
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateHappyPath:
+    async def test_streams_response_and_replaces_old_message(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        user_id = bypass_auth["id"]
+        conv_id = str(uuid4())
+        old_id = str(uuid4())
+
+        user_msg = _msg(role="user", conv_id=conv_id)
+        old_msg = {**_msg(role="assistant", conv_id=conv_id), "id": old_id}
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_message",
+                new_callable=AsyncMock,
+                return_value=old_msg,
+            ),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[user_msg, old_msg],
+            ),
+            patch(
+                "backend.routes.messages.repository.create_message",
+                new_callable=AsyncMock,
+                return_value={"id": str(uuid4())},
+            ) as mock_create,
+            patch(
+                "backend.routes.messages.repository.delete_message",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_delete,
+            patch("backend.routes.messages.repository.list_videos", new_callable=AsyncMock, return_value=[]),
+            patch("backend.routes.messages.stream_chat", side_effect=_fake_stream),
+            patch("backend.routes.messages.LLM_TOOLS_ENABLED", False),
+        ):
+            from backend.routes.messages import regenerate_message
+
+            resp = await regenerate_message(message_id=old_id, current_user=bypass_auth)
+            chunks = await _drain(resp.body_iterator)
+
+        # SSE tokens and terminator present
+        assert any(json.dumps("Hello") in c for c in chunks)
+        assert any("[DONE]" in c for c in chunks)
+
+        # New message persisted with assistant content
+        mock_create.assert_awaited_once()
+        kw = mock_create.call_args.kwargs
+        assert kw["role"] == "assistant"
+        assert "Hello" in kw["content"]
+        assert kw["conversation_id"] == conv_id
+
+        # Old message deleted with the correct ownership args
+        mock_delete.assert_awaited_once()
+        del_args = mock_delete.call_args.args
+        assert del_args[0] == old_id
+        assert del_args[1] == user_id
+
+    async def test_increments_rate_limit_counter(
+        self, bypass_auth: dict[str, Any], message_store
+    ) -> None:
+        user_id = bypass_auth["id"]
+        conv_id = str(uuid4())
+        old_id = str(uuid4())
+        user_msg = _msg(role="user", conv_id=conv_id)
+        old_msg = {**_msg(role="assistant", conv_id=conv_id), "id": old_id}
+
+        with (
+            patch("backend.routes.messages.repository.get_message", new_callable=AsyncMock, return_value=old_msg),
+            patch("backend.routes.messages.repository.list_messages", new_callable=AsyncMock, return_value=[user_msg, old_msg]),
+            patch("backend.routes.messages.repository.create_message", new_callable=AsyncMock, return_value={"id": str(uuid4())}),
+            patch("backend.routes.messages.repository.delete_message", new_callable=AsyncMock, return_value=True),
+            patch("backend.routes.messages.repository.list_videos", new_callable=AsyncMock, return_value=[]),
+            patch("backend.routes.messages.stream_chat", side_effect=_fake_stream),
+            patch("backend.routes.messages.LLM_TOOLS_ENABLED", False),
+        ):
+            from backend.routes.messages import regenerate_message
+
+            resp = await regenerate_message(message_id=old_id, current_user=bypass_auth)
+            await _drain(resp.body_iterator)
+
+        # Exactly one audit row recorded for this user
+        assert len(message_store[user_id]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateErrors:
+    async def test_404_when_message_not_found(self, bypass_auth: dict[str, Any]) -> None:
+        from fastapi import HTTPException
+
+        with patch(
+            "backend.routes.messages.repository.get_message",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            from backend.routes.messages import regenerate_message
+
+            with pytest.raises(HTTPException) as exc_info:
+                await regenerate_message(message_id=str(uuid4()), current_user=bypass_auth)
+
+        assert exc_info.value.status_code == 404
+
+    async def test_403_when_target_is_user_message(self, bypass_auth: dict[str, Any]) -> None:
+        from fastapi import HTTPException
+
+        target = _msg(role="user")
+
+        with patch(
+            "backend.routes.messages.repository.get_message",
+            new_callable=AsyncMock,
+            return_value=target,
+        ):
+            from backend.routes.messages import regenerate_message
+
+            with pytest.raises(HTTPException) as exc_info:
+                await regenerate_message(message_id=target["id"], current_user=bypass_auth)
+
+        assert exc_info.value.status_code == 403
+
+    async def test_400_when_not_the_last_message(self, bypass_auth: dict[str, Any]) -> None:
+        from fastapi import HTTPException
+
+        conv_id = str(uuid4())
+        target = _msg(role="assistant", conv_id=conv_id)
+        later = _msg(role="user", conv_id=conv_id)
+
+        with (
+            patch("backend.routes.messages.repository.get_message", new_callable=AsyncMock, return_value=target),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[target, later],  # target is NOT the last element
+            ),
+        ):
+            from backend.routes.messages import regenerate_message
+
+            with pytest.raises(HTTPException) as exc_info:
+                await regenerate_message(message_id=target["id"], current_user=bypass_auth)
+
+        assert exc_info.value.status_code == 400
+        assert "last" in exc_info.value.detail.lower()
+
+    async def test_400_when_no_preceding_user_message(self, bypass_auth: dict[str, Any]) -> None:
+        from fastapi import HTTPException
+
+        conv_id = str(uuid4())
+        target = _msg(role="assistant", conv_id=conv_id)
+
+        with (
+            patch("backend.routes.messages.repository.get_message", new_callable=AsyncMock, return_value=target),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[target],  # no user message before it
+            ),
+        ):
+            from backend.routes.messages import regenerate_message
+
+            with pytest.raises(HTTPException) as exc_info:
+                await regenerate_message(message_id=target["id"], current_user=bypass_auth)
+
+        assert exc_info.value.status_code == 400
+        assert "preceding" in exc_info.value.detail.lower()
+
+    async def test_429_when_rate_limit_exceeded(
+        self, bypass_auth: dict[str, Any], message_store
+    ) -> None:
+        from fastapi.responses import JSONResponse
+
+        from backend import rate_limit
+
+        user_id = bypass_auth["id"]
+        conv_id = str(uuid4())
+        target = _msg(role="assistant", conv_id=conv_id)
+        user_msg = _msg(role="user", conv_id=conv_id)
+
+        # Seed the cap so the next call triggers 429
+        now = datetime.now(UTC)
+        message_store[user_id] = [now - timedelta(minutes=i) for i in range(rate_limit.DAILY_MESSAGE_CAP)]
+
+        with (
+            patch("backend.routes.messages.repository.get_message", new_callable=AsyncMock, return_value=target),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[user_msg, target],
+            ),
+        ):
+            from backend.routes.messages import regenerate_message
+
+            resp = await regenerate_message(message_id=target["id"], current_user=bypass_auth)
+
+        assert isinstance(resp, JSONResponse)
+        assert resp.status_code == 429
+
+        body = json.loads(resp.body)
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+        assert "reset_at" in body
+
+        # Counter must NOT have grown — 429 path does not record
+        assert len(message_store[user_id]) == rate_limit.DAILY_MESSAGE_CAP

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -323,6 +324,8 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const [failedMessageText, setFailedMessageText] = useState<string | null>(null);
   // Track the temp user message ID so we can remove it on failure
   const pendingUserMsgIdRef = useRef<string | null>(null);
+  // Track the message being regenerated so we can restore it on failure
+  const pendingRegenerateMsgRef = useRef<MessageType | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
 
@@ -583,6 +586,83 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     handleSend(text);
   }, [failedMessageText, handleSend]);
 
+  // ── Regenerate the last assistant message ──
+  const handleRegenerate = useCallback(
+    async (messageId: string) => {
+      if (!conversationId) return;
+      if (isStreaming) return;
+
+      setInlineError(null);
+      setFailedMessageText(null);
+
+      // Capture the old message before removing it
+      let oldMsg: MessageType | undefined;
+      setMessages((prev) => {
+        oldMsg = prev.find((m) => m.id === messageId);
+        return prev.filter((m) => m.id !== messageId);
+      });
+
+      if (!oldMsg) return;
+      pendingRegenerateMsgRef.current = oldMsg;
+      autoScrollRef.current = true;
+      scrollToBottom();
+
+      try {
+        await startRegenerate(messageId, ({ fullText, sources }) => {
+          const assistantMsg: MessageType = {
+            id: `temp-assistant-${Date.now()}`,
+            conversation_id: conversationId,
+            role: 'assistant',
+            content: fullText,
+            created_at: new Date().toISOString(),
+            sources: sources.length > 0 ? sources : undefined,
+          };
+          setMessages((prev) => [...prev, assistantMsg]);
+        });
+        pendingRegenerateMsgRef.current = null;
+        // Pull fresh quota counter so the sidebar updates after each send.
+        refreshAuth();
+        // Refresh conversations list so sidebar shows auto-generated title.
+        refreshConversationsRef?.current?.();
+      } catch (e) {
+        // Restore the old message on any error/abort
+        if (pendingRegenerateMsgRef.current) {
+          setMessages((prev) => [...prev, pendingRegenerateMsgRef.current!]);
+          pendingRegenerateMsgRef.current = null;
+        }
+
+        // Intentional abort (navigation or user cancel) — no error toast
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          return;
+        }
+
+        if (e instanceof RateLimitError) {
+          // MISSION §10 #1 — daily cap hit.
+          const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+          setInlineError(friendly);
+          addToast(friendly, 'error');
+          // Sync counter so the sidebar flips to 25/25 with a reset time.
+          refreshAuth();
+          return;
+        }
+
+        const errMsg = e instanceof Error ? e.message : 'Failed to regenerate response';
+        setInlineError('Failed to regenerate response. Please try again.');
+        addToast(errMsg || 'Network error — regeneration failed', 'error');
+      }
+    },
+    [
+      conversationId,
+      isStreaming,
+      setMessages,
+      startRegenerate,
+      scrollToBottom,
+      addToast,
+      refreshAuth,
+      refreshConversationsRef,
+    ],
+  );
+
   // ── Starter click handler ──
   const handleStarterClick = useCallback((text: string) => {
     chatInputRef.current?.setInputText(text);
@@ -708,13 +788,19 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
-              messages.map((msg) => (
+              messages.map((msg, index) => (
                 <Message
                   key={msg.id}
                   role={msg.role}
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  isLastAssistant={msg.role === 'assistant' && index === messages.length - 1}
+                  onRegenerate={
+                    msg.role === 'assistant' && index === messages.length - 1
+                      ? () => handleRegenerate(msg.id)
+                      : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,10 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** True for the last assistant message in the conversation */
+  isLastAssistant?: boolean;
+  /** Called when the user clicks the regenerate button */
+  onRegenerate?: () => void;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,9 +171,12 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  isLastAssistant,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
+  const showRegenerate = !isUser && !isStreaming && isLastAssistant && !!onRegenerate;
 
   return (
     <div
@@ -204,6 +211,50 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {showRegenerate && (
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 6 }}>
+                <button
+                  onClick={onRegenerate}
+                  title="Regenerate response"
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid rgba(148,163,184,0.3)',
+                    borderRadius: 6,
+                    color: '#94a3b8',
+                    cursor: 'pointer',
+                    padding: '4px 8px',
+                    fontSize: 12,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    transition: 'all 0.15s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.borderColor = 'rgba(59,130,246,0.5)';
+                    e.currentTarget.style.color = '#f1f5f9';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.borderColor = 'rgba(148,163,184,0.3)';
+                    e.currentTarget.style.color = '#94a3b8';
+                  }}
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M1,6 A5,5 0 1,0 6,1" />
+                    <polyline points="1,6 1,2 5,2" />
+                  </svg>
+                  Regenerate
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -218,12 +218,172 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startRegenerate = useCallback(
+    async (
+      messageId: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> => {
+      setIsStreaming(true);
+      setStreamingContent('');
+      setStreamingSources([]);
+      setStreamingStatus(null);
+
+      let fullText = '';
+      let sources: Citation[] = [];
+      let streamError: Error | null = null;
+
+      try {
+        const abortController = new AbortController();
+        streamAbortRef.current = abortController;
+
+        const res = await fetch(`/api/messages/${messageId}/regenerate`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          signal: abortController.signal,
+        });
+
+        if (res.status === 401) {
+          if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+            const returnTo = window.location.pathname + window.location.search;
+            window.location.assign(`/login?from=${encodeURIComponent(returnTo)}`);
+          }
+          throw new Error('Not authenticated');
+        }
+        if (res.status === 429) {
+          let body: Record<string, unknown> | null = null;
+          try {
+            body = await res.json();
+          } catch (jsonErr) {
+            console.warn('[useStreamingResponse] Failed to parse 429 body:', jsonErr);
+          }
+          if (body && typeof body === 'object' && 'limit' in body) {
+            throw new RateLimitError(
+              body as { limit: number; window_hours: number; reset_at: string },
+            );
+          }
+          throw new Error('Daily message limit reached');
+        }
+        if (!res.ok) {
+          let errorText = '';
+          try {
+            errorText = await res.text();
+          } catch (textErr) {
+            console.warn('[useStreamingResponse] Failed to read error body:', textErr);
+          }
+          throw new Error(`HTTP ${res.status}${errorText ? `: ${errorText}` : ''}`);
+        }
+        if (!res.body) throw new Error('No response body');
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() ?? '';
+
+          for (const rawEvent of parts) {
+            if (!rawEvent.trim()) continue;
+
+            let eventType = 'message';
+            const dataLines: string[] = [];
+
+            for (const line of rawEvent.split('\n')) {
+              if (line.startsWith('event:')) {
+                eventType = line.slice(6).trim();
+              } else if (line.startsWith('data:')) {
+                const val = line.slice(5);
+                dataLines.push(val.startsWith(' ') ? val.slice(1) : val);
+              }
+            }
+
+            const data = dataLines.join('\n');
+
+            if (eventType === 'sources') {
+              try {
+                const parsed = JSON.parse(data);
+                if (Array.isArray(parsed)) {
+                  sources = parsed;
+                  setStreamingSources(parsed);
+                }
+              } catch (e) {
+                console.warn('[useStreamingResponse] Failed to parse sources event:', e);
+              }
+            } else if (eventType === 'status') {
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+                  if (parsed.type === 'tool_call_start') {
+                    setStreamingStatus({
+                      tool: String(parsed.tool ?? ''),
+                      subject: String(parsed.subject ?? ''),
+                      label: String(parsed.label ?? ''),
+                    });
+                  } else if (parsed.type === 'tool_call_done') {
+                    if (!parsed.tool || parsed.tool !== streamingStatus?.tool) {
+                      console.warn(
+                        '[useStreamingResponse] tool_call_done mismatch or missing tool:',
+                        parsed,
+                      );
+                    }
+                  }
+                }
+              } catch (e) {
+                console.warn('[useStreamingResponse] Failed to parse status event:', e);
+              }
+            } else if (data === '[DONE]') {
+              // Stream complete — no action needed here
+            } else if (data.startsWith('{"error"')) {
+              let errMsg = 'Stream error from server';
+              try {
+                errMsg = JSON.parse(data).error || errMsg;
+              } catch {
+                // Use default message
+              }
+              streamError = new Error(errMsg);
+              break;
+            } else if (data) {
+              let token = data;
+              try {
+                const parsed = JSON.parse(data);
+                if (typeof parsed === 'string') {
+                  token = parsed;
+                }
+              } catch {
+                // Not JSON-encoded — use raw data (backward compat)
+              }
+              setStreamingStatus(null);
+              fullText += token;
+              setStreamingContent(fullText);
+            }
+          }
+        }
+
+        onComplete({ fullText, sources });
+      } finally {
+        setIsStreaming(false);
+        setStreamingContent('');
+        setStreamingSources([]);
+        setStreamingStatus(null);
+      }
+      if (streamError) throw streamError;
+    },
+    [],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   };
 }

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -237,3 +237,11 @@ export const resyncVideo = (id: string) =>
 
 export const syncChannel = () =>
   request<SyncChannelResponse>('/admin/videos/sync-channel', { method: 'POST' });
+
+// Messages
+export const regenerateMessage = (messageId: string): Promise<Response> =>
+  fetch(`${BASE}/messages/${messageId}/regenerate`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `KK` (plan=Kimi, impl=Kimi)
**Source run-id:** `aa05d60d-37f6-42d4-b906-d5f3b980cb7f`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.