### PR TITLE
[bench-XO] review: fix body parameter shadowing in runStream

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -603,6 +603,31 @@ async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     return results
 
 
+async def delete_message(message_id: str, conversation_id: str, user_id: str) -> bool:
+    """Delete a single message, scoped to the conversation owner.
+
+    The owner check is enforced atomically via an EXISTS subquery so a message
+    can only be deleted by the user who owns its conversation — mirroring the
+    ownership guard in ``create_message``. Returns True if a row was deleted.
+    """
+    async with _acquire() as conn:
+        result = await conn.execute(
+            """
+            DELETE FROM messages
+            WHERE id = $1
+              AND conversation_id = $2
+              AND EXISTS (
+                  SELECT 1 FROM conversations WHERE id = $3 AND user_id = $4
+              )
+            """,
+            message_id,
+            conversation_id,
+            conversation_id,
+            user_id,
+        )
+    return not result.endswith(" 0")
+
+
 # ---------------------------------------------------------------------------
 # Channel sync runs
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -116,6 +116,116 @@ async def create_message(
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
 
+    # 5-8. Stream the assistant response (tool-driven retrieval, SSE framing,
+    # the sources event, and post-stream persistence) via the shared helper.
+    return await _stream_assistant_response(
+        conv_id=conv_id,
+        user_id=user_id,
+        llm_messages=llm_messages,
+        current_user=current_user,
+        title_seed=user_content,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/messages/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/messages/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate a fresh assistant response for the most recent user turn.
+
+    Deletes the latest assistant message and streams a replacement grounded in
+    the same conversation history (which still ends with the user's question).
+    The new answer carries its own citations and streams exactly like a normal
+    send. Regeneration consumes one slot from the 25 msg/user/24h cap so it
+    cannot be used to slip past the daily limit (MISSION §10 invariant #1).
+
+    Returns:
+        StreamingResponse with Content-Type: text/event-stream (same framing as
+        ``create_message``).
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user.
+    # 404 (not 403) — don't leak existence of other users' conversations.
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. Load history and confirm there is an assistant answer to regenerate.
+    #    This is a read-only check, so doing it before the rate-limit record
+    #    means an invalid request (no assistant turn) never burns a quota slot.
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+    if not all_messages or all_messages[-1]["role"] != "assistant":
+        raise HTTPException(
+            status_code=400,
+            detail="No assistant response to regenerate",
+        )
+    last_assistant = all_messages[-1]
+
+    # 3. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1) BEFORE
+    #    deleting anything. Recording the slot first means a user cannot
+    #    delete-spam old answers to slip past the cap — every regenerate costs
+    #    a slot regardless of whether the stream later aborts.
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 4. Delete the stale assistant message so the replacement takes its place.
+    #    A crash mid-stream then leaves the conversation ending on the user
+    #    message (no answer) rather than two assistant answers.
+    await repository.delete_message(last_assistant["id"], conv_id, user_id)
+
+    # 5. Build the LLM context from the remaining history — it now ends with
+    #    the user message that prompted the answer, exactly as a normal send
+    #    would after persisting the user message.
+    history = all_messages[:-1]
+    llm_messages = [{"role": m["role"], "content": m["content"]} for m in history]
+
+    # 6-8. Stream the replacement. title_seed=None: regeneration adds no new
+    # user message, so the auto-title logic must not re-run.
+    return await _stream_assistant_response(
+        conv_id=conv_id,
+        user_id=user_id,
+        llm_messages=llm_messages,
+        current_user=current_user,
+        title_seed=None,
+    )
+
+
+async def _stream_assistant_response(
+    *,
+    conv_id: str,
+    user_id: str,
+    llm_messages: list[dict[str, Any]],
+    current_user: dict[str, Any],
+    title_seed: str | None,
+) -> StreamingResponse:
+    """Run the tool-driven RAG stream and return the SSE ``StreamingResponse``.
+
+    Shared by both the normal send and the regenerate flows. Callers are
+    responsible for ownership verification, rate-limit recording, and (for
+    sends) persisting the user message before invoking this helper.
+
+    ``title_seed`` is the user content used to auto-generate a conversation
+    title on the first send; pass ``None`` (e.g. for regeneration) to skip the
+    title step entirely.
+    """
     # 5. Set up tool plumbing. All retrieval happens inside the LLM loop via
     # tool calls — no pre-retrieval runs here. The executor closure collects
     # every chunk returned by any tool call so the final SSE `sources` event
@@ -291,14 +401,17 @@ async def create_message(
                     raise
                 # Title auto-generation is best-effort: client-disconnect swallowed,
                 # unexpected errors logged but not re-raised (message was saved above).
-                try:
-                    await asyncio.shield(
-                        _maybe_set_conversation_title(conv_id, user_id, user_content)
-                    )
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:
-                    logger.warning("Failed to update conversation title: %s", exc)
+                # Skipped entirely when title_seed is None (e.g. regeneration adds
+                # no new user message, so the title must not change).
+                if title_seed is not None:
+                    try:
+                        await asyncio.shield(
+                            _maybe_set_conversation_title(conv_id, user_id, title_seed)
+                        )
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception as exc:
+                        logger.warning("Failed to update conversation title: %s", exc)
 
     return StreamingResponse(
         event_generator(),

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,228 @@
+"""
+Tests for POST /api/conversations/{conv_id}/messages/regenerate
+(routes/messages.py::regenerate_message).
+
+The regenerate flow must:
+  1. Delete the latest assistant message and stream a replacement that is
+     persisted in its place (with its own sources).
+  2. Count against the 25 msg/user/24h cap — `rate_limit.check_and_record`
+     runs BEFORE the delete so a user cannot delete-spam past the cap.
+  3. Refuse (400) when there is no assistant answer to regenerate, WITHOUT
+     consuming a quota slot or deleting anything.
+  4. Not re-run the conversation auto-title logic (no new user message).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from backend.auth.dependencies import get_current_user
+from backend.main import app
+
+
+@pytest.fixture
+def bypass_auth():
+    stub = {"id": str(uuid4()), "email": "t@t"}
+    app.dependency_overrides[get_current_user] = lambda: stub
+    yield stub
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+async def _fake_stream(*args: Any, **kwargs: Any):
+    final_text_out = kwargs.get("final_text_out")
+    for token in ("Fresh", " answer", "."):
+        yield f"data: {json.dumps(token)}\n\n"
+    if final_text_out is not None:
+        final_text_out.append("Fresh answer.")
+    yield "data: [DONE]\n\n"
+
+
+async def _drain(resp: Any) -> None:
+    """Consume the StreamingResponse so the persist `finally` block runs."""
+    async for _ in resp.body_iterator:
+        pass
+    # Let the shielded save settle.
+    await asyncio.sleep(0.05)
+
+
+class TestRegenerateHappyPath:
+    async def test_deletes_old_answer_records_quota_and_persists_replacement(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        user = bypass_auth
+        conv = {"id": str(uuid4()), "user_id": user["id"], "title": "Some title"}
+        last_assistant_id = str(uuid4())
+        history = [
+            {"id": str(uuid4()), "role": "user", "content": "what is X?"},
+            {"id": last_assistant_id, "role": "assistant", "content": "old answer"},
+        ]
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=history,
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+            ) as mock_rate,
+            patch(
+                "backend.routes.messages.repository.delete_message",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_delete,
+            patch(
+                "backend.routes.messages.repository.create_message",
+                new_callable=AsyncMock,
+                return_value={"id": str(uuid4())},
+            ) as mock_create,
+            patch(
+                "backend.routes.messages.repository.list_videos",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("backend.routes.messages.stream_chat", side_effect=_fake_stream),
+            patch(
+                "backend.routes.messages._maybe_set_conversation_title",
+                new_callable=AsyncMock,
+            ) as mock_title,
+        ):
+            from backend.routes.messages import regenerate_message
+
+            resp = await regenerate_message(conv_id=conv["id"], current_user=user)
+            await _drain(resp)
+
+        # Quota consumed exactly once.
+        mock_rate.assert_awaited_once()
+        # Old assistant message deleted (scoped to conv + user).
+        mock_delete.assert_awaited_once()
+        del_args = mock_delete.await_args.args
+        assert del_args[0] == last_assistant_id
+        assert del_args[1] == conv["id"]
+        assert del_args[2] == user["id"]
+        # Replacement persisted as an assistant message.
+        mock_create.assert_awaited_once()
+        assert mock_create.await_args.kwargs["role"] == "assistant"
+        assert "Fresh answer" in mock_create.await_args.kwargs["content"]
+        # Title logic must NOT re-run (no new user message).
+        mock_title.assert_not_called()
+
+
+class TestRegenerateGuards:
+    async def test_400_when_last_message_is_not_assistant(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """No assistant answer to regenerate → 400, no quota burned, no delete."""
+        user = bypass_auth
+        conv = {"id": str(uuid4()), "user_id": user["id"], "title": "t"}
+        history = [{"id": str(uuid4()), "role": "user", "content": "hi"}]
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=history,
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+            ) as mock_rate,
+            patch(
+                "backend.routes.messages.repository.delete_message",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            from fastapi import HTTPException
+
+            from backend.routes.messages import regenerate_message
+
+            with pytest.raises(HTTPException) as exc:
+                await regenerate_message(conv_id=conv["id"], current_user=user)
+            assert exc.value.status_code == 400
+
+        mock_rate.assert_not_called()
+        mock_delete.assert_not_called()
+
+    async def test_rate_limited_does_not_delete_old_answer(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """When the user is over the cap, the old answer must NOT be deleted."""
+        from datetime import datetime, timezone
+
+        from backend import rate_limit
+
+        user = bypass_auth
+        conv = {"id": str(uuid4()), "user_id": user["id"], "title": "t"}
+        history = [
+            {"id": str(uuid4()), "role": "user", "content": "q"},
+            {"id": str(uuid4()), "role": "assistant", "content": "a"},
+        ]
+
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch(
+                "backend.routes.messages.repository.list_messages",
+                new_callable=AsyncMock,
+                return_value=history,
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+                side_effect=rate_limit.RateLimitExceeded(
+                    reset_at=datetime(2030, 1, 1, tzinfo=timezone.utc)
+                ),
+            ),
+            patch(
+                "backend.routes.messages.repository.delete_message",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            from backend.routes.messages import regenerate_message
+
+            resp = await regenerate_message(conv_id=conv["id"], current_user=user)
+
+        assert resp.status_code == 429
+        mock_delete.assert_not_called()
+
+    async def test_404_when_conversation_not_owned(self, bypass_auth: dict[str, Any]) -> None:
+        user = bypass_auth
+        with (
+            patch(
+                "backend.routes.messages.repository.get_conversation",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "backend.routes.messages.rate_limit.check_and_record",
+                new_callable=AsyncMock,
+            ) as mock_rate,
+        ):
+            from fastapi import HTTPException
+
+            from backend.routes.messages import regenerate_message
+
+            with pytest.raises(HTTPException) as exc:
+                await regenerate_message(conv_id=str(uuid4()), current_user=user)
+            assert exc.value.status_code == 404
+        mock_rate.assert_not_called()

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    regenerateStream,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -559,6 +560,69 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     ],
   );
 
+  // ── Regenerate handler — replace the latest assistant answer in place ──
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId || isStreaming) return;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return;
+
+    setInlineError(null);
+    setFailedMessageText(null);
+
+    // Optimistically drop the stale answer so the streaming bubble takes its
+    // place (rather than showing both at once). Keep a reference so we can
+    // restore it if the regenerate request fails.
+    setMessages((prev) => prev.filter((m) => m.id !== last.id));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await regenerateStream(conversationId, ({ fullText, sources }) => {
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      // Pull fresh quota counter — a regenerate counts against the daily cap.
+      refreshAuth();
+    } catch (e) {
+      // Restore the previous answer so the conversation isn't left truncated.
+      setMessages((prev) => [...prev, last]);
+
+      // Intentional abort (navigation or user cancel) — no error toast.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        addToast(friendly, 'error');
+        // Sync counter so the sidebar reflects the exhausted quota.
+        refreshAuth();
+        return;
+      }
+
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate response';
+      setInlineError('Failed to regenerate the response. Please try again.');
+      addToast(errMsg || 'Network error — could not regenerate', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    setMessages,
+    regenerateStream,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+  ]);
+
   // Send pending message after conversation is created (post-route-change).
   // We read from `location.state.initialMessage`, which survives the
   // LandingPage → ConversationPage remount. Clear state with `replace`
@@ -708,15 +772,22 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
-              messages.map((msg) => (
-                <Message
-                  key={msg.id}
-                  role={msg.role}
-                  content={msg.content}
-                  sources={msg.sources}
-                  onCitationClick={handleCitationClick}
-                />
-              ))
+              messages.map((msg, idx) => {
+                // The regenerate action only belongs on the most recent
+                // assistant answer, and only when nothing is streaming.
+                const isLatestAssistant =
+                  idx === messages.length - 1 && msg.role === 'assistant' && !isStreaming;
+                return (
+                  <Message
+                    key={msg.id}
+                    role={msg.role}
+                    content={msg.content}
+                    sources={msg.sources}
+                    onCitationClick={handleCitationClick}
+                    onRegenerate={isLatestAssistant ? handleRegenerate : undefined}
+                  />
+                );
+              })
             )}
 
             {/* Streaming assistant bubble */}

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,59 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** When provided, renders a "Regenerate" action below an assistant message.
+   *  ChatArea passes this only for the most recent assistant answer. */
+  onRegenerate?: () => void;
+}
+
+// ── Regenerate action ─────────────────────────────────────────────
+function RegenerateButton({ onRegenerate }: { onRegenerate: () => void }) {
+  return (
+    <button
+      onClick={onRegenerate}
+      title="Regenerate this response"
+      aria-label="Regenerate this response"
+      className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+      style={{
+        marginTop: 10,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        background: 'transparent',
+        border: '1px solid rgba(255,255,255,0.12)',
+        borderRadius: 7,
+        color: '#94a3b8',
+        cursor: 'pointer',
+        fontSize: 12,
+        padding: '4px 10px',
+        fontFamily: 'inherit',
+        transition: 'background 0.15s, color 0.15s, border-color 0.15s',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.color = '#f1f5f9';
+        e.currentTarget.style.borderColor = 'rgba(59,130,246,0.4)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.color = '#94a3b8';
+        e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)';
+      }}
+    >
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 13 13"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M11,2 L11,5 L8,5" />
+        <path d="M11,5 A4.5,4.5 0 1,0 11.5,8.5" />
+      </svg>
+      Regenerate
+    </button>
+  );
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,9 +220,13 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
+  // Show the regenerate action on a settled (non-streaming) assistant message
+  // when ChatArea wired the handler (i.e. it is the latest answer).
+  const showRegenerate = !isUser && !isStreaming && !!onRegenerate;
 
   return (
     <div
@@ -204,6 +261,7 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {showRegenerate && onRegenerate && <RegenerateButton onRegenerate={onRegenerate} />}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -81,15 +81,15 @@ export function useStreamingResponse(conversationId: string | null) {
         }
         if (res.status === 429) {
           // MISSION §10 #1 — daily cap hit. Body: {error, limit, window_hours, reset_at}.
-          let body: Record<string, unknown> | null = null;
+          let errBody: Record<string, unknown> | null = null;
           try {
-            body = await res.json();
+            errBody = await res.json();
           } catch (jsonErr) {
             console.warn('[useStreamingResponse] Failed to parse 429 body:', jsonErr);
           }
-          if (body && typeof body === 'object' && 'limit' in body) {
+          if (errBody && typeof errBody === 'object' && 'limit' in errBody) {
             throw new RateLimitError(
-              body as { limit: number; window_hours: number; reset_at: string },
+              errBody as { limit: number; window_hours: number; reset_at: string },
             );
           }
           throw new Error('Daily message limit reached');

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -42,10 +42,13 @@ export function useStreamingResponse(conversationId: string | null) {
     }
   }, []);
 
-  const startStream = useCallback(
+  // Shared SSE consumer for both the normal send and the regenerate flows.
+  // `url` is the POST endpoint; `body` is the JSON request body (null for
+  // regenerate, which carries no payload). Parsing is identical for both.
+  const runStream = useCallback(
     async (
-      conversationId: string,
-      userMessage: string,
+      url: string,
+      body: string | null,
       onComplete: (result: StreamResult) => void,
     ): Promise<void> => {
       setIsStreaming(true);
@@ -61,11 +64,11 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+        const res = await fetch(url, {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
+          body: body ?? undefined,
           signal: abortController.signal,
         });
 
@@ -218,12 +221,36 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startStream = useCallback(
+    (
+      conversationId: string,
+      userMessage: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> =>
+      runStream(
+        `/api/conversations/${conversationId}/messages`,
+        JSON.stringify({ content: userMessage }),
+        onComplete,
+      ),
+    [runStream],
+  );
+
+  // Regenerate a fresh assistant answer for the latest user turn. No request
+  // body — the backend replays the existing history. Streams identically to a
+  // normal send so the UI path is shared.
+  const regenerateStream = useCallback(
+    (conversationId: string, onComplete: (result: StreamResult) => void): Promise<void> =>
+      runStream(`/api/conversations/${conversationId}/messages/regenerate`, null, onComplete),
+    [runStream],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    regenerateStream,
     abortStream,
   };
 }


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `XO` (plan=NONE, impl=Opus)
**Source run-id:** `db767b8a-22f8-4460-8759-2ed749b3197d`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.