### PR TITLE
[bench-XK] impl: address issue #277 — saved answer's sources don't match what was shown live after an interrupted response

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -174,6 +174,12 @@ async def create_message(
         # Two-tier citations (issue #176): strip `[c:<id>]` markers from the
         # stream; use them at [DONE] to flag is_cited on retrieved chunks.
         marker_stripper = CitationMarkerStripper()
+        # Guard against persisting sources that were never successfully emitted
+        # to the client (issue #277).  The flag is only set after a yield
+        # returns normally; if GeneratorExit is raised at the yield point
+        # (client disconnect) the flag stays False.
+        sources_emitted = False
+        sources_snapshot: list[dict] | None = None
         try:
             # is_member_for_turn is captured above when tools are wired.
             # Re-bind to a local that's always defined so we can pass it
@@ -227,8 +233,10 @@ async def create_message(
                             else _extract_text_from_sse(full_response)
                         )
                         if not _is_refusal(final_text):
+                            sources_snapshot = list(source_citations)
                             sources_json = json.dumps(source_citations)
                             yield f"event: sources\ndata: {sources_json}\n\n"
+                            sources_emitted = True
                     full_response.append(sse_chunk)
                     yield sse_chunk
                     continue
@@ -269,8 +277,10 @@ async def create_message(
                 refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
                 sources_to_persist: list[dict] | None = (
                     None
-                    if not source_citations or _is_refusal(refusal_check_text)
-                    else source_citations
+                    if not sources_emitted
+                    or sources_snapshot is None
+                    or _is_refusal(refusal_check_text)
+                    else sources_snapshot
                 )
                 try:
                     await asyncio.shield(

--- a/app/backend/tests/test_message_persist_shield.py
+++ b/app/backend/tests/test_message_persist_shield.py
@@ -26,6 +26,31 @@ from backend.auth.dependencies import get_current_user
 from backend.main import app
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_chunk(cid: str, vid: str = "v1") -> dict[str, Any]:
+    return {
+        "chunk_id": cid,
+        "video_id": vid,
+        "video_title": "T",
+        "video_url": "u",
+        "start_seconds": 0.0,
+        "end_seconds": 1.0,
+        "snippet": "s",
+    }
+
+
+def _parse_sources_from_sse(body: str) -> list[dict[str, Any]]:
+    for line in body.splitlines():
+        if line.startswith("event: sources"):
+            continue
+        if line.startswith("data: ") and "chunk_id" in line:
+            return json.loads(line[len("data: "):])
+    return []
+
+
 @pytest.fixture
 def bypass_auth():
     """Satisfy the auth dependency for the message route."""
@@ -218,3 +243,289 @@ class TestEventGeneratorPersistsOnCancel:
         second_call_kwargs = mock_create.call_args_list[1].kwargs
         assert second_call_kwargs["role"] == "assistant"
         assert "Hello world" in second_call_kwargs["content"]
+
+
+class TestSourcesPersistRegression:
+    """Regression for issue #277: persisted sources must match what the
+    user actually saw live.  If the stream is interrupted before the
+    ``event: sources`` SSE event is successfully emitted, sources must
+    NOT be persisted (no duplicate / phantom chips on reload)."""
+
+    async def test_clean_done_sources_persisted_and_match_sse(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """Normal completion: sources in DB == sources on the wire."""
+
+        async def fake_stream(*args: Any, **kwargs: Any):
+            final_text_out = kwargs.get("final_text_out")
+            tool_executor = kwargs.get("tool_executor")
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "t"}))
+            for token in ("Hello ", "world."):
+                yield f"data: {json.dumps(token)}\n\n"
+            if final_text_out is not None:
+                final_text_out.append("Hello world.")
+            yield "data: [DONE]\n\n"
+
+        fake_user = bypass_auth
+        fake_conv = {
+            "id": str(uuid4()),
+            "user_id": fake_user["id"],
+            "title": "New Conversation",
+        }
+        chunks = [_fake_chunk("c1", "v1"), _fake_chunk("c2", "v2")]
+
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
+            return {"ok": True, "text": "ctx", "chunks": chunks}
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=fake_conv,
+            ),
+            patch(
+                "backend.routes.messages.repository.create_message",
+                new_callable=AsyncMock,
+                return_value={"id": str(uuid4())},
+            ) as mock_create,
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[{"role": "user", "content": "hi"}],
+            ),
+            patch(
+                "backend.routes.messages.repository.list_videos",
+                new_callable=AsyncMock,
+                return_value=[{"id": "v1"}, {"id": "v2"}],
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend.routes.messages.stream_chat",
+                side_effect=fake_stream,
+            ),
+            patch(
+                "backend.routes.messages.execute_tool",
+                side_effect=mock_execute_tool,
+            ),
+            patch(
+                "backend.routes.messages._maybe_set_conversation_title",
+                new_callable=AsyncMock,
+            ),
+        ):
+            from backend.routes.messages import MessageCreate, create_message
+
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=fake_user,
+            )
+
+            body_parts: list[str] = []
+            async for chunk in resp.body_iterator:
+                body_parts.append(chunk)
+
+            await asyncio.sleep(0.1)
+
+        body = "".join(body_parts)
+        sse_sources = _parse_sources_from_sse(body)
+        assert len(sse_sources) == 2, "SSE must contain the two source chips"
+
+        assert mock_create.call_count == 2
+        second_call = mock_create.call_args_list[1].kwargs
+        assert second_call["role"] == "assistant"
+        assert second_call["sources"] is not None
+        assert len(second_call["sources"]) == 2
+        # The snapshot should match the emitted payload (same chunk_ids).
+        persisted_ids = {c["chunk_id"] for c in second_call["sources"]}
+        assert persisted_ids == {"c1", "c2"}
+
+    async def test_disconnect_before_done_sources_not_persisted(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """Client hangs up before [DONE]: sources must NOT be saved."""
+
+        async def fake_stream(*args: Any, **kwargs: Any):
+            final_text_out = kwargs.get("final_text_out")
+            tool_executor = kwargs.get("tool_executor")
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "t"}))
+            for token in ("Hello ", "world."):
+                yield f"data: {json.dumps(token)}\n\n"
+            if final_text_out is not None:
+                final_text_out.append("Hello world.")
+            yield "data: [DONE]\n\n"
+
+        fake_user = bypass_auth
+        fake_conv = {
+            "id": str(uuid4()),
+            "user_id": fake_user["id"],
+            "title": "New Conversation",
+        }
+        chunks = [_fake_chunk("c1", "v1")]
+
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
+            return {"ok": True, "text": "ctx", "chunks": chunks}
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=fake_conv,
+            ),
+            patch(
+                "backend.routes.messages.repository.create_message",
+                new_callable=AsyncMock,
+                return_value={"id": str(uuid4())},
+            ) as mock_create,
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[{"role": "user", "content": "hi"}],
+            ),
+            patch(
+                "backend.routes.messages.repository.list_videos",
+                new_callable=AsyncMock,
+                return_value=[{"id": "v1"}],
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend.routes.messages.stream_chat",
+                side_effect=fake_stream,
+            ),
+            patch(
+                "backend.routes.messages.execute_tool",
+                side_effect=mock_execute_tool,
+            ),
+            patch(
+                "backend.routes.messages._maybe_set_conversation_title",
+                new_callable=AsyncMock,
+            ),
+        ):
+            from backend.routes.messages import MessageCreate, create_message
+
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=fake_user,
+            )
+
+            body_iter = resp.body_iterator
+            # Pull one token then bail.
+            await body_iter.__anext__()
+            await body_iter.aclose()
+            await asyncio.sleep(0.1)
+
+        second_call = mock_create.call_args_list[1].kwargs
+        assert second_call["role"] == "assistant"
+        assert second_call.get("sources") is None, (
+            "sources must not be persisted when the stream was interrupted"
+        )
+
+    async def test_exception_in_done_processing_sources_not_persisted(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """If _collapse_by_video blows up inside the [DONE] handler, the
+        sources list is left partially mutated.  The finally block must
+        NOT persist it (issue #277 root cause)."""
+
+        async def fake_stream(*args: Any, **kwargs: Any):
+            final_text_out = kwargs.get("final_text_out")
+            tool_executor = kwargs.get("tool_executor")
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "t"}))
+            for token in ("Hello ", "world."):
+                yield f"data: {json.dumps(token)}\n\n"
+            if final_text_out is not None:
+                final_text_out.append("Hello world.")
+            yield "data: [DONE]\n\n"
+
+        fake_user = bypass_auth
+        fake_conv = {
+            "id": str(uuid4()),
+            "user_id": fake_user["id"],
+            "title": "New Conversation",
+        }
+        chunks = [_fake_chunk("c1", "v1"), _fake_chunk("c2", "v1")]
+
+        async def mock_execute_tool(
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        ):
+            return {"ok": True, "text": "ctx", "chunks": chunks}
+
+        def boom(chunks):
+            raise RuntimeError("boom")
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=fake_conv,
+            ),
+            patch(
+                "backend.routes.messages.repository.create_message",
+                new_callable=AsyncMock,
+                return_value={"id": str(uuid4())},
+            ) as mock_create,
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=[{"role": "user", "content": "hi"}],
+            ),
+            patch(
+                "backend.routes.messages.repository.list_videos",
+                new_callable=AsyncMock,
+                return_value=[{"id": "v1"}],
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend.routes.messages.stream_chat",
+                side_effect=fake_stream,
+            ),
+            patch(
+                "backend.routes.messages.execute_tool",
+                side_effect=mock_execute_tool,
+            ),
+            patch(
+                "backend.routes.messages._collapse_by_video",
+                side_effect=boom,
+            ),
+            patch(
+                "backend.routes.messages._maybe_set_conversation_title",
+                new_callable=AsyncMock,
+            ),
+        ):
+            from backend.routes.messages import MessageCreate, create_message
+
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=fake_user,
+            )
+
+            body_iter = resp.body_iterator
+            got: list[str] = []
+            with pytest.raises(RuntimeError, match="boom"):
+                async for chunk in body_iter:
+                    got.append(chunk)
+
+            await asyncio.sleep(0.1)
+
+        second_call = mock_create.call_args_list[1].kwargs
+        assert second_call["role"] == "assistant"
+        assert second_call.get("sources") is None, (
+            "partially-processed sources must not be persisted when [DONE] processing crashes"
+        )


### PR DESCRIPTION
Fixes #277

**Benchmark cell:** `XK` (plan=NONE, impl=Kimi)
**Source run-id:** `b310f52c-6eef-4f42-b9aa-b5e690854f61`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.