### PR TITLE
[bench-KO] fix(channels): don't count skipped videos as new; surface failed syncs

### DIFF
--- a/app/backend/routes/channels.py
+++ b/app/backend/routes/channels.py
@@ -156,7 +156,6 @@ async def sync_channel(limit: int | None = None, force: bool = False) -> SyncRes
             existing = await repo.get_video_by_youtube_id(youtube_video_id)
             if existing is not None and not force:
                 logger.info("Video %s already ingested, skipping", youtube_video_id)
-                videos_new += 1
                 await repo.update_sync_video_status(
                     video_id=sync_video_record["id"],
                     status="ingested",

--- a/app/backend/tests/test_channel_sync.py
+++ b/app/backend/tests/test_channel_sync.py
@@ -145,7 +145,7 @@ def make_mock_transcript(text):
 async def test_sync_channel_idempotent_skips_existing_videos():
     """
     If a video is already in the DB (matched by youtube_video_id in URL),
-    it is skipped and counted as 'new' (already ingested = already counted).
+    it is skipped and NOT counted as 'new' (only genuinely ingested videos count).
     """
     # Pre-ingest a video so get_video_by_youtube_id returns it
     await repository.create_video(
@@ -181,7 +181,7 @@ async def test_sync_channel_idempotent_skips_existing_videos():
     data = response.json()
     assert data["sync_run_id"]
     assert data["videos_total"] == 2
-    assert data["videos_new"] == 2  # one skipped (already in DB), one "new" (abc...)
+    assert data["videos_new"] == 1  # only the genuinely new video counts (abc...)
     assert data["videos_error"] == 0
 
 

--- a/app/backend/tests/test_channel_sync_regression.py
+++ b/app/backend/tests/test_channel_sync_regression.py
@@ -1,0 +1,116 @@
+"""
+Regression tests for channel sync counting + status (issue #295).
+
+Two bugs are covered here:
+
+1. Videos that already exist in the DB are *skipped* (idempotent behaviour)
+   and must NOT be counted toward ``videos_new`` — only genuinely-ingested
+   videos count.
+2. Because the run-status check distinguishes a total failure from a partial
+   success via ``videos_new == 0``, the first bug used to *mask* real
+   ingestion outages: a run where every genuinely-new video failed still
+   reported ``completed`` because the skipped videos inflated ``videos_new``.
+
+This module is deliberately separate from ``test_channel_sync.py`` (which is
+globally skipped pending an Alembic schema-fixture rewrite). Here we mock the
+repository + Supadata boundaries directly, so no DB schema is required.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Set env BEFORE any backend imports so config.py picks them up.
+os.environ["JWT_SECRET"] = "test-secret-please-do-not-use-in-prod"
+os.environ["DATABASE_URL"] = "postgresql://test:test@localhost:5432/test"
+os.environ["SUPADATA_API_KEY"] = "test-supadata-key"
+os.environ["YOUTUBE_CHANNEL_ID"] = "UC_testchannel"
+os.environ["CHANNEL_SYNC_TYPE"] = "video"
+
+from backend.auth.dependencies import get_current_admin, get_current_user
+from backend.main import app
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """Channel sync is admin-gated; override both user and admin dependencies."""
+    stub_user = {"id": "test-user", "email": "t@t"}
+    app.dependency_overrides[get_current_user] = lambda: stub_user
+    app.dependency_overrides[get_current_admin] = lambda: stub_user
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_current_admin, None)
+
+
+async def test_sync_channel_skipped_plus_failed_new_surfaces_failed():
+    """
+    A run mixing already-ingested (skipped) videos with genuinely-new videos
+    that all fail to ingest must:
+      - count ``videos_new == 0`` (skips don't inflate the count), and
+      - surface ``status == "failed"`` (the failure isn't masked by skips).
+    """
+
+    # One video is already in the DB (skip), one is genuinely new (will fail).
+    async def fake_get_video_by_youtube_id(youtube_video_id, *args, **kwargs):
+        return {"id": "vid-existing"} if youtube_video_id == "existing_vid" else None
+
+    # Each create_sync_video call returns a record carrying the id the route
+    # needs for subsequent status updates.
+    sync_video_counter = {"n": 0}
+
+    async def fake_create_sync_video(*args, **kwargs):
+        sync_video_counter["n"] += 1
+        return {"id": f"sync-vid-{sync_video_counter['n']}"}
+
+    # The genuinely-new video fails to fetch → ingestion error.
+    async def failing_fetch(*args, **kwargs):
+        raise RuntimeError("Transcript service unavailable")
+
+    with (
+        patch(
+            "backend.routes.channels.supadata.get_channel_video_ids",
+            new=AsyncMock(
+                return_value={
+                    "video_ids": ["existing_vid", "new_vid"],
+                    "short_ids": [],
+                    "live_ids": [],
+                }
+            ),
+        ),
+        patch("backend.routes.channels.repo.create_sync_run", new=AsyncMock()),
+        patch("backend.routes.channels.repo.update_sync_run", new=AsyncMock()),
+        patch(
+            "backend.routes.channels.repo.create_sync_video",
+            new=AsyncMock(side_effect=fake_create_sync_video),
+        ),
+        patch(
+            "backend.routes.channels.repo.update_sync_video_status",
+            new=AsyncMock(),
+        ),
+        patch(
+            "backend.routes.channels.repo.get_video_by_youtube_id",
+            new=AsyncMock(side_effect=fake_get_video_by_youtube_id),
+        ),
+        patch(
+            "backend.routes.channels.fetch_video_for_ingest",
+            new=AsyncMock(side_effect=failing_fetch),
+        ),
+        patch("backend.routes.channels.retriever_hybrid.invalidate_cache"),
+        patch("backend.routes.channels.catalog.invalidate_catalog"),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post("/api/channels/sync")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["videos_total"] == 2
+    # Skipped (already-ingested) video must NOT count as new.
+    assert data["videos_new"] == 0
+    # The genuinely-new video failed.
+    assert data["videos_error"] == 1
+    # The failure must be surfaced, not masked by the skipped video.
+    assert data["status"] == "failed"


### PR DESCRIPTION
Fixes #295

**Benchmark cell:** `KO` (plan=Kimi, impl=Opus)
**Source run-id:** `112bc13c-4922-4dcc-9a31-a8765e1ed16d`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.