### PR TITLE
[bench-XO] fix(citations): keep distinct same-video moments as separate chips

### DIFF
--- a/app/backend/rag/expansion.py
+++ b/app/backend/rag/expansion.py
@@ -34,13 +34,13 @@ async def expand_and_merge(
                 Defaults to repository.get_chunk_neighbors.
 
     Returns:
-        List of span dicts (same shape as input chunks but with merged content):
-          - video_id, video_title, video_url from the video of the first chunk in span
-          - content: concatenated text of all chunks in the span
-          - start_seconds: from the first chunk in the span
-          - end_seconds: from the last chunk in the span
-          - snippet: from the originally-retrieved chunk (preserved for citation)
-          - chunk_id: from the originally-retrieved chunk (preserved for citation)
+        List of citation dicts (same shape as input chunks but with merged
+        content). A contiguous span emits ONE entry per originally-retrieved
+        chunk it contains (issue #276), each:
+          - video_id, video_title, video_url from the span's first chunk
+          - content: concatenated text of all chunks in the span (shared context)
+          - start_seconds / end_seconds: from this entry's own retrieved chunk
+          - snippet / chunk_id: from this entry's own retrieved chunk
     """
     if window <= 0 or not chunks:
         return chunks
@@ -111,37 +111,47 @@ async def expand_and_merge(
                 else:
                     raw_spans.append([chunk])
 
-        # Convert raw spans to result spans, anchoring citation to the first
-        # originally-retrieved chunk in each raw span.
+        # Convert raw spans to result entries. A span can contain more than one
+        # originally-retrieved chunk when two retrieved moments are close enough
+        # that their neighbor windows overlap into one contiguous run. Emit one
+        # citation entry PER originally-retrieved chunk so two nearby moments
+        # from the same video don't collapse into a single chip (issue #276).
+        # Each entry shares the merged span content (small-to-big context) but
+        # anchors its timestamp/snippet/chunk_id to its OWN chunk, so the
+        # deep-link opens at the moment the model actually cited rather than at
+        # the (earlier) start of the expanded span.
         for raw in raw_spans:
-            # Find the first originally-retrieved chunk in this raw span
-            anchor = raw[0]
-            for c in raw:
-                if (current_video_id, c["chunk_index"]) in retrieved_by_index:
-                    anchor = c
-                    break
-
             content = "\n\n".join(c["content"] for c in raw)
-            merged.append(
-                {
-                    "video_id": raw[0]["video_id"],
-                    "video_title": raw[0].get("video_title", ""),
-                    "video_url": raw[0].get("video_url", ""),
-                    # Issue #147: preserve the source-type discriminator and
-                    # lesson_url for Dynamous chunks so the frontend can render
-                    # community.dynamous.ai citation links. Pull these from the
-                    # anchor (originally-retrieved chunk) — it went through
-                    # _hydrate_chunks and is guaranteed to have them. raw[0]
-                    # could be a neighbor fetched via get_chunk_neighbors, which
-                    # doesn't include those columns.
-                    "source_type": anchor.get("source_type", "youtube"),
-                    "lesson_url": anchor.get("lesson_url", ""),
-                    "content": content,
-                    "start_seconds": raw[0]["start_seconds"],
-                    "end_seconds": raw[-1]["end_seconds"],
-                    "snippet": anchor["snippet"],
-                    "chunk_id": anchor.get("chunk_id") or anchor.get("id", ""),
-                }
-            )
+            span_video_id = raw[0]["video_id"]
+            span_title = raw[0].get("video_title", "")
+            span_url = raw[0].get("video_url", "")
+
+            anchors = [
+                c for c in raw if (current_video_id, c["chunk_index"]) in retrieved_by_index
+            ]
+            if not anchors:
+                # Defensive: every span is built around at least one retrieved
+                # chunk, but fall back to the first chunk if that ever changes.
+                anchors = [raw[0]]
+
+            for anchor in anchors:
+                merged.append(
+                    {
+                        "video_id": span_video_id,
+                        "video_title": span_title,
+                        "video_url": span_url,
+                        # Issue #147: source_type/lesson_url come from the anchor
+                        # (an originally-retrieved chunk that went through
+                        # _hydrate_chunks); neighbors fetched via
+                        # get_chunk_neighbors don't carry these columns.
+                        "source_type": anchor.get("source_type", "youtube"),
+                        "lesson_url": anchor.get("lesson_url", ""),
+                        "content": content,
+                        "start_seconds": anchor.get("start_seconds", 0.0),
+                        "end_seconds": anchor.get("end_seconds", 0.0),
+                        "snippet": anchor.get("snippet", ""),
+                        "chunk_id": anchor.get("chunk_id") or anchor.get("id", ""),
+                    }
+                )
 
     return merged

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -211,9 +211,10 @@ async def create_message(
                         cited_ids = extract_cited_chunk_ids(final_text_raw)
                         for chunk in source_citations:
                             chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
-                        # Collapse same-video chunks (issue #208): keep one
-                        # entry per video_id, choosing the earliest-cited
-                        # timestamp as the representative.
+                        # Shape citations (issues #208, #276): keep every cited
+                        # moment as its own chip with its own timestamp; collapse
+                        # only the uncited "consulted" chunks to one chip per
+                        # video.
                         source_citations[:] = _collapse_by_video(source_citations)
                         # Cap fallback (issue #176): cited pass through, non-cited sliced.
                         cited = [c for c in source_citations if c.get("is_cited")]
@@ -467,42 +468,57 @@ async def _maybe_set_conversation_title(
 
 
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse multiple chunks from the same video into a single citation entry.
+    """Shape retrieved chunks into citation chips.
 
-    After the ``is_cited`` pass, chunks from the same video are redundant in
-    the UI — the user needs one clickable chip per video, not one per 5-second
-    transcript segment (issue #208).
+    Every distinct moment the model actually cited must keep its own chip with
+    its own timestamp — even when two cited moments come from the same video and
+    sit close together in the timeline (issue #276). Collapsing those into a
+    single chip (the prior behaviour) dropped a source and made the surviving
+    chip point at the earlier moment.
 
-    For each ``video_id`` group:
-    - ``is_cited`` is True if ANY chunk in the group was cited by the LLM.
-    - ``start_seconds`` is the earliest timestamp among cited chunks (or among
-      all chunks if none were cited), so the deep-link opens near the most
-      relevant moment.
-    - ``segment_count`` records how many chunks were collapsed so the frontend
-      can optionally display "(N segments)".
-    - All other fields are taken from the representative chunk.
+    The original noise-reduction goal (issue #208 — don't show one chip per
+    5-second transcript segment) still applies to the *consulted* tier:
 
-    Insertion order of videos is preserved (first-seen wins).
+    - Each chunk with ``is_cited`` becomes its own entry, anchored to its own
+      ``chunk_id`` / ``start_seconds`` (``segment_count`` = 1).
+    - Uncited chunks are collapsed per ``video_id`` into a single representative
+      entry (earliest ``start_seconds``), with ``segment_count`` recording how
+      many were merged.
+    - A video that contributed a cited chunk is already represented by that
+      chip, so its uncited siblings are dropped (they were absorbed under the
+      old per-video collapse too).
+
+    First-seen order is preserved: cited moments first (in input order), then
+    one consulted entry per remaining video.
     """
-    seen: dict[str, list[dict]] = {}
+    cited_video_ids: set[str] = set()
+    result: list[dict] = []
+
+    # Cited moments: one chip each, anchored to its own chunk.
     for c in chunks:
+        if c.get("is_cited"):
+            entry = dict(c)
+            entry["is_cited"] = True
+            entry["segment_count"] = 1
+            result.append(entry)
+            cited_video_ids.add(c.get("video_id") or "")
+
+    # Uncited chunks: collapse per video, skipping videos already represented
+    # by a cited chip. Insertion order of videos is preserved (first-seen wins).
+    uncited_groups: dict[str, list[dict]] = {}
+    for c in chunks:
+        if c.get("is_cited"):
+            continue
         vid = c.get("video_id") or ""
-        if vid not in seen:
-            seen[vid] = []
-        seen[vid].append(c)
+        if vid in cited_video_ids:
+            continue
+        uncited_groups.setdefault(vid, []).append(c)
 
-    collapsed: list[dict] = []
-    for group in seen.values():
-        cited_in_group = [c for c in group if c.get("is_cited")]
-        if cited_in_group:
-            representative = min(cited_in_group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = True
-        else:
-            representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
-            is_cited = False
+    for group in uncited_groups.values():
+        representative = min(group, key=lambda c: c.get("start_seconds") or 0.0)
         entry = dict(representative)
-        entry["is_cited"] = is_cited
+        entry["is_cited"] = False
         entry["segment_count"] = len(group)
-        collapsed.append(entry)
+        result.append(entry)
 
-    return collapsed
+    return result

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -223,9 +223,10 @@ class TestSseIntegration:
         # 2 cited + CITATIONS_MAX_COUNT non-cited = 12 total.
         assert len(payload) == 2 + CITATIONS_MAX_COUNT
 
-    async def test_same_video_chunks_collapsed_to_one_citation(self) -> None:
-        """Multiple chunks from the same video collapse into a single citation
-        entry (issue #208). segment_count reflects the original chunk count."""
+    async def test_single_cited_chunk_absorbs_uncited_siblings(self) -> None:
+        """When exactly one chunk from a video is cited, its uncited same-video
+        siblings are absorbed (issue #208 noise reduction) and the lone cited
+        moment stands as its own chip with its own timestamp (issue #276)."""
         chunks = [{**_chunk(f"c{i}", "v1"), "start_seconds": float(i * 10)} for i in range(5)]
         # Only c2 (start_seconds=20.0) is cited
         body = await _post_message(
@@ -237,13 +238,42 @@ class TestSseIntegration:
         entry = payload[0]
         assert entry["video_id"] == "v1"
         assert entry["is_cited"] is True
-        assert entry["segment_count"] == 5
-        # Representative picks earliest cited chunk → c2 at 20.0s
+        # A cited chip is a single distinct moment, not a merged segment count.
+        assert entry["segment_count"] == 1
+        # The cited chip anchors to c2's own timestamp (20.0s), not the earliest.
         assert entry["start_seconds"] == 20.0
 
+    async def test_two_cited_moments_same_video_each_get_own_chip(self) -> None:
+        """Two distinct moments the model cited from the SAME video must each
+        get their own chip with their own timestamp — not collapse into one chip
+        pointing at the earlier moment (issue #276). Uncited siblings of a cited
+        video are still absorbed."""
+        chunks = [
+            {**_chunk("early", "v1"), "start_seconds": 30.0},
+            {**_chunk("late", "v1"), "start_seconds": 90.0},
+            {**_chunk("consulted", "v1"), "start_seconds": 150.0},  # not cited
+        ]
+        body = await _post_message(
+            answer_tokens=["First point [c:early]. Second, later point [c:late]."],
+            retrieved_chunks=chunks,
+        )
+        payload = _parse_sources(body)
+        # Both cited moments survive as distinct chips; the uncited sibling from
+        # the same (already-cited) video is absorbed.
+        assert len(payload) == 2
+        by_id = {c["chunk_id"]: c for c in payload}
+        assert set(by_id) == {"early", "late"}
+        assert by_id["early"]["is_cited"] is True
+        assert by_id["late"]["is_cited"] is True
+        # Each chip keeps its OWN timestamp — the later claim is not mis-anchored
+        # to the earlier moment.
+        assert by_id["early"]["start_seconds"] == 30.0
+        assert by_id["late"]["start_seconds"] == 90.0
+
     async def test_collapse_two_videos_preserves_both(self) -> None:
-        """Chunks from two different videos collapse to two entries, each with
-        correct is_cited and segment_count."""
+        """One cited chunk in each of two videos yields two cited chips, each
+        anchored to the cited moment's own timestamp. Uncited siblings of those
+        cited videos are absorbed (issues #208, #276)."""
         chunks_v1 = [{**_chunk(f"v1c{i}", "v1"), "start_seconds": float(i * 5)} for i in range(3)]
         chunks_v2 = [{**_chunk(f"v2c{i}", "v2"), "start_seconds": float(i * 5)} for i in range(3)]
         # v1c1 and v2c0 are cited
@@ -255,10 +285,10 @@ class TestSseIntegration:
         assert len(payload) == 2
         by_vid = {e["video_id"]: e for e in payload}
         assert by_vid["v1"]["is_cited"] is True
-        assert by_vid["v1"]["segment_count"] == 3
+        assert by_vid["v1"]["segment_count"] == 1
         assert by_vid["v1"]["start_seconds"] == 5.0  # v1c1
         assert by_vid["v2"]["is_cited"] is True
-        assert by_vid["v2"]["segment_count"] == 3
+        assert by_vid["v2"]["segment_count"] == 1
         assert by_vid["v2"]["start_seconds"] == 0.0  # v2c0
 
     async def test_collapse_uncited_group_picks_earliest_timestamp(self) -> None:

--- a/app/backend/tests/test_expansion.py
+++ b/app/backend/tests/test_expansion.py
@@ -112,9 +112,10 @@ class TestExpandAndMerge:
         # Citation fields from original chunk
         assert span["chunk_id"] == "c5"
         assert span["snippet"] == "hello world snippet"
-        # Span boundaries
-        assert span["start_seconds"] == 40.0  # from left neighbor
-        assert span["end_seconds"] == 70.0  # from right neighbor
+        # Timestamp anchors to the retrieved chunk itself (issue #276) so the
+        # deep-link opens at the cited moment, not the expanded span's start.
+        assert span["start_seconds"] == 50.0
+        assert span["end_seconds"] == 60.0
 
     @pytest.mark.asyncio
     async def test_non_adjacent_chunks_remain_separate(self):
@@ -286,3 +287,52 @@ class TestExpandAndMerge:
         all_contents = [r["content"] for r in result]
         for content in all_contents:
             assert all_contents.count(content) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_nearby_retrieved_chunks_keep_distinct_anchors(self):
+        """Two retrieved chunks whose neighbor windows overlap into one
+        contiguous span must still yield one citation entry each, anchored to
+        its own timestamp — not a single merged chip pointing at the earlier
+        moment (issue #276)."""
+        c5 = dict(_ORIG_CHUNK)  # chunk_index 5, start 50.0
+        c7 = {
+            "chunk_id": "c7",
+            "video_id": "v1",
+            "content": "later moment",
+            "chunk_index": 7,
+            "start_seconds": 70.0,
+            "end_seconds": 80.0,
+            "snippet": "later snippet",
+            "video_title": "Test Video",
+            "video_url": "https://youtube.com/watch?v=v1",
+        }
+        c8 = {
+            "id": "c8",
+            "video_id": "v1",
+            "content": "after",
+            "chunk_index": 8,
+            "start_seconds": 80.0,
+            "end_seconds": 90.0,
+            "snippet": "s8",
+            "video_title": "Test Video",
+            "video_url": "https://youtube.com/watch?v=v1",
+        }
+
+        async def fake_neighbors(video_id, chunk_index, window):
+            if chunk_index == 5:
+                return [_NEIGHBOR_LEFT, _NEIGHBOR_RIGHT]  # indices 4, 6
+            if chunk_index == 7:
+                # index 6 is shared with c5's right neighbor (deduped by id)
+                return [_NEIGHBOR_RIGHT, c8]  # indices 6, 8
+            return []
+
+        result = await expand_and_merge([c5, c7], window=1, _fetch_neighbors=fake_neighbors)
+
+        # Indices 4,5,6,7,8 form one contiguous span, but c5 and c7 are both
+        # originally-retrieved → two distinct citation entries.
+        assert len(result) == 2
+        by_id = {r["chunk_id"]: r for r in result}
+        assert set(by_id) == {"c5", "c7"}
+        # Each entry keeps its OWN timestamp, not the span's earliest.
+        assert by_id["c5"]["start_seconds"] == 50.0
+        assert by_id["c7"]["start_seconds"] == 70.0


### PR DESCRIPTION
Fixes #276

**Benchmark cell:** `XO` (plan=NONE, impl=Opus)
**Source run-id:** `d150078a-adb7-4adf-b1ad-5c6ebc59b711`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.