### PR TITLE
[bench-OK] impl: address issue

### DIFF
--- a/app/backend/alembic/versions/0001_initial.py
+++ b/app/backend/alembic/versions/0001_initial.py
@@ -159,7 +159,7 @@ def upgrade() -> None:
             id TEXT PRIMARY KEY,
             sync_run_id TEXT NOT NULL REFERENCES channel_sync_runs(id) ON DELETE CASCADE,
             youtube_video_id TEXT NOT NULL,
-            status TEXT NOT NULL CHECK (status IN ('pending', 'ingested', 'error')),
+            status TEXT NOT NULL CHECK (status IN ('pending', 'ingested', 'error', 'skipped')),
             error_message TEXT,
             created_at TIMESTAMPTZ NOT NULL
         )

--- a/app/backend/alembic/versions/0006_add_skipped_sync_status.py
+++ b/app/backend/alembic/versions/0006_add_skipped_sync_status.py
@@ -1,0 +1,39 @@
+"""Add 'skipped' to channel_sync_videos status CHECK constraint.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # PostgreSQL auto-generates the constraint name as
+    # channel_sync_videos_status_check for an inline column CHECK.
+    op.execute(
+        "ALTER TABLE channel_sync_videos DROP CONSTRAINT IF EXISTS channel_sync_videos_status_check"
+    )
+    op.execute(
+        "ALTER TABLE channel_sync_videos ADD CONSTRAINT channel_sync_videos_status_check "
+        "CHECK (status IN ('pending', 'ingested', 'error', 'skipped'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE channel_sync_videos DROP CONSTRAINT IF EXISTS channel_sync_videos_status_check"
+    )
+    op.execute(
+        "ALTER TABLE channel_sync_videos ADD CONSTRAINT channel_sync_videos_status_check "
+        "CHECK (status IN ('pending', 'ingested', 'error'))"
+    )

--- a/app/backend/routes/channels.py
+++ b/app/backend/routes/channels.py
@@ -134,6 +134,7 @@ async def sync_channel(limit: int | None = None, force: bool = False) -> SyncRes
     videos_total = len(all_video_ids)
     videos_new = 0
     videos_error = 0
+    videos_skipped = 0
 
     logger.info(
         "Channel %s has %d videos (type=%s)",
@@ -156,10 +157,10 @@ async def sync_channel(limit: int | None = None, force: bool = False) -> SyncRes
             existing = await repo.get_video_by_youtube_id(youtube_video_id)
             if existing is not None and not force:
                 logger.info("Video %s already ingested, skipping", youtube_video_id)
-                videos_new += 1
+                videos_skipped += 1
                 await repo.update_sync_video_status(
                     video_id=sync_video_record["id"],
-                    status="ingested",
+                    status="skipped",
                 )
                 continue
 
@@ -365,11 +366,12 @@ async def sync_channel(limit: int | None = None, force: bool = False) -> SyncRes
     )
 
     logger.info(
-        "Channel sync run %s complete: total=%d new=%d error=%d",
+        "Channel sync run %s complete: total=%d new=%d error=%d skipped=%d",
         sync_run_id,
         videos_total,
         videos_new,
         videos_error,
+        videos_skipped,
     )
 
     return SyncResponse(

--- a/app/backend/tests/test_channel_sync.py
+++ b/app/backend/tests/test_channel_sync.py
@@ -145,7 +145,7 @@ def make_mock_transcript(text):
 async def test_sync_channel_idempotent_skips_existing_videos():
     """
     If a video is already in the DB (matched by youtube_video_id in URL),
-    it is skipped and counted as 'new' (already ingested = already counted).
+    it is skipped and must NOT be counted in videos_new.
     """
     # Pre-ingest a video so get_video_by_youtube_id returns it
     await repository.create_video(
@@ -181,8 +181,62 @@ async def test_sync_channel_idempotent_skips_existing_videos():
     data = response.json()
     assert data["sync_run_id"]
     assert data["videos_total"] == 2
-    assert data["videos_new"] == 2  # one skipped (already in DB), one "new" (abc...)
+    assert data["videos_new"] == 1  # only abc123def456 is truly new
     assert data["videos_error"] == 0
+
+    # Verify the skipped video is recorded with status "skipped"
+    sync_runs = await repository.list_sync_runs(limit=10)
+    sync_videos = await repository.list_sync_videos_for_run(sync_runs[0]["id"])
+    assert len(sync_videos) == 2
+    skipped = next((v for v in sync_videos if v["youtube_video_id"] == "dQw4w9WgXcQ"), None)
+    assert skipped is not None
+    assert skipped["status"] == "skipped"
+
+
+async def test_sync_channel_all_new_failed_with_skip_shows_failed():
+    """
+    Regression for issue #295: when genuinely-new videos all fail and a
+    pre-existing video is skipped, the sync run must surface as 'failed'.
+    """
+    # Pre-ingest a video so it gets skipped
+    await repository.create_video(
+        title="Already ingested",
+        description="Already in DB",
+        url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        transcript="Already ingested transcript.",
+    )
+
+    with patch("backend.services.supadata._get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.youtube.channel.videos = make_mock_channel_videos(
+            ["dQw4w9WgXcQ", "newVideoFails"]
+        )
+        # Simulate a transcript fetch failure for the new video
+        exc = SupadataError(error="server_error", message="Transcript unavailable", details="")
+        exc.status = 500
+        mock_client.transcript = lambda *args, **kwargs: (_ for _ in ()).throw(exc)
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post("/api/channels/sync")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["videos_total"] == 2
+    assert data["videos_new"] == 0
+    assert data["videos_error"] == 1
+    assert data["status"] == "failed"
+
+    # Verify sync_video statuses reflect reality
+    sync_runs = await repository.list_sync_runs(limit=10)
+    sync_videos = await repository.list_sync_videos_for_run(sync_runs[0]["id"])
+    assert len(sync_videos) == 2
+    skipped = next((v for v in sync_videos if v["youtube_video_id"] == "dQw4w9WgXcQ"), None)
+    failed = next((v for v in sync_videos if v["youtube_video_id"] == "newVideoFails"), None)
+    assert skipped is not None and skipped["status"] == "skipped"
+    assert failed is not None and failed["status"] == "error"
 
 
 async def test_sync_channel_returns_sync_run_id():


### PR DESCRIPTION
Fixes #295

**Benchmark cell:** `OK` (plan=Opus, impl=Kimi)
**Source run-id:** `374a3ef5-4189-4ca2-8b1e-c7ae484df14b`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.