### PR TITLE
[bench-OK] review: address self-review findings

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -459,7 +459,13 @@ async def list_conversations(user_id: str) -> list[dict]:
                     FROM messages
                     WHERE conversation_id = c.id
                     ORDER BY created_at DESC
-                    LIMIT 1) AS preview
+                    LIMIT 1) AS preview,
+                   (SELECT array_agg(DISTINCT elem->>'video_id')
+                    FROM messages m
+                    CROSS JOIN LATERAL jsonb_array_elements(m.sources) elem
+                    WHERE m.conversation_id = c.id
+                      AND m.sources IS NOT NULL
+                      AND jsonb_typeof(m.sources) = 'array') AS video_ids
             FROM conversations c
             WHERE c.user_id = $1
             ORDER BY c.updated_at DESC

--- a/app/backend/tests/test_list_conversations_video_ids.py
+++ b/app/backend/tests/test_list_conversations_video_ids.py
@@ -1,0 +1,159 @@
+"""
+Tests for list_conversations returning video_ids aggregated from messages.sources.
+
+Uses fake asyncpg connections so no real Postgres is required.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+from backend.db import repository
+
+
+class _FakeRow:
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def __iter__(self):
+        return iter(self._data.items())
+
+    def keys(self):
+        return self._data.keys()
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+
+class _FakeConnWithRows:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    async def fetch(self, *args: Any, **kwargs: Any) -> list[_FakeRow]:
+        return [_FakeRow(r) for r in self._rows]
+
+    async def __aenter__(self) -> _FakeConnWithRows:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _FakePoolWithRows:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self._rows)
+
+
+class _FakeAcquire:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def __await__(self):
+        async def _do() -> _FakeConnWithRows:
+            return _FakeConnWithRows(self._rows)
+
+        return _do().__await__()
+
+    async def __aenter__(self) -> _FakeConnWithRows:
+        return _FakeConnWithRows(self._rows)
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+async def test_list_conversations_includes_video_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    user_id = str(uuid4())
+    rows = [
+        {
+            "id": "conv-1",
+            "user_id": user_id,
+            "title": "Chat with sources",
+            "created_at": "2026-05-30T10:00:00+00:00",
+            "updated_at": "2026-05-30T12:00:00+00:00",
+            "preview": "Last message",
+            "video_ids": ["vid-a", "vid-b"],
+        },
+        {
+            "id": "conv-2",
+            "user_id": user_id,
+            "title": "Chat without sources",
+            "created_at": "2026-05-29T10:00:00+00:00",
+            "updated_at": "2026-05-29T12:00:00+00:00",
+            "preview": "Hello",
+            "video_ids": None,
+        },
+    ]
+    fake_pool = _FakePoolWithRows(rows)
+    monkeypatch.setattr(repository, "get_pg_pool", lambda: fake_pool)
+
+    results = await repository.list_conversations(user_id)
+
+    assert len(results) == 2
+    assert results[0]["video_ids"] == ["vid-a", "vid-b"]
+    assert results[1]["video_ids"] is None
+
+
+async def test_list_conversations_orders_by_updated_at_desc(monkeypatch: pytest.MonkeyPatch) -> None:
+    user_id = str(uuid4())
+    rows = [
+        {
+            "id": "conv-new",
+            "user_id": user_id,
+            "title": "New",
+            "created_at": "2026-05-02T10:00:00+00:00",
+            "updated_at": "2026-05-02T12:00:00+00:00",
+            "preview": "New msg",
+            "video_ids": None,
+        },
+        {
+            "id": "conv-old",
+            "user_id": user_id,
+            "title": "Old",
+            "created_at": "2026-05-01T10:00:00+00:00",
+            "updated_at": "2026-05-01T12:00:00+00:00",
+            "preview": "Old msg",
+            "video_ids": None,
+        },
+    ]
+    fake_pool = _FakePoolWithRows(rows)
+    monkeypatch.setattr(repository, "get_pg_pool", lambda: fake_pool)
+
+    results = await repository.list_conversations(user_id)
+
+    assert [r["id"] for r in results] == ["conv-new", "conv-old"]
+
+
+async def test_list_conversations_scopes_to_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    alice = str(uuid4())
+    rows = [
+        {
+            "id": "conv-alice",
+            "user_id": alice,
+            "title": "Alice chat",
+            "created_at": "2026-05-01T10:00:00+00:00",
+            "updated_at": "2026-05-01T12:00:00+00:00",
+            "preview": "Hi",
+            "video_ids": None,
+        },
+    ]
+    fake_pool = _FakePoolWithRows(rows)
+    monkeypatch.setattr(repository, "get_pg_pool", lambda: fake_pool)
+
+    # The fake returns rows regardless of SQL; we verify the function signature
+    # still requires user_id and that we can simulate an empty result for Bob.
+    bob = str(uuid4())
+    empty_pool = _FakePoolWithRows([])
+    monkeypatch.setattr(repository, "get_pg_pool", lambda: empty_pool)
+
+    results = await repository.list_conversations(bob)
+    assert results == []

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,9 @@
-import { type MutableRefObject, type RefObject, useEffect, useRef, useState } from 'react';
+import { type MutableRefObject, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import { type Conversation, type Video, createConversation, deleteConversation, getVideos } from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
 
 // ── Relative time helper ─────────────────────────────────────────
@@ -413,8 +413,44 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [datePreset, setDatePreset] = useState<'all' | 'week' | 'month' | 'lastMonth' | 'custom'>('all');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+  const [videoFilter, setVideoFilter] = useState('');
+  const [videos, setVideos] = useState<Video[]>([]);
+
+  const { dateFrom, dateTo } = useMemo(() => {
+    const now = new Date();
+    if (datePreset === 'week') {
+      const d = new Date(now);
+      d.setDate(d.getDate() - 6);
+      d.setHours(0, 0, 0, 0);
+      return { dateFrom: d, dateTo: null };
+    }
+    if (datePreset === 'month') {
+      const d = new Date(now.getFullYear(), now.getMonth(), 1);
+      return { dateFrom: d, dateTo: null };
+    }
+    if (datePreset === 'lastMonth') {
+      const d = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const end = new Date(now.getFullYear(), now.getMonth(), 0);
+      end.setHours(23, 59, 59, 999);
+      return { dateFrom: d, dateTo: end };
+    }
+    if (datePreset === 'custom') {
+      const from = customFrom ? new Date(customFrom) : null;
+      const to = customTo ? new Date(customTo) : null;
+      return { dateFrom: from, dateTo: to };
+    }
+    return { dateFrom: null, dateTo: null };
+  }, [datePreset, customFrom, customTo]);
+
   const { conversations, loading, refetch, rename, filteredConversations } =
-    useConversations(debouncedQuery);
+    useConversations(debouncedQuery, {
+      dateFrom,
+      dateTo,
+      videoId: videoFilter || null,
+    });
   const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -424,6 +460,11 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const [explorerOpen, setExplorerOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const { addToast } = useToast();
+
+  // Fetch video list once for the picker
+  useEffect(() => {
+    getVideos().then(setVideos).catch(() => {});
+  }, []);
 
   // Debounce search query — 250ms per issue #92
   useEffect(() => {
@@ -437,6 +478,15 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
       conversationsRef.current = refetch;
     }
   }, [refetch, conversationsRef]);
+
+  const clearFilters = () => {
+    setSearchQuery('');
+    setDebouncedQuery('');
+    setDatePreset('all');
+    setCustomFrom('');
+    setCustomTo('');
+    setVideoFilter('');
+  };
 
   // ── New Chat ──
   const handleNewChat = async () => {
@@ -601,6 +651,87 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           />
         </div>
 
+        {/* ── Filters ── */}
+        <div style={{ padding: '0 12px 8px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <select
+            value={datePreset}
+            onChange={(e) => setDatePreset(e.target.value as typeof datePreset)}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 13,
+              outline: 'none',
+            }}
+          >
+            <option value="all">Any time</option>
+            <option value="week">This week</option>
+            <option value="month">This month</option>
+            <option value="lastMonth">Last month</option>
+            <option value="custom">Custom range</option>
+          </select>
+
+          {datePreset === 'custom' && (
+            <div style={{ display: 'flex', gap: 6 }}>
+              <input
+                type="date"
+                value={customFrom}
+                onChange={(e) => setCustomFrom(e.target.value)}
+                style={{
+                  flex: 1,
+                  padding: '6px 8px',
+                  borderRadius: 8,
+                  background: '#1e293b',
+                  border: '1px solid #334155',
+                  color: '#f1f5f9',
+                  fontSize: 13,
+                  outline: 'none',
+                }}
+              />
+              <input
+                type="date"
+                value={customTo}
+                onChange={(e) => setCustomTo(e.target.value)}
+                style={{
+                  flex: 1,
+                  padding: '6px 8px',
+                  borderRadius: 8,
+                  background: '#1e293b',
+                  border: '1px solid #334155',
+                  color: '#f1f5f9',
+                  fontSize: 13,
+                  outline: 'none',
+                }}
+              />
+            </div>
+          )}
+
+          <select
+            value={videoFilter}
+            onChange={(e) => setVideoFilter(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 13,
+              outline: 'none',
+            }}
+          >
+            <option value="">All videos</option>
+            {videos.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.title}
+              </option>
+            ))}
+          </select>
+        </div>
+
         {/* ── Conversation list ── */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {loading ? (
@@ -611,7 +742,7 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               <SkeletonRow />
             </>
           ) : filteredConversations.length === 0 ? (
-            // Empty state — distinct copy when the user is searching
+            // Empty state — distinct copy when filters are active
             <div
               style={{
                 padding: '40px 16px',
@@ -630,10 +761,38 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              {debouncedQuery.trim() ? (
-                <p style={{ margin: 0, fontSize: 13 }}>
-                  No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
-                </p>
+              {debouncedQuery.trim() || datePreset !== 'all' || videoFilter ? (
+                <>
+                  <p style={{ margin: 0, fontSize: 13 }}>
+                    No matches
+                    {debouncedQuery.trim() && (
+                      <> for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong></>
+                    )}
+                  </p>
+                  <button
+                    onClick={clearFilters}
+                    className="active:brightness-90 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                    style={{
+                      marginTop: 10,
+                      background: 'transparent',
+                      border: '1px solid rgba(59,130,246,0.4)',
+                      borderRadius: 8,
+                      color: '#3b82f6',
+                      cursor: 'pointer',
+                      fontSize: 13,
+                      padding: '7px 16px',
+                      transition: 'background 0.15s, filter 0.15s',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.background = 'rgba(59,130,246,0.1)')
+                    }
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.background = 'transparent';
+                    }}
+                  >
+                    Clear filters
+                  </button>
+                </>
               ) : (
                 <>
                   <p style={{ margin: 0, fontSize: 13 }}>No conversations yet</p>

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -215,4 +215,105 @@ describe('useConversations', () => {
       expect(result.current.filteredConversations[0].id).toBe('1');
     });
   });
+
+  describe('date filter', () => {
+    it('keeps conversations within the date range', async () => {
+      const conversations = [
+        { id: '1', title: 'Old Chat', created_at: '', updated_at: '2026-05-01T12:00:00Z', preview: 'Hi', video_ids: null },
+        { id: '2', title: 'Recent Chat', created_at: '', updated_at: '2026-05-20T12:00:00Z', preview: 'Hello', video_ids: null },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const from = new Date('2026-05-15');
+      const to = new Date('2026-05-25');
+      const { result } = renderHook(() => useConversations('', { dateFrom: from, dateTo: to }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('2');
+    });
+
+    it('is inclusive on the bounds', async () => {
+      const conversations = [
+        { id: '1', title: 'Edge Morning', created_at: '', updated_at: '2026-05-15T12:00:00Z', preview: 'A', video_ids: null },
+        { id: '2', title: 'Edge Night', created_at: '', updated_at: '2026-05-16T12:00:00Z', preview: 'B', video_ids: null },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const from = new Date('2026-05-15');
+      const to = new Date('2026-05-16');
+      const { result } = renderHook(() => useConversations('', { dateFrom: from, dateTo: to }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
+    });
+
+    it('drops out-of-range conversations', async () => {
+      const conversations = [
+        { id: '1', title: 'Too old', created_at: '', updated_at: '2026-04-01T12:00:00Z', preview: 'X', video_ids: null },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const from = new Date('2026-05-01');
+      const { result } = renderHook(() => useConversations('', { dateFrom: from }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(0));
+    });
+  });
+
+  describe('video filter', () => {
+    it('keeps conversations that reference the video', async () => {
+      const conversations = [
+        { id: '1', title: 'About A', created_at: '', updated_at: '', preview: 'Hi', video_ids: ['vid-a'] },
+        { id: '2', title: 'About B', created_at: '', updated_at: '', preview: 'Hello', video_ids: ['vid-b'] },
+        { id: '3', title: 'No videos', created_at: '', updated_at: '', preview: 'Hey', video_ids: null },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('', { videoId: 'vid-a' }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('1');
+    });
+  });
+
+  describe('combined filters', () => {
+    it('applies text, date and video filters with AND', async () => {
+      const conversations = [
+        { id: '1', title: 'Python A', created_at: '', updated_at: '2026-05-20T12:00:00Z', preview: 'Hi', video_ids: ['vid-a'] },
+        { id: '2', title: 'Python B', created_at: '', updated_at: '2026-05-10T12:00:00Z', preview: 'Hi', video_ids: ['vid-a'] },
+        { id: '3', title: 'Rust A', created_at: '', updated_at: '2026-05-20T12:00:00Z', preview: 'Hi', video_ids: ['vid-a'] },
+        { id: '4', title: 'Python A', created_at: '', updated_at: '2026-05-20T12:00:00Z', preview: 'Hi', video_ids: ['vid-b'] },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const from = new Date('2026-05-15');
+      const { result } = renderHook(() => useConversations('python', { dateFrom: from, videoId: 'vid-a' }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('1');
+    });
+
+    it('preserves most-recent-first order', async () => {
+      const conversations = [
+        { id: '1', title: 'Old', created_at: '', updated_at: '2026-05-01T12:00:00Z', preview: 'X', video_ids: ['vid-a'] },
+        { id: '2', title: 'New', created_at: '', updated_at: '2026-05-20T12:00:00Z', preview: 'Y', video_ids: ['vid-a'] },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('', { videoId: 'vid-a' }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(2));
+      expect(result.current.filteredConversations.map((c) => c.id)).toEqual(['2', '1']);
+    });
+
+    it('excludes empty conversations even when filters match', async () => {
+      const conversations = [
+        { id: '1', title: 'Empty', created_at: '', updated_at: '2026-05-20T12:00:00Z', preview: null, video_ids: ['vid-a'] },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue(conversations as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('', { videoId: 'vid-a' }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(0));
+    });
+  });
 });

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,7 +1,26 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { type Conversation, getConversations, renameConversation } from '../lib/api';
 
-export function useConversations(searchQuery?: string) {
+function startOfDay(d: Date): Date {
+  const result = new Date(d);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+function endOfDay(d: Date): Date {
+  const result = new Date(d);
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+export function useConversations(
+  searchQuery?: string,
+  filters?: {
+    dateFrom?: Date | null;
+    dateTo?: Date | null;
+    videoId?: string | null;
+  }
+) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -46,9 +65,23 @@ export function useConversations(searchQuery?: string) {
   const withMessages = conversations.filter((c) => c.preview !== null);
 
   const trimmed = (searchQuery ?? '').trim().toLowerCase();
-  const filteredConversations = trimmed
+  let filtered = trimmed
     ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
     : withMessages;
+
+  if (filters?.dateFrom) {
+    const from = startOfDay(filters.dateFrom);
+    filtered = filtered.filter((c) => new Date(c.updated_at) >= from);
+  }
+  if (filters?.dateTo) {
+    const to = endOfDay(filters.dateTo);
+    filtered = filtered.filter((c) => new Date(c.updated_at) <= to);
+  }
+  if (filters?.videoId) {
+    filtered = filtered.filter((c) => c.video_ids?.includes(filters.videoId));
+  }
+
+  const filteredConversations = filtered;
 
   return {
     conversations,

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -78,7 +78,8 @@ export function useConversations(
     filtered = filtered.filter((c) => new Date(c.updated_at) <= to);
   }
   if (filters?.videoId) {
-    filtered = filtered.filter((c) => c.video_ids?.includes(filters.videoId));
+    const videoId = filters.videoId;
+    filtered = filtered.filter((c) => c.video_ids?.includes(videoId));
   }
 
   const filteredConversations = filtered;

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,7 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  video_ids?: string[] | null;
 }
 
 export interface Citation {


### PR DESCRIPTION
Fixes #294

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `398a3de3-1cb1-4f55-8bb4-1d51498a68d0`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.