### PR TITLE
[bench-KO] impl: regenerate the last assistant response (#280)

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -577,6 +577,43 @@ async def create_message(
     }
 
 
+async def delete_last_assistant_message(conversation_id: str, user_id: str) -> str | None:
+    """Delete the most recent assistant message in a conversation (owner-scoped).
+
+    Used by the regenerate flow (issue #280) to drop the stale answer so the
+    history ends on the user's question before re-streaming a fresh reply.
+
+    Ownership is enforced via a JOIN on conversations.user_id inside the
+    subquery, so a cross-user call can never delete another user's message.
+
+    Returns the deleted message id, or None if the conversation has no
+    assistant message (or doesn't belong to the user).
+    """
+    async with _acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            DELETE FROM messages
+            WHERE id = (
+                SELECT m.id
+                FROM messages m
+                JOIN conversations c ON c.id = m.conversation_id
+                WHERE m.conversation_id = $1
+                  AND c.user_id = $2
+                  AND m.role = 'assistant'
+                ORDER BY m.created_at DESC
+                LIMIT 1
+            )
+            RETURNING id
+            """,
+            conversation_id,
+            user_id,
+        )
+    if row is None:
+        return None
+    await touch_conversation(conversation_id, user_id)
+    return str(row["id"])
+
+
 async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     """Return messages only if the conversation belongs to the given user."""
     async with _acquire() as conn:

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -112,6 +112,84 @@ async def create_message(
     if inserted is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    # 4-8. Stream the assistant reply (history load, tool setup, SSE,
+    # persist). Shared with the regenerate endpoint below.
+    return await _build_streaming_response(conv_id, user_id, current_user, title_seed=user_content)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate the most recent assistant response (issue #280).
+
+    Deletes the latest assistant message and re-streams a fresh answer to the
+    user's last question. Counts against the daily cap exactly like a normal
+    send (MISSION §10 invariant #1) so regeneration can't be used to bypass it.
+
+    Returns:
+        StreamingResponse (text/event-stream) — identical SSE shape to the
+        normal send endpoint (token chunks → sources event → [DONE]).
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user (404, no leak).
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. Enforce the 25 msg / user / 24h cap BEFORE any mutation or LLM work,
+    #    identical to the normal send path. Runs before the delete below so a
+    #    rate-limited user keeps their existing answer (no destructive 429).
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 3. Drop the latest assistant message so the history ends on the user's
+    #    question. 404 if there's no assistant turn to regenerate.
+    deleted_id = await repository.delete_last_assistant_message(
+        conversation_id=conv_id, user_id=user_id
+    )
+    if deleted_id is None:
+        raise HTTPException(status_code=404, detail="No assistant message to regenerate")
+
+    # 4-8. Stream a fresh reply against the preserved history. title_seed=None
+    #      because the conversation already has a title from the first send.
+    return await _build_streaming_response(conv_id, user_id, current_user, title_seed=None)
+
+
+async def _build_streaming_response(
+    conv_id: str,
+    user_id: str,
+    current_user: dict[str, Any],
+    title_seed: str | None,
+) -> StreamingResponse:
+    """Build the SSE StreamingResponse for an assistant turn.
+
+    Shared by the normal send (`create_message`) and regenerate
+    (`regenerate_message`) flows. Both end with the conversation history
+    terminating on the user's question; this helper loads that history, wires
+    the retrieval tools, streams the LLM, and persists the assistant message.
+
+    ``title_seed`` is the user message used to auto-generate the conversation
+    title on first send; pass ``None`` (regenerate) to skip title generation.
+    """
     # 4. Retrieve conversation history for LLM context
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
@@ -291,14 +369,17 @@ async def create_message(
                     raise
                 # Title auto-generation is best-effort: client-disconnect swallowed,
                 # unexpected errors logged but not re-raised (message was saved above).
-                try:
-                    await asyncio.shield(
-                        _maybe_set_conversation_title(conv_id, user_id, user_content)
-                    )
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:
-                    logger.warning("Failed to update conversation title: %s", exc)
+                # Skipped on regenerate (title_seed is None) — the conversation
+                # already has a title from the original send.
+                if title_seed is not None:
+                    try:
+                        await asyncio.shield(
+                            _maybe_set_conversation_title(conv_id, user_id, title_seed)
+                        )
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception as exc:
+                        logger.warning("Failed to update conversation title: %s", exc)
 
     return StreamingResponse(
         event_generator(),

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,375 @@
+"""
+Tests for the regenerate-last-answer endpoint (issue #280).
+
+POST /api/conversations/{conv_id}/regenerate must:
+  - count against the daily cap exactly like a normal send (MISSION §10 #1),
+  - 404 when the conversation has no assistant turn to replace,
+  - 404 on a cross-user attempt (no leak of existence),
+  - stream the fresh answer in the identical SSE shape as a normal send
+    (token chunks → sources event → [DONE]),
+  - delete only the most recent assistant message (repository unit test).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.auth.tokens import encode_token
+
+# ---------------------------------------------------------------------------
+# Shared mock builders
+# ---------------------------------------------------------------------------
+
+_ANSWER_TEXT = "Here is a fresh take on your question."
+_SOURCES = [
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Test Video",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "Test snippet",
+    }
+]
+
+
+async def _mock_stream_chat(
+    messages,
+    tools=None,
+    tool_executor=None,
+    max_tool_calls=0,
+    final_text_out=None,
+    **_kwargs,
+):
+    if tool_executor is not None:
+        await tool_executor("search_videos", json.dumps({"query": "test"}))
+    yield f"data: {json.dumps(_ANSWER_TEXT)}\n\n"
+    if final_text_out is not None:
+        final_text_out.append(_ANSWER_TEXT)
+    yield "data: [DONE]\n\n"
+
+
+async def _mock_execute_tool(
+    name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+):
+    return {"ok": True, "text": "context", "chunks": _SOURCES}
+
+
+async def _mock_list_videos():
+    return [{"id": "v1", "title": "Test Video", "url": "https://youtube.com/watch?v=abc"}]
+
+
+def _patches(*, conv_owner_id: str, conv_id: str, deleted_id: str | None, create_mock):
+    """Build the standard patch set for an authenticated regenerate request."""
+
+    async def mock_get_user_by_id(user_id):
+        return {
+            "id": conv_owner_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    async def mock_get_conversation(c_id, user_id):
+        # Owner-scoped: only return the conversation for its real owner.
+        if c_id == conv_id and str(user_id) == conv_owner_id:
+            return {
+                "id": conv_id,
+                "user_id": conv_owner_id,
+                "title": "Existing Title",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        return None
+
+    async def mock_delete_last_assistant_message(conversation_id, user_id):
+        return deleted_id
+
+    async def mock_list_messages(c_id, user_id):
+        # History ends on the user's question (assistant already deleted).
+        return [{"role": "user", "content": "original question"}]
+
+    return [
+        patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+        patch("backend.db.repository.get_conversation", mock_get_conversation),
+        patch(
+            "backend.db.repository.delete_last_assistant_message",
+            mock_delete_last_assistant_message,
+        ),
+        patch("backend.db.repository.create_message", create_mock),
+        patch("backend.db.repository.list_messages", mock_list_messages),
+        patch("backend.db.repository.list_videos", _mock_list_videos),
+        patch("backend.routes.messages.stream_chat", _mock_stream_chat),
+        patch("backend.routes.messages.execute_tool", _mock_execute_tool),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateEndpoint:
+    async def test_regenerate_streams_sse_shape_matching_send(self) -> None:
+        """Happy path: regenerate emits token chunks, a sources event, and [DONE]."""
+        from backend.main import app
+
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+        create_mock = AsyncMock(return_value={"id": str(uuid4())})
+
+        with _block(
+            _patches(
+                conv_owner_id=user_id,
+                conv_id=conv_id,
+                deleted_id=str(uuid4()),
+                create_mock=create_mock,
+            )
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 200
+        out = resp.text
+        assert json.dumps(_ANSWER_TEXT) in out  # token chunk
+        assert "event: sources" in out  # its own citations
+        assert "data: [DONE]" in out
+        # The fresh assistant message was persisted.
+        assert create_mock.call_count == 1
+        assert create_mock.call_args.kwargs["role"] == "assistant"
+
+    async def test_regenerate_consumes_rate_limit_quota(self, message_store) -> None:
+        """A successful regenerate records one message against the daily cap."""
+        from backend.main import app
+
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+        create_mock = AsyncMock(return_value={"id": str(uuid4())})
+
+        assert len(message_store[user_id]) == 0
+        with _block(
+            _patches(
+                conv_owner_id=user_id,
+                conv_id=conv_id,
+                deleted_id=str(uuid4()),
+                create_mock=create_mock,
+            )
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 200
+        # check_and_record (conftest fake) appended exactly one timestamp.
+        assert len(message_store[user_id]) == 1
+
+    async def test_regenerate_rejected_when_cap_reached(self, message_store) -> None:
+        """At the cap, regenerate returns 429 and never streams."""
+        from datetime import UTC, datetime
+
+        from backend import rate_limit
+        from backend.main import app
+
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+        # Pre-fill the window to the cap so check_and_record raises.
+        message_store[user_id] = [datetime.now(UTC)] * rate_limit.DAILY_MESSAGE_CAP
+        create_mock = AsyncMock(return_value={"id": str(uuid4())})
+
+        with _block(
+            _patches(
+                conv_owner_id=user_id,
+                conv_id=conv_id,
+                deleted_id=str(uuid4()),
+                create_mock=create_mock,
+            )
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+        # No assistant message was persisted on a rate-limited regenerate.
+        assert create_mock.call_count == 0
+
+    async def test_regenerate_404_when_no_assistant_message(self) -> None:
+        """When the conversation has no assistant turn, regenerate 404s and
+        does not stream."""
+        from backend.main import app
+
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+        create_mock = AsyncMock(return_value={"id": str(uuid4())})
+
+        with _block(
+            _patches(
+                conv_owner_id=user_id,
+                conv_id=conv_id,
+                deleted_id=None,  # nothing to delete
+                create_mock=create_mock,
+            )
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 404
+        assert create_mock.call_count == 0
+
+    async def test_regenerate_cross_user_returns_404(self) -> None:
+        """A user regenerating someone else's conversation gets 404 (no leak),
+        and the assistant message is never deleted."""
+        from backend.main import app
+
+        owner_id = str(uuid4())
+        attacker_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(attacker_id)
+        create_mock = AsyncMock(return_value={"id": str(uuid4())})
+
+        delete_mock = AsyncMock(return_value=str(uuid4()))
+
+        async def mock_get_user_by_id(user_id):
+            return {
+                "id": attacker_id,
+                "email": "attacker@example.com",
+                "password_hash": "hashed",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        async def mock_get_conversation(c_id, user_id):
+            # Conversation belongs to owner_id; attacker query returns None.
+            if c_id == conv_id and str(user_id) == owner_id:
+                return {"id": conv_id, "user_id": owner_id, "title": "t"}
+            return None
+
+        with _block(
+            [
+                patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+                patch("backend.db.repository.get_conversation", mock_get_conversation),
+                patch("backend.db.repository.delete_last_assistant_message", delete_mock),
+                patch("backend.db.repository.create_message", create_mock),
+            ]
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 404
+        delete_mock.assert_not_called()
+        assert create_mock.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Repository unit test: delete_last_assistant_message
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteLastAssistantMessage:
+    async def test_returns_deleted_id_and_targets_newest_assistant(self) -> None:
+        """The DELETE selects the newest assistant message (ORDER BY created_at
+        DESC LIMIT 1) scoped to the owner, and returns its id."""
+        from backend.db import repository
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value={"id": "msg-newest"})
+        mock_conn.execute = AsyncMock(return_value="UPDATE 1")  # touch_conversation
+
+        with patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)):
+            deleted = await repository.delete_last_assistant_message(
+                conversation_id="conv-1", user_id="user-1"
+            )
+
+        assert deleted == "msg-newest"
+        sql = mock_conn.fetchrow.call_args.args[0]
+        assert "DELETE FROM messages" in sql
+        assert "role = 'assistant'" in sql
+        assert "ORDER BY m.created_at DESC" in sql
+        assert "LIMIT 1" in sql
+        # Ownership join present so a cross-user call can't delete.
+        assert "c.user_id = $2" in sql
+
+    async def test_returns_none_when_no_assistant_message(self) -> None:
+        """No assistant row → returns None and does not touch the conversation."""
+        from backend.db import repository
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+        mock_conn.execute = AsyncMock()
+
+        with patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)):
+            deleted = await repository.delete_last_assistant_message(
+                conversation_id="conv-1", user_id="user-1"
+            )
+
+        assert deleted is None
+        # touch_conversation must not run when nothing was deleted.
+        mock_conn.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeAcquire:
+    """Dual-purpose awaitable + async context manager wrapping a mock conn."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __await__(self):
+        async def _do():
+            return self._conn
+
+        return _do().__await__()
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _block:
+    """Enter a list of context managers together (like contextlib.ExitStack)."""
+
+    def __init__(self, managers):
+        self._managers = managers
+
+    def __enter__(self):
+        for m in self._managers:
+            m.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        for m in reversed(self._managers):
+            m.__exit__(*exc)
+        return False

--- a/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for ChatArea regenerate orchestration (issue #280).
+ *
+ * Covers:
+ *  - the Regenerate action renders only on the most recent assistant message,
+ *  - clicking it calls startRegenerate and optimistically removes the old answer,
+ *  - the completion callback appends the fresh assistant message,
+ *  - the button is hidden while a stream is in flight,
+ *  - a failed regenerate restores the previous answer and surfaces an error.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArea } from '../components/ChatArea';
+import type { Message } from '../lib/api';
+
+// ── Shared mocks ──────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+let mockMessages: Message[] = [];
+const setMessagesSpy = vi.fn();
+
+vi.mock('../hooks/useMessages', () => ({
+  useMessages: () => ({
+    messages: mockMessages,
+    setMessages: setMessagesSpy,
+    loading: false,
+    error: null,
+    notFound: false,
+    conversation: { id: 'conv-1', title: 'Test Chat', created_at: '', updated_at: '' },
+  }),
+}));
+
+let mockIsStreaming = false;
+const startRegenerateSpy = vi.fn();
+
+vi.mock('../hooks/useStreamingResponse', () => ({
+  useStreamingResponse: () => ({
+    streamingContent: '',
+    streamingSources: [],
+    streamingStatus: null,
+    isStreaming: mockIsStreaming,
+    startStream: vi.fn(),
+    startRegenerate: startRegenerateSpy,
+    abortStream: vi.fn(),
+  }),
+}));
+
+const addToastSpy = vi.fn();
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ addToast: addToastSpy, removeToast: vi.fn() }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user', email: 'test@test.com', is_admin: false },
+    refresh: vi.fn(),
+  }),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function userMsg(id: string, content: string): Message {
+  return {
+    id,
+    conversation_id: 'conv-1',
+    role: 'user',
+    content,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function assistantMsg(id: string, content: string): Message {
+  return {
+    id,
+    conversation_id: 'conv-1',
+    role: 'assistant',
+    content,
+    created_at: new Date().toISOString(),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ChatArea — regenerate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    mockIsStreaming = false;
+    startRegenerateSpy.mockReset();
+  });
+
+  afterEach(() => {
+    mockMessages = [];
+  });
+
+  const regenName = { name: /regenerate response/i };
+
+  it('renders the Regenerate action only on the most recent assistant message', () => {
+    mockMessages = [
+      userMsg('u1', 'first question'),
+      assistantMsg('a1', 'first answer'),
+      userMsg('u2', 'second question'),
+      assistantMsg('a2', 'second answer'),
+    ];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    // Exactly one regenerate button across the whole transcript.
+    expect(screen.getAllByRole('button', regenName)).toHaveLength(1);
+  });
+
+  it('hides the Regenerate action while a stream is in flight', () => {
+    mockIsStreaming = true;
+    mockMessages = [userMsg('u1', 'q'), assistantMsg('a1', 'a')];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('button', regenName)).not.toBeInTheDocument();
+  });
+
+  it('removes the stale answer and appends the fresh one on success', async () => {
+    startRegenerateSpy.mockResolvedValue(undefined);
+    mockMessages = [userMsg('u1', 'q'), assistantMsg('a1', 'stale answer')];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', regenName));
+
+    // startRegenerate called with the conversation id + a completion callback.
+    expect(startRegenerateSpy).toHaveBeenCalledTimes(1);
+    expect(startRegenerateSpy.mock.calls[0][0]).toBe('conv-1');
+    const onComplete = startRegenerateSpy.mock.calls[0][1] as (r: {
+      fullText: string;
+      sources: never[];
+    }) => void;
+
+    // First setMessages call optimistically drops the stale assistant answer.
+    const removeUpdater = setMessagesSpy.mock.calls[0][0] as (prev: Message[]) => Message[];
+    expect(removeUpdater(mockMessages).map((m) => m.id)).toEqual(['u1']);
+
+    // Drive the completion callback → the fresh answer is appended.
+    setMessagesSpy.mockClear();
+    onComplete({ fullText: 'fresh answer', sources: [] });
+    const appendUpdater = setMessagesSpy.mock.calls[0][0] as (prev: Message[]) => Message[];
+    const appended = appendUpdater([userMsg('u1', 'q')]);
+    expect(appended).toHaveLength(2);
+    expect(appended[1]).toMatchObject({ role: 'assistant', content: 'fresh answer' });
+  });
+
+  it('restores the previous answer and shows an error when regenerate fails', async () => {
+    startRegenerateSpy.mockRejectedValue(new Error('network boom'));
+    const previous = assistantMsg('a1', 'previous answer');
+    mockMessages = [userMsg('u1', 'q'), previous];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', regenName));
+
+    // The inline error renders after the rejected promise settles.
+    await waitFor(() => {
+      expect(screen.getByText(/failed to regenerate/i)).toBeInTheDocument();
+    });
+
+    // A restore updater re-adds the previous answer when it's no longer present.
+    const restoreCall = setMessagesSpy.mock.calls.find((call) => {
+      const updater = call[0] as (prev: Message[]) => Message[];
+      return updater([userMsg('u1', 'q')]).some((m) => m.id === 'a1');
+    });
+    expect(restoreCall).toBeDefined();
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -583,6 +584,89 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     handleSend(text);
   }, [failedMessageText, handleSend]);
 
+  // ── Regenerate handler ──
+  // Re-runs the user's last question and replaces the most recent assistant
+  // answer with a fresh stream (issue #280). Mirrors handleSend's optimistic
+  // pattern: drop the stale answer, let the streaming bubble render the new
+  // tokens in its place, append the persisted message on completion. On
+  // failure the previous answer is restored so the turn is never left blank.
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId || isStreaming) return;
+
+    // Find the most recent assistant message — the only one regenerate touches.
+    let snapshot: MessageType | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'assistant') {
+        snapshot = messages[i];
+        break;
+      }
+    }
+    if (!snapshot) return;
+    const previous = snapshot;
+
+    setInlineError(null);
+    setFailedMessageText(null);
+
+    // Optimistically remove the stale answer; the streaming bubble takes its place.
+    setMessages((prev) => prev.filter((m) => m.id !== previous.id));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    let completed = false;
+    try {
+      await startRegenerate(conversationId, ({ fullText, sources }) => {
+        completed = true;
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      // Refresh the quota counter so the sidebar reflects the consumed message.
+      refreshAuth();
+    } catch (e) {
+      // Restore the previous answer if no fresh content streamed in, so the
+      // user is never left with a blank turn (rate-limit, network, 401).
+      if (!completed) {
+        setMessages((prev) =>
+          prev.some((m) => m.id === previous.id) ? prev : [...prev, previous],
+        );
+      }
+
+      // Intentional abort (navigation or user cancel) — no error toast.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        // Daily cap hit — the regenerate consumed no answer (429 fires before
+        // the delete), so the restored message above is the real DB state.
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate response';
+      setInlineError('Failed to regenerate the response. Please try again.');
+      addToast(errMsg || 'Network error — could not regenerate', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    setMessages,
+    startRegenerate,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+  ]);
+
   // ── Starter click handler ──
   const handleStarterClick = useCallback((text: string) => {
     chatInputRef.current?.setInputText(text);
@@ -601,6 +685,16 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // before dispatchedInitialRef fires (#205).
   const showEmptyInConversation =
     messages.length === 0 && !inlineError && !isStreaming && !location.state?.initialMessage;
+
+  // ID of the most recent assistant message — the only bubble that gets a
+  // regenerate action (issue #280). null when the conversation has no
+  // assistant turn yet (e.g. first send still in flight).
+  const lastAssistantId = (() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'assistant') return messages[i].id;
+    }
+    return null;
+  })();
 
   const handleExport = useCallback(() => {
     try {
@@ -715,6 +809,11 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  // Regenerate is offered only on the latest assistant answer,
+                  // and only while idle (issue #280).
+                  onRegenerate={
+                    !isStreaming && msg.id === lastAssistantId ? handleRegenerate : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Citation } from '../lib/api';
 import { Message } from './Message';
@@ -147,5 +147,44 @@ describe('Message — citation chip segment_count label', () => {
       />,
     );
     expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — regenerate action (issue #280)', () => {
+  it('renders a Regenerate button on an assistant message when onRegenerate is provided', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." onRegenerate={onRegenerate} />,
+    );
+    const btn = screen.getByRole('button', { name: /regenerate response/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it('invokes onRegenerate when the button is clicked', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." onRegenerate={onRegenerate} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /regenerate response/i }));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a Regenerate button when onRegenerate is absent', () => {
+    render(<Message role="assistant" content="An answer." />);
+    expect(screen.queryByRole('button', { name: /regenerate response/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render a Regenerate button on a user message', () => {
+    const onRegenerate = vi.fn();
+    render(<Message role="user" content="My question." onRegenerate={onRegenerate} />);
+    expect(screen.queryByRole('button', { name: /regenerate response/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render a Regenerate button while the assistant message is still streaming', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="" isStreaming={true} onRegenerate={onRegenerate} />,
+    );
+    expect(screen.queryByRole('button', { name: /regenerate response/i })).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,63 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /**
+   * When provided on an assistant message, renders a "Regenerate" action that
+   * re-runs the last question (issue #280). ChatArea passes this only to the
+   * most recent assistant bubble.
+   */
+  onRegenerate?: () => void;
+}
+
+// ── Regenerate action (circular-arrow icon) ───────────────────────
+function RegenerateButton({ onRegenerate }: { onRegenerate: () => void }) {
+  return (
+    <button
+      onClick={onRegenerate}
+      title="Regenerate response"
+      aria-label="Regenerate response"
+      className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        marginTop: 10,
+        padding: '4px 10px',
+        background: 'transparent',
+        border: '1px solid rgba(255,255,255,0.12)',
+        borderRadius: 7,
+        color: '#94a3b8',
+        cursor: 'pointer',
+        fontSize: 12,
+        fontFamily: 'inherit',
+        transition: 'background 0.15s, color 0.15s',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'rgba(255,255,255,0.05)';
+        e.currentTarget.style.color = '#f1f5f9';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent';
+        e.currentTarget.style.color = '#94a3b8';
+      }}
+    >
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 13 13"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M11,6.5 A4.5,4.5 0 1,1 9.5,3.2" />
+        <polyline points="11,1.5 11,3.5 9,3.5" />
+      </svg>
+      Regenerate
+    </button>
+  );
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,6 +224,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +262,7 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && <RegenerateButton onRegenerate={onRegenerate} />}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Citation, RateLimitError } from '../lib/api';
+import { type Citation, RateLimitError, regenerateResponse } from '../lib/api';
 
 export interface StreamResult {
   fullText: string;
@@ -42,10 +42,15 @@ export function useStreamingResponse(conversationId: string | null) {
     }
   }, []);
 
-  const startStream = useCallback(
+  // Shared SSE consumer for both the normal send and regenerate flows. The
+  // only difference between the two is how the request is issued (`doFetch`);
+  // the 401/429/error handling, token/sources/status parsing, and the
+  // streaming-state reset are identical, so they live here once. The caller's
+  // `doFetch` receives the abort signal so an in-flight stream can be cancelled
+  // via `abortStream`.
+  const runStream = useCallback(
     async (
-      conversationId: string,
-      userMessage: string,
+      doFetch: (signal: AbortSignal) => Promise<Response>,
       onComplete: (result: StreamResult) => void,
     ): Promise<void> => {
       setIsStreaming(true);
@@ -61,13 +66,7 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
-          signal: abortController.signal,
-        });
+        const res = await doFetch(abortController.signal);
 
         if (res.status === 401) {
           if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
@@ -218,12 +217,43 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startStream = useCallback(
+    (
+      conversationId: string,
+      userMessage: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> =>
+      runStream(
+        (signal) =>
+          fetch(`/api/conversations/${conversationId}/messages`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: userMessage }),
+            signal,
+          }),
+        onComplete,
+      ),
+    [runStream],
+  );
+
+  // Regenerate consumes the regenerate SSE stream exactly like a normal send,
+  // but issues no optimistic user message — the user's question is already the
+  // last persisted message. The backend deletes the stale answer and replays
+  // the history, so the stream shape (tokens → sources → [DONE]) is identical.
+  const startRegenerate = useCallback(
+    (conversationId: string, onComplete: (result: StreamResult) => void): Promise<void> =>
+      runStream((signal) => regenerateResponse(conversationId, signal), onComplete),
+    [runStream],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   };
 }

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -158,6 +158,25 @@ export const renameConversation = (id: string, title: string) =>
     body: JSON.stringify({ title }),
   });
 
+/**
+ * Regenerate the most recent assistant response (issue #280).
+ *
+ * POSTs to the regenerate endpoint and returns the raw `Response` so the
+ * SSE hook can read the streaming body directly — mirrors how the normal
+ * send flow consumes `POST /conversations/{id}/messages`. The body is empty;
+ * the server replays the conversation history after dropping the stale answer.
+ */
+export const regenerateResponse = (
+  conversationId: string,
+  signal?: AbortSignal,
+): Promise<Response> =>
+  fetch(`${BASE}/conversations/${conversationId}/regenerate`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    signal,
+  });
+
 // Videos
 export const getVideos = () => request<Video[]>('/videos');
 


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `762207db-3c24-4ecd-8268-1d97ef815394`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.