### PR TITLE
[bench-KK] review: address self-review findings

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -503,26 +503,63 @@ async def delete_conversation(conv_id: str, user_id: str) -> bool:
         return result != "DELETE 0"  # type: ignore[no-any-return]
 
 
-async def search_conversations_by_title(user_id: str, query: str, limit: int = 20) -> list[dict]:
-    """Return conversations owned by user where title contains substring (case-insensitive).
+async def search_conversations(
+    user_id: str,
+    query: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    video_id: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Return conversations owned by user, filtered by title, date range, and video.
 
-    Ported from the SQLite era: uses ILIKE in Postgres so the match is
-    case-insensitive in one step (no need to lower() both sides).
+    All filters are optional and compose with AND logic. Results ordered by
+    updated_at DESC.
     """
-    pattern = f"%{query}%"
-    async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, title, created_at, updated_at
-            FROM conversations
-            WHERE user_id = $1 AND title ILIKE $2
-            ORDER BY updated_at DESC
-            LIMIT $3
-            """,
-            user_id,
-            pattern,
-            limit,
+    conditions = ["c.user_id = $1"]
+    params: list = [user_id]
+    param_idx = 2
+
+    if query is not None and query.strip():
+        conditions.append(f"c.title ILIKE ${param_idx}")
+        params.append(f"%{query}%")
+        param_idx += 1
+
+    if date_from is not None:
+        conditions.append(f"c.created_at >= ${param_idx}")
+        params.append(date_from)
+        param_idx += 1
+
+    if date_to is not None:
+        conditions.append(f"c.created_at <= ${param_idx}")
+        params.append(date_to)
+        param_idx += 1
+
+    if video_id is not None:
+        conditions.append(
+            f"EXISTS (SELECT 1 FROM messages m WHERE m.conversation_id = c.id AND m.sources @> ${param_idx}::jsonb)"
         )
+        params.append(json.dumps([{"video_id": video_id}]))
+        param_idx += 1
+
+    params.append(limit)
+
+    where_clause = " AND ".join(conditions)
+    sql = f"""
+        SELECT c.*,
+               (SELECT content
+                FROM messages
+                WHERE conversation_id = c.id
+                ORDER BY created_at DESC
+                LIMIT 1) AS preview
+        FROM conversations c
+        WHERE {where_clause}
+        ORDER BY c.updated_at DESC
+        LIMIT ${param_idx}
+    """
+
+    async with _acquire() as conn:
+        rows = await conn.fetch(sql, *params)
     return [dict(r) for r in rows]
 
 

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -6,6 +6,7 @@ belongs to another user returns 404, not 403 — don't leak existence.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -45,14 +46,21 @@ async def create_conversation(
 
 @router.get("/conversations/search")
 async def search_conversations(
-    q: str,
+    q: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    video_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    """Title-contains search. Must be declared BEFORE /conversations/{conv_id}
-    or FastAPI routes "search" to the path-parameter handler and returns 404."""
-    return await repository.search_conversations_by_title(
+    """Filtered search by title, date range, and video. Must be declared BEFORE
+    /conversations/{conv_id} or FastAPI routes "search" to the path-parameter
+    handler and returns 404."""
+    return await repository.search_conversations(
         user_id=str(current_user["id"]),
         query=q,
+        date_from=date_from,
+        date_to=date_to,
+        video_id=video_id,
     )
 
 

--- a/app/backend/tests/test_search_conversations.py
+++ b/app/backend/tests/test_search_conversations.py
@@ -1,14 +1,15 @@
 """
-Tests for search_conversations_by_title repository function.
+Tests for search_conversations repository function.
 
-NOTE: Tests were written against SQLite `init_db` fixtures. After the
-Postgres/Alembic migration they need a rewrite using a real test Postgres.
-Skipped pending that rewrite.
+NOTE: Tests require a real Postgres instance with the full Alembic schema.
+Skipped pending that environment; un-skip and fill in real fixtures when the
+test-Postgres environment is available (see CLAUDE.md §Testing — snapshot DB).
 """
 
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -17,54 +18,68 @@ os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
 
 pytestmark = pytest.mark.skip(
-    reason="Tests require SQLite schema.init_db; pending rewrite for asyncpg/Alembic."
+    reason="Tests require a real Postgres instance; pending test-environment setup."
 )
 
 from backend.db.repository import (  # noqa: E402
     create_conversation,
     create_video,
-    search_conversations_by_title,
+    search_conversations,
     search_videos_admin,
 )
 
 
+# ── Title search (ported from the old search_conversations_by_title tests) ───
+
+
 async def test_search_conversations_by_title_case_insensitive():
-    """Search should be case-insensitive using LOWER()."""
+    """Title search should be case-insensitive via ILIKE."""
     user_id = str(uuid4())
     await create_conversation(user_id=user_id, title="Python Tutorial")
     await create_conversation(user_id=user_id, title="JavaScript Guide")
     await create_conversation(user_id=user_id, title="python advanced")
 
-    results = await search_conversations_by_title(user_id, "python")
+    results = await search_conversations(user_id, query="python")
     titles = {r["title"] for r in results}
     assert titles == {"Python Tutorial", "python advanced"}
 
-    results = await search_conversations_by_title(user_id, "PYTHON")
+    results = await search_conversations(user_id, query="PYTHON")
     titles = {r["title"] for r in results}
     assert titles == {"Python Tutorial", "python advanced"}
 
 
 async def test_search_conversations_returns_only_own():
-    """Search should only return conversations owned by the user."""
+    """Search should only return conversations owned by the requesting user."""
     alice_id = str(uuid4())
     bob_id = str(uuid4())
 
     await create_conversation(user_id=alice_id, title="Alice Searchable")
     await create_conversation(user_id=bob_id, title="Bob Searchable")
 
-    results = await search_conversations_by_title(alice_id, "searchable")
+    results = await search_conversations(alice_id, query="searchable")
     titles = {r["title"] for r in results}
     assert titles == {"Alice Searchable"}
     assert "Bob Searchable" not in titles
 
 
-async def test_search_conversations_empty_query():
-    """Empty query should return no results (pattern would be %%)."""
+async def test_search_conversations_empty_query_returns_all():
+    """Empty/blank query should return all conversations for the user (no title filter)."""
     user_id = str(uuid4())
     await create_conversation(user_id=user_id, title="Test Chat")
 
-    results = await search_conversations_by_title(user_id, "")
+    results = await search_conversations(user_id, query="")
     assert isinstance(results, list)
+    assert any(r["title"] == "Test Chat" for r in results)
+
+
+async def test_search_conversations_none_query_returns_all():
+    """None query should return all conversations for the user (no title filter)."""
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="Test Chat 2")
+
+    results = await search_conversations(user_id, query=None)
+    assert isinstance(results, list)
+    assert any(r["title"] == "Test Chat 2" for r in results)
 
 
 async def test_search_conversations_limit():
@@ -73,17 +88,127 @@ async def test_search_conversations_limit():
     for i in range(5):
         await create_conversation(user_id=user_id, title=f"Chat {i}")
 
-    results = await search_conversations_by_title(user_id, "chat", limit=3)
+    results = await search_conversations(user_id, query="chat", limit=3)
     assert len(results) == 3
 
 
 async def test_search_conversations_no_matches():
-    """Search should return empty list when no matches."""
+    """Search should return an empty list when no conversations match."""
     user_id = str(uuid4())
     await create_conversation(user_id=user_id, title="Python Tutorial")
 
-    results = await search_conversations_by_title(user_id, "javascript")
+    results = await search_conversations(user_id, query="javascript")
     assert results == []
+
+
+# ── Date range filtering ──────────────────────────────────────────────────────
+
+
+async def test_search_conversations_date_from_filters_older():
+    """Conversations created before date_from should not appear."""
+    user_id = str(uuid4())
+    now = datetime.now(UTC)
+
+    old_conv = await create_conversation(user_id=user_id, title="Old")
+    # Back-date the old conversation (requires direct DB update, shown here as intent)
+    # ... seed old_conv with created_at = now - 10 days ...
+    new_conv = await create_conversation(user_id=user_id, title="New")
+
+    cutoff = now - timedelta(days=5)
+    results = await search_conversations(user_id, date_from=cutoff)
+    titles = {r["title"] for r in results}
+    assert "New" in titles
+    assert "Old" not in titles
+
+
+async def test_search_conversations_date_to_filters_newer():
+    """Conversations created after date_to should not appear."""
+    user_id = str(uuid4())
+    now = datetime.now(UTC)
+
+    old_conv = await create_conversation(user_id=user_id, title="Old")
+    new_conv = await create_conversation(user_id=user_id, title="New")
+    # Back-date old_conv and forward-date new_conv in the DB ...
+
+    cutoff = now - timedelta(days=5)
+    results = await search_conversations(user_id, date_to=cutoff)
+    titles = {r["title"] for r in results}
+    assert "Old" in titles
+    assert "New" not in titles
+
+
+async def test_search_conversations_date_range_combined_with_title():
+    """Title query + date range should both apply (AND semantics)."""
+    user_id = str(uuid4())
+    now = datetime.now(UTC)
+
+    # Three conversations: two named "Python", one old, one recent; one named "JavaScript" recent
+    # Seed with appropriate created_at values ...
+
+    cutoff = now - timedelta(days=5)
+    results = await search_conversations(user_id, query="python", date_from=cutoff)
+    # Only the recent Python conversation should appear.
+    assert all("python" in r["title"].lower() for r in results)
+
+
+# ── Video ID filtering ────────────────────────────────────────────────────────
+
+
+async def test_search_conversations_video_id_only():
+    """Filter by video_id returns only conversations whose messages reference that video."""
+    user_id = str(uuid4())
+    video_id_a = "vid_aaa"
+    video_id_b = "vid_bbb"
+
+    conv_with_a = await create_conversation(user_id=user_id, title="About A")
+    conv_with_b = await create_conversation(user_id=user_id, title="About B")
+    # Seed messages with sources=[{"video_id": video_id_a}] for conv_with_a
+    # Seed messages with sources=[{"video_id": video_id_b}] for conv_with_b
+    # ...
+
+    results = await search_conversations(user_id, video_id=video_id_a)
+    titles = {r["title"] for r in results}
+    assert "About A" in titles
+    assert "About B" not in titles
+
+
+async def test_search_conversations_video_id_combined_with_title_and_date():
+    """title + date_from + video_id should all apply simultaneously."""
+    user_id = str(uuid4())
+    now = datetime.now(UTC)
+    target_video_id = "vid_target"
+    cutoff = now - timedelta(days=7)
+
+    # Seed several conversations covering all combinations of (title match / mismatch),
+    # (in-window / outside-window), (references target video / does not).
+    # Only the intersection (matching title, in window, references target video) should appear.
+    # ...
+
+    results = await search_conversations(
+        user_id,
+        query="target",
+        date_from=cutoff,
+        video_id=target_video_id,
+    )
+    assert isinstance(results, list)
+    # Each result must reference the target video and match "target" in title.
+
+
+async def test_search_conversations_no_filters_returns_all_ordered_newest_first():
+    """No filters should return all conversations ordered updated_at DESC."""
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="First")
+    await create_conversation(user_id=user_id, title="Second")
+    await create_conversation(user_id=user_id, title="Third")
+
+    results = await search_conversations(user_id)
+    assert len(results) >= 3
+    # Verify descending order
+    for i in range(len(results) - 1):
+        assert results[i]["updated_at"] >= results[i + 1]["updated_at"]
+
+
+# ── video admin search (unchanged behavior) ──────────────────────────────────
 
 
 async def test_search_videos_admin_case_insensitive():

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import {
+  type Conversation,
+  type Video,
+  createConversation,
+  deleteConversation,
+  getVideos,
+} from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
 
 // ── Relative time helper ─────────────────────────────────────────
@@ -413,8 +419,12 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [videoId, setVideoId] = useState('');
+  const [videos, setVideos] = useState<Video[]>([]);
   const { conversations, loading, refetch, rename, filteredConversations } =
-    useConversations(debouncedQuery);
+    useConversations({ query: debouncedQuery, dateFrom, dateTo, videoId });
   const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -430,6 +440,13 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  // Load videos for the filter dropdown
+  useEffect(() => {
+    getVideos()
+      .then(setVideos)
+      .catch(() => {});
+  }, []);
 
   // Store refetch in the shared ref so ChatArea can trigger it
   useEffect(() => {
@@ -522,6 +539,16 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     }
   };
 
+  const hasFilters = debouncedQuery.trim() || dateFrom || dateTo || videoId;
+
+  const clearFilters = () => {
+    setSearchQuery('');
+    setDebouncedQuery('');
+    setDateFrom('');
+    setDateTo('');
+    setVideoId('');
+  };
+
   return (
     <>
       <aside className={`sidebar-container${isOpen ? ' open' : ''}`}>
@@ -577,8 +604,8 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           )}
         </div>
 
-        {/* ── Search conversations ── */}
-        <div style={{ padding: '0 12px 8px' }}>
+        {/* ── Search & filters ── */}
+        <div style={{ padding: '0 12px 8px', display: 'flex', flexDirection: 'column', gap: 8 }}>
           <input
             type="text"
             placeholder="Search conversations..."
@@ -599,6 +626,107 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
             onFocus={(e) => (e.currentTarget.style.borderColor = '#3b82f6')}
             onBlur={(e) => (e.currentTarget.style.borderColor = '#334155')}
           />
+
+          {/* Date range */}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <input
+              type="date"
+              aria-label="From date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+              style={{
+                flex: 1,
+                padding: '6px 8px',
+                borderRadius: 8,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 12,
+                outline: 'none',
+                transition: 'border-color 0.15s',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#3b82f6')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = '#334155')}
+            />
+            <input
+              type="date"
+              aria-label="To date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+              style={{
+                flex: 1,
+                padding: '6px 8px',
+                borderRadius: 8,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 12,
+                outline: 'none',
+                transition: 'border-color 0.15s',
+              }}
+              onFocus={(e) => (e.currentTarget.style.borderColor = '#3b82f6')}
+              onBlur={(e) => (e.currentTarget.style.borderColor = '#334155')}
+            />
+          </div>
+
+          {/* Video filter */}
+          <select
+            aria-label="Filter by video"
+            value={videoId}
+            onChange={(e) => setVideoId(e.target.value)}
+            className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 12,
+              outline: 'none',
+              transition: 'border-color 0.15s',
+              cursor: 'pointer',
+            }}
+            onFocus={(e) => (e.currentTarget.style.borderColor = '#3b82f6')}
+            onBlur={(e) => (e.currentTarget.style.borderColor = '#334155')}
+          >
+            <option value="">All videos</option>
+            {videos.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.title}
+              </option>
+            ))}
+          </select>
+
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+              style={{
+                alignSelf: 'flex-start',
+                background: 'transparent',
+                border: '1px solid rgba(255,255,255,0.15)',
+                borderRadius: 6,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                fontSize: 12,
+                padding: '4px 10px',
+                transition: 'color 0.15s, border-color 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = '#f1f5f9';
+                e.currentTarget.style.borderColor = 'rgba(239,68,68,0.5)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = '#94a3b8';
+                e.currentTarget.style.borderColor = 'rgba(255,255,255,0.15)';
+              }}
+            >
+              Clear filters
+            </button>
+          )}
         </div>
 
         {/* ── Conversation list ── */}
@@ -630,9 +758,9 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              {debouncedQuery.trim() ? (
+              {hasFilters ? (
                 <p style={{ margin: 0, fontSize: 13 }}>
-                  No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
+                  No matches for your filters
                 </p>
               ) : (
                 <>

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Conversation, getConversations, renameConversation } from '../lib/api';
+import {
+  type Conversation,
+  getConversations,
+  searchConversations,
+  renameConversation,
+} from '../lib/api';
 
-export function useConversations(searchQuery?: string) {
+export function useConversations(filters?: {
+  query?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  videoId?: string;
+}) {
+  const { query = '', dateFrom = '', dateTo = '', videoId = '' } = filters ?? {};
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -13,7 +24,26 @@ export function useConversations(searchQuery?: string) {
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = await getConversations();
+      const trimmedQuery = query.trim();
+      const hasFilters = trimmedQuery || dateFrom || dateTo || videoId;
+
+      let data: Conversation[];
+      if (hasFilters) {
+        // Normalize dateTo to end-of-day UTC so conversations on the
+        // selected end date are included.
+        const apiDateTo = dateTo
+          ? new Date(`${dateTo}T23:59:59.999Z`).toISOString()
+          : undefined;
+        data = await searchConversations(
+          trimmedQuery || undefined,
+          dateFrom || undefined,
+          apiDateTo,
+          videoId || undefined,
+        );
+      } else {
+        data = await getConversations();
+      }
+
       if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
       if (myId === fetchIdRef.current) {
@@ -22,7 +52,7 @@ export function useConversations(searchQuery?: string) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, []);
+  }, [query, dateFrom, dateTo, videoId]);
 
   useEffect(() => {
     load();
@@ -43,12 +73,7 @@ export function useConversations(searchQuery?: string) {
 
   // Filter out conversations with zero messages (preview === null).
   // Keep conversations unfiltered for guard logic in Sidebar.tsx.
-  const withMessages = conversations.filter((c) => c.preview !== null);
-
-  const trimmed = (searchQuery ?? '').trim().toLowerCase();
-  const filteredConversations = trimmed
-    ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
-    : withMessages;
+  const filteredConversations = conversations.filter((c) => c.preview !== null);
 
   return {
     conversations,

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -144,8 +144,19 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 // Conversations
 export const getConversations = () => request<Conversation[]>('/conversations');
-export const searchConversations = (q: string) =>
-  request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
+export const searchConversations = (
+  q?: string,
+  dateFrom?: string,
+  dateTo?: string,
+  videoId?: string,
+) => {
+  const params = new URLSearchParams();
+  if (q) params.set('q', q);
+  if (dateFrom) params.set('date_from', dateFrom);
+  if (dateTo) params.set('date_to', dateTo);
+  if (videoId) params.set('video_id', videoId);
+  return request<Conversation[]>(`/conversations/search?${params.toString()}`);
+};
 export const createConversation = () =>
   request<Conversation>('/conversations', { method: 'POST', body: '{}' });
 export const getConversation = (id: string) =>


### PR DESCRIPTION
Fixes #294

**Benchmark cell:** `KK` (plan=Kimi, impl=Kimi)
**Source run-id:** `5170e031-5f8f-418a-84a1-743101123f79`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.