### PR TITLE
[bench-KO] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -526,6 +526,90 @@ async def search_conversations_by_title(user_id: str, query: str, limit: int = 2
     return [dict(r) for r in rows]
 
 
+async def search_conversations(
+    user_id: str,
+    q: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    video_id: str | None = None,
+) -> list[dict]:
+    """Filter a user's conversations by optional title text, date range, and video.
+
+    Every filter is optional and the non-null ones combine with AND. The result
+    mirrors ``list_conversations`` (same columns + ``preview`` subquery) and is
+    ordered most-recent-first. Filters are scoped to the owning user; a NULL
+    parameter disables that filter via the ``$N IS NULL OR ...`` guard so a
+    single prepared statement covers every combination.
+
+    - ``q``: case-insensitive substring match on the title (ILIKE).
+    - ``start_date`` / ``end_date``: ISO 8601 bounds on ``updated_at`` (inclusive),
+      passed straight through to Postgres TIMESTAMPTZ parsing.
+    - ``video_id``: keeps only conversations whose messages cite the given video,
+      extracted from the ``messages.sources`` JSONB citation array.
+    """
+    pattern = f"%{q}%" if q is not None else None
+    async with _acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT c.*,
+                   (SELECT content
+                    FROM messages
+                    WHERE conversation_id = c.id
+                    ORDER BY created_at DESC
+                    LIMIT 1) AS preview
+            FROM conversations c
+            WHERE c.user_id = $1
+              AND ($2::text IS NULL OR c.title ILIKE $2)
+              AND ($3::timestamptz IS NULL OR c.updated_at >= $3::timestamptz)
+              AND ($4::timestamptz IS NULL OR c.updated_at <= $4::timestamptz)
+              AND ($5::text IS NULL OR EXISTS (
+                      SELECT 1
+                      FROM messages m
+                      WHERE m.conversation_id = c.id
+                        AND m.sources IS NOT NULL
+                        AND EXISTS (
+                            SELECT 1
+                            FROM jsonb_array_elements(m.sources) elem
+                            WHERE elem ->> 'video_id' = $5::text
+                        )
+                  ))
+            ORDER BY c.updated_at DESC
+            """,
+            user_id,
+            pattern,
+            start_date,
+            end_date,
+            video_id,
+        )
+    return [dict(r) for r in rows]
+
+
+async def list_conversation_videos(user_id: str) -> list[dict]:
+    """Return the distinct videos cited across the user's conversations.
+
+    Walks ``messages.sources`` (JSONB citation arrays) for the user's messages
+    and returns deduplicated ``{video_id, video_title}`` pairs, ordered by title.
+    Feeds the sidebar's "filter by video" dropdown.
+    """
+    async with _acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT DISTINCT
+                   elem ->> 'video_id'    AS video_id,
+                   elem ->> 'video_title' AS video_title
+            FROM messages m
+            JOIN conversations c ON c.id = m.conversation_id
+            CROSS JOIN LATERAL jsonb_array_elements(m.sources) elem
+            WHERE c.user_id = $1
+              AND m.sources IS NOT NULL
+              AND elem ->> 'video_id' IS NOT NULL
+            ORDER BY video_title
+            """,
+            user_id,
+        )
+    return [dict(r) for r in rows]
+
+
 # ---------------------------------------------------------------------------
 # Messages
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -45,15 +45,35 @@ async def create_conversation(
 
 @router.get("/conversations/search")
 async def search_conversations(
-    q: str,
+    q: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    video_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    """Title-contains search. Must be declared BEFORE /conversations/{conv_id}
+    """Filter a user's conversations by optional title text, date range, and video.
+
+    All params are optional and combine with AND; results stay newest-first and
+    include the `preview` field. Must be declared BEFORE /conversations/{conv_id}
     or FastAPI routes "search" to the path-parameter handler and returns 404."""
-    return await repository.search_conversations_by_title(
+    return await repository.search_conversations(
         user_id=str(current_user["id"]),
-        query=q,
+        q=q,
+        start_date=start_date,
+        end_date=end_date,
+        video_id=video_id,
     )
+
+
+@router.get("/conversations/videos")
+async def list_conversation_videos(
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Distinct videos cited in the user's conversations, for the filter dropdown.
+
+    Must be declared BEFORE /conversations/{conv_id} so FastAPI does not route
+    "videos" to the path-parameter handler."""
+    return await repository.list_conversation_videos(user_id=str(current_user["id"]))
 
 
 @router.get("/conversations/{conv_id}")

--- a/app/backend/tests/test_conversation_scoping.py
+++ b/app/backend/tests/test_conversation_scoping.py
@@ -250,6 +250,8 @@ async def test_repository_functions_require_user_id():
         "update_conversation_title",
         "touch_conversation",
         "delete_conversation",
+        "search_conversations",
+        "list_conversation_videos",
         "create_message",
         "list_messages",
     ]

--- a/app/backend/tests/test_filter_conversations.py
+++ b/app/backend/tests/test_filter_conversations.py
@@ -1,0 +1,117 @@
+"""
+Tests for the filtered conversation search (issue #294): combine title text,
+date range, and video filters, newest-first, user-scoped.
+
+NOTE: Like the other repository tests, these need a real test Postgres — the
+video filter relies on `jsonb_array_elements` over `messages.sources`, which has
+no SQLite analogue. Skipped pending the asyncpg/Alembic test harness, mirroring
+`test_search_conversations.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+pytestmark = pytest.mark.skip(
+    reason="Tests require a real test Postgres (jsonb_array_elements); pending harness."
+)
+
+from backend.db.repository import (  # noqa: E402
+    create_conversation,
+    create_message,
+    list_conversation_videos,
+    search_conversations,
+)
+
+
+async def _conv_with_video(user_id: str, title: str, video_id: str, video_title: str) -> str:
+    conv = await create_conversation(user_id=user_id, title=title)
+    await create_message(
+        conversation_id=conv["id"],
+        user_id=user_id,
+        role="assistant",
+        content="answer",
+        sources=[{"video_id": video_id, "video_title": video_title}],
+    )
+    return conv["id"]
+
+
+async def test_search_no_filters_returns_all_user_conversations():
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="One")
+    await create_conversation(user_id=user_id, title="Two")
+
+    results = await search_conversations(user_id)
+    assert {r["title"] for r in results} == {"One", "Two"}
+    # preview column is present (matches the Conversation interface)
+    assert all("preview" in r for r in results)
+
+
+async def test_search_filters_by_title():
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="Python basics")
+    await create_conversation(user_id=user_id, title="Rust basics")
+
+    results = await search_conversations(user_id, q="python")
+    assert {r["title"] for r in results} == {"Python basics"}
+
+
+async def test_search_filters_by_video():
+    user_id = str(uuid4())
+    target = await _conv_with_video(user_id, "About Docker", "vid-docker", "Docker 101")
+    await _conv_with_video(user_id, "About K8s", "vid-k8s", "Kubernetes 101")
+
+    results = await search_conversations(user_id, video_id="vid-docker")
+    assert [r["id"] for r in results] == [target]
+
+
+async def test_search_combines_title_and_video():
+    user_id = str(uuid4())
+    match = await _conv_with_video(user_id, "Docker deep dive", "vid-docker", "Docker 101")
+    # Same video, non-matching title.
+    await _conv_with_video(user_id, "Random chat", "vid-docker", "Docker 101")
+    # Matching title, different video.
+    await _conv_with_video(user_id, "Docker notes", "vid-other", "Other")
+
+    results = await search_conversations(user_id, q="deep dive", video_id="vid-docker")
+    assert [r["id"] for r in results] == [match]
+
+
+async def test_search_scoped_to_user():
+    alice = str(uuid4())
+    bob = str(uuid4())
+    await create_conversation(user_id=alice, title="Alice chat")
+    await create_conversation(user_id=bob, title="Bob chat")
+
+    results = await search_conversations(alice)
+    assert {r["title"] for r in results} == {"Alice chat"}
+
+
+async def test_search_orders_newest_first():
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="First")
+    await create_conversation(user_id=user_id, title="Second")
+
+    results = await search_conversations(user_id)
+    # updated_at DESC — most recently created/updated comes first.
+    assert results[0]["updated_at"] >= results[-1]["updated_at"]
+
+
+async def test_list_conversation_videos_dedupes_and_scopes():
+    user_id = str(uuid4())
+    await _conv_with_video(user_id, "Chat A", "vid-1", "Video One")
+    await _conv_with_video(user_id, "Chat B", "vid-1", "Video One")  # duplicate video
+    await _conv_with_video(user_id, "Chat C", "vid-2", "Video Two")
+
+    other = str(uuid4())
+    await _conv_with_video(other, "Other chat", "vid-3", "Video Three")
+
+    videos = await list_conversation_videos(user_id)
+    pairs = {(v["video_id"], v["video_title"]) for v in videos}
+    assert pairs == {("vid-1", "Video One"), ("vid-2", "Video Two")}

--- a/app/frontend/src/__tests__/conversationApi.test.ts
+++ b/app/frontend/src/__tests__/conversationApi.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getConversationVideos, searchConversations } from '../lib/api';
+
+describe('conversation filter api wrappers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function mockJson(body: unknown, status = 200) {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'OK',
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    });
+  }
+
+  function calledUrl(): string {
+    return (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+  }
+
+  it('searchConversations with no filters hits the bare search endpoint', async () => {
+    mockJson([]);
+    await searchConversations();
+    expect(calledUrl()).toBe('/api/conversations/search');
+  });
+
+  it('searchConversations encodes every filter into query params', async () => {
+    mockJson([]);
+    await searchConversations({
+      q: 'hello world',
+      startDate: '2026-01-01T00:00:00.000Z',
+      endDate: '2026-02-01T23:59:59.000Z',
+      videoId: 'vid-123',
+    });
+    const url = new URL(calledUrl(), 'http://localhost');
+    expect(url.pathname).toBe('/api/conversations/search');
+    expect(url.searchParams.get('q')).toBe('hello world');
+    expect(url.searchParams.get('start_date')).toBe('2026-01-01T00:00:00.000Z');
+    expect(url.searchParams.get('end_date')).toBe('2026-02-01T23:59:59.000Z');
+    expect(url.searchParams.get('video_id')).toBe('vid-123');
+  });
+
+  it('searchConversations omits falsy filter values', async () => {
+    mockJson([]);
+    await searchConversations({ q: '', videoId: 'vid-9' });
+    const url = new URL(calledUrl(), 'http://localhost');
+    expect(url.searchParams.has('q')).toBe(false);
+    expect(url.searchParams.get('video_id')).toBe('vid-9');
+  });
+
+  it('getConversationVideos hits the videos endpoint with credentials', async () => {
+    mockJson([{ video_id: 'v1', video_title: 'Intro' }]);
+    const res = await getConversationVideos();
+    expect(res).toEqual([{ video_id: 'v1', video_title: 'Intro' }]);
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/conversations/videos');
+    expect(init.credentials).toBe('include');
+  });
+});

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -3,8 +3,44 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import {
+  type Conversation,
+  type ConversationVideo,
+  createConversation,
+  deleteConversation,
+  getConversationVideos,
+} from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
+
+// ── Date-range filter presets ────────────────────────────────────
+type DatePreset = 'all' | 'this-week' | 'last-month' | 'custom';
+
+// Resolve a preset (or custom inputs) into ISO 8601 bounds for the backend.
+// `updated_at` is TIMESTAMPTZ, so passing ISO strings is safe. Custom end is
+// pinned to end-of-day so the chosen day is inclusive.
+function computeDateRange(
+  preset: DatePreset,
+  customStart: string,
+  customEnd: string,
+): { startDate?: string; endDate?: string } {
+  if (preset === 'this-week') {
+    const start = new Date();
+    start.setDate(start.getDate() - 7);
+    return { startDate: start.toISOString() };
+  }
+  if (preset === 'last-month') {
+    const start = new Date();
+    start.setMonth(start.getMonth() - 1);
+    return { startDate: start.toISOString() };
+  }
+  if (preset === 'custom') {
+    return {
+      startDate: customStart ? new Date(`${customStart}T00:00:00`).toISOString() : undefined,
+      endDate: customEnd ? new Date(`${customEnd}T23:59:59`).toISOString() : undefined,
+    };
+  }
+  return {};
+}
 
 // ── Relative time helper ─────────────────────────────────────────
 function formatRelativeTime(dateStr: string): string {
@@ -413,8 +449,22 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
-  const { conversations, loading, refetch, rename, filteredConversations } =
-    useConversations(debouncedQuery);
+  const [datePreset, setDatePreset] = useState<DatePreset>('all');
+  const [customStart, setCustomStart] = useState('');
+  const [customEnd, setCustomEnd] = useState('');
+  const [selectedVideoId, setSelectedVideoId] = useState('');
+  const [videos, setVideos] = useState<ConversationVideo[]>([]);
+
+  const { startDate, endDate } = computeDateRange(datePreset, customStart, customEnd);
+  // Date/video filters apply immediately; only the text query is debounced.
+  const { conversations, loading, refetch, rename, filteredConversations } = useConversations({
+    q: debouncedQuery.trim() || undefined,
+    startDate,
+    endDate,
+    videoId: selectedVideoId || undefined,
+  });
+  const hasActiveFilter =
+    debouncedQuery.trim() !== '' || datePreset !== 'all' || selectedVideoId !== '';
   const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -430,6 +480,14 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  // Populate the video filter dropdown with videos cited in the user's
+  // conversations. Best-effort: failure just leaves the dropdown empty.
+  useEffect(() => {
+    getConversationVideos()
+      .then(setVideos)
+      .catch(() => setVideos([]));
+  }, []);
 
   // Store refetch in the shared ref so ChatArea can trigger it
   useEffect(() => {
@@ -601,6 +659,103 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           />
         </div>
 
+        {/* ── Date + video filters ── */}
+        <div
+          style={{
+            padding: '0 12px 8px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <select
+            aria-label="Filter by date"
+            value={datePreset}
+            onChange={(e) => setDatePreset(e.target.value as DatePreset)}
+            className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            style={{
+              width: '100%',
+              padding: '7px 10px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 13,
+              outline: 'none',
+            }}
+          >
+            <option value="all">Any date</option>
+            <option value="this-week">This week</option>
+            <option value="last-month">Last month</option>
+            <option value="custom">Custom range…</option>
+          </select>
+
+          {datePreset === 'custom' && (
+            <div style={{ display: 'flex', gap: 8 }}>
+              <input
+                type="date"
+                aria-label="Start date"
+                value={customStart}
+                onChange={(e) => setCustomStart(e.target.value)}
+                className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  padding: '7px 10px',
+                  borderRadius: 8,
+                  background: '#1e293b',
+                  border: '1px solid #334155',
+                  color: '#f1f5f9',
+                  fontSize: 13,
+                  outline: 'none',
+                }}
+              />
+              <input
+                type="date"
+                aria-label="End date"
+                value={customEnd}
+                onChange={(e) => setCustomEnd(e.target.value)}
+                className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  padding: '7px 10px',
+                  borderRadius: 8,
+                  background: '#1e293b',
+                  border: '1px solid #334155',
+                  color: '#f1f5f9',
+                  fontSize: 13,
+                  outline: 'none',
+                }}
+              />
+            </div>
+          )}
+
+          <select
+            aria-label="Filter by video"
+            value={selectedVideoId}
+            onChange={(e) => setSelectedVideoId(e.target.value)}
+            className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            style={{
+              width: '100%',
+              padding: '7px 10px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 13,
+              outline: 'none',
+            }}
+          >
+            <option value="">Any video</option>
+            {videos.map((v) => (
+              <option key={v.video_id} value={v.video_id}>
+                {v.video_title}
+              </option>
+            ))}
+          </select>
+        </div>
+
         {/* ── Conversation list ── */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {loading ? (
@@ -630,10 +785,14 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              {debouncedQuery.trim() ? (
-                <p style={{ margin: 0, fontSize: 13 }}>
-                  No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
-                </p>
+              {hasActiveFilter ? (
+                debouncedQuery.trim() ? (
+                  <p style={{ margin: 0, fontSize: 13 }}>
+                    No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
+                  </p>
+                ) : (
+                  <p style={{ margin: 0, fontSize: 13 }}>No conversations match these filters</p>
+                )
               ) : (
                 <>
                   <p style={{ margin: 0, fontSize: 13 }}>No conversations yet</p>

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -13,7 +13,9 @@ describe('useConversations', () => {
       const conversations = [
         { id: '1', title: 'Old Title', created_at: '', updated_at: '', preview: 'Hello' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValueOnce(conversations as api.Conversation[]);
+      vi.spyOn(api, 'searchConversations').mockResolvedValueOnce(
+        conversations as api.Conversation[],
+      );
       vi.spyOn(api, 'renameConversation').mockResolvedValueOnce({} as api.Conversation);
 
       const { result } = renderHook(() => useConversations());
@@ -31,7 +33,9 @@ describe('useConversations', () => {
       const conversations = [
         { id: '1', title: 'Original', created_at: '', updated_at: '', preview: 'Hello' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValueOnce(conversations as api.Conversation[]);
+      vi.spyOn(api, 'searchConversations').mockResolvedValueOnce(
+        conversations as api.Conversation[],
+      );
       vi.spyOn(api, 'renameConversation').mockRejectedValueOnce(new Error('Network error'));
 
       const { result } = renderHook(() => useConversations());
@@ -47,7 +51,7 @@ describe('useConversations', () => {
 
   describe('load error handling', () => {
     it('sets error and clears loading when load fails', async () => {
-      vi.spyOn(api, 'getConversations').mockRejectedValueOnce(new Error('Network error'));
+      vi.spyOn(api, 'searchConversations').mockRejectedValueOnce(new Error('Network error'));
 
       const { result } = renderHook(() => useConversations());
 
@@ -62,7 +66,7 @@ describe('useConversations', () => {
         resolveStale = r;
       });
 
-      vi.spyOn(api, 'getConversations')
+      vi.spyOn(api, 'searchConversations')
         .mockReturnValueOnce(stalePromise)
         .mockResolvedValueOnce([
           { id: 'fresh', title: 'Fresh', created_at: '', updated_at: '', preview: 'X' },
@@ -96,7 +100,7 @@ describe('useConversations', () => {
         // Empty-string preview must pass through — strict null check, not falsy check.
         { id: '4', title: 'Chat C', created_at: '', updated_at: '', preview: '' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+      vi.spyOn(api, 'searchConversations').mockResolvedValue(conversations as api.Conversation[]);
 
       const { result } = renderHook(() => useConversations());
 
@@ -110,7 +114,7 @@ describe('useConversations', () => {
       const conversations = [
         { id: '1', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+      vi.spyOn(api, 'searchConversations').mockResolvedValue(conversations as api.Conversation[]);
 
       const { result } = renderHook(() => useConversations());
       await waitFor(() => expect(result.current.filteredConversations).toHaveLength(0));
@@ -125,94 +129,73 @@ describe('useConversations', () => {
           preview: 'First message',
         },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(updated as api.Conversation[]);
+      vi.spyOn(api, 'searchConversations').mockResolvedValue(updated as api.Conversation[]);
       await result.current.refetch();
 
       await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
     });
   });
 
-  describe('client-side search', () => {
-    it('filters conversations by title case-insensitively', async () => {
+  describe('server-side filtering', () => {
+    it('forwards the filter object to searchConversations and does not filter locally', async () => {
       const conversations = [
         { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '', preview: 'Hello' },
-        { id: '2', title: 'JavaScript Guide', created_at: '', updated_at: '', preview: 'Hi' },
-        { id: '3', title: 'python advanced', created_at: '', updated_at: '', preview: 'Hey' },
+        { id: '2', title: 'python advanced', created_at: '', updated_at: '', preview: 'Hey' },
       ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+      const spy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValue(conversations as api.Conversation[]);
 
-      const { result } = renderHook(() => useConversations('python'));
+      const { result } = renderHook(() =>
+        useConversations({ q: 'python', startDate: 'S', endDate: 'E', videoId: 'vid-1' }),
+      );
 
       await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
-      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['1', '3']);
+      expect(spy).toHaveBeenCalledWith({
+        q: 'python',
+        startDate: 'S',
+        endDate: 'E',
+        videoId: 'vid-1',
+      });
+      // The hook returns exactly what the server sent (no client-side title match).
+      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['1', '2']);
     });
 
-    it('excludes empty conversations from search results', async () => {
-      const conversations = [
-        { id: '1', title: 'New Conversation', created_at: '', updated_at: '', preview: null },
-        {
-          id: '2',
-          title: 'New Conversation',
-          created_at: '',
-          updated_at: '',
-          preview: 'Has messages',
-        },
-      ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+    it('refetches when a filter value changes', async () => {
+      const spy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValue([] as api.Conversation[]);
 
-      const { result } = renderHook(() => useConversations('New'));
+      const { rerender } = renderHook((props: api.ConversationFilters) => useConversations(props), {
+        initialProps: { q: 'a' },
+      });
 
-      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
-      expect(result.current.filteredConversations[0].id).toBe('2');
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+      rerender({ q: 'b' });
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+      expect(spy).toHaveBeenLastCalledWith({
+        q: 'b',
+        startDate: undefined,
+        endDate: undefined,
+        videoId: undefined,
+      });
     });
 
-    it('returns full list when query is empty', async () => {
-      const conversations = [
-        { id: '1', title: 'Chat A', created_at: '', updated_at: '', preview: 'Hello' },
-        { id: '2', title: 'Chat B', created_at: '', updated_at: '', preview: 'World' },
-      ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+    it('calls searchConversations with no filters when none are provided', async () => {
+      const spy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValue([] as api.Conversation[]);
 
-      const { result } = renderHook(() => useConversations(''));
+      renderHook(() => useConversations());
 
-      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
-    });
-
-    it('trims whitespace-only queries and returns full list', async () => {
-      const conversations = [
-        { id: '1', title: 'Chat A', created_at: '', updated_at: '', preview: 'Hello' },
-      ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
-
-      const { result } = renderHook(() => useConversations('   '));
-
-      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
-    });
-
-    it('returns empty list when query has no matches', async () => {
-      const conversations = [
-        { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '', preview: 'Hello' },
-      ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
-
-      const { result } = renderHook(() => useConversations('rust'));
-
-      // Wait for the underlying load to settle, then assert the filter returns []
-      await waitFor(() => expect(result.current.loading).toBe(false));
-      expect(result.current.filteredConversations).toHaveLength(0);
-    });
-
-    it('trims leading/trailing whitespace from non-empty queries', async () => {
-      const conversations = [
-        { id: '1', title: 'Python Tutorial', created_at: '', updated_at: '', preview: 'Hello' },
-        { id: '2', title: 'JavaScript', created_at: '', updated_at: '', preview: 'Hi' },
-      ];
-      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
-
-      const { result } = renderHook(() => useConversations('  python  '));
-
-      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
-      expect(result.current.filteredConversations[0].id).toBe('1');
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      expect(spy).toHaveBeenCalledWith({
+        q: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        videoId: undefined,
+      });
     });
   });
 });

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Conversation, getConversations, renameConversation } from '../lib/api';
+import {
+  type Conversation,
+  type ConversationFilters,
+  renameConversation,
+  searchConversations,
+} from '../lib/api';
 
-export function useConversations(searchQuery?: string) {
+export function useConversations(filters: ConversationFilters = {}) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -9,12 +14,21 @@ export function useConversations(searchQuery?: string) {
   // when the user types faster than the network replies.
   const fetchIdRef = useRef(0);
 
+  // Destructure so the effect re-runs on value changes, not on the fresh
+  // object identity callers build every render.
+  const { q, startDate, endDate, videoId } = filters;
+
   const load = useCallback(async () => {
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = await getConversations();
-      if (myId === fetchIdRef.current) setConversations(data);
+      // Server-side filtering: title text, date range, and video all combine
+      // and the backend returns results newest-first with previews intact.
+      const data = await searchConversations({ q, startDate, endDate, videoId });
+      if (myId === fetchIdRef.current) {
+        setConversations(data);
+        setError(null);
+      }
     } catch (e) {
       if (myId === fetchIdRef.current) {
         setError(e instanceof Error ? e.message : 'Failed to load conversations');
@@ -22,7 +36,7 @@ export function useConversations(searchQuery?: string) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, []);
+  }, [q, startDate, endDate, videoId]);
 
   useEffect(() => {
     load();
@@ -43,12 +57,7 @@ export function useConversations(searchQuery?: string) {
 
   // Filter out conversations with zero messages (preview === null).
   // Keep conversations unfiltered for guard logic in Sidebar.tsx.
-  const withMessages = conversations.filter((c) => c.preview !== null);
-
-  const trimmed = (searchQuery ?? '').trim().toLowerCase();
-  const filteredConversations = trimmed
-    ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
-    : withMessages;
+  const filteredConversations = conversations.filter((c) => c.preview !== null);
 
   return {
     conversations,

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -144,8 +144,31 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 // Conversations
 export const getConversations = () => request<Conversation[]>('/conversations');
-export const searchConversations = (q: string) =>
-  request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
+
+export interface ConversationFilters {
+  q?: string;
+  startDate?: string;
+  endDate?: string;
+  videoId?: string;
+}
+
+export interface ConversationVideo {
+  video_id: string;
+  video_title: string;
+}
+
+export const searchConversations = (filters: ConversationFilters = {}) => {
+  const params = new URLSearchParams();
+  if (filters.q) params.set('q', filters.q);
+  if (filters.startDate) params.set('start_date', filters.startDate);
+  if (filters.endDate) params.set('end_date', filters.endDate);
+  if (filters.videoId) params.set('video_id', filters.videoId);
+  const qs = params.toString();
+  return request<Conversation[]>(`/conversations/search${qs ? `?${qs}` : ''}`);
+};
+
+export const getConversationVideos = () =>
+  request<ConversationVideo[]>('/conversations/videos');
 export const createConversation = () =>
   request<Conversation>('/conversations', { method: 'POST', body: '{}' });
 export const getConversation = (id: string) =>


### PR DESCRIPTION
Fixes #294

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `b0cba60e-e25f-4fc8-9a67-b7fc3152f85c`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.