### PR TITLE
[bench-XO] review: fix infinite re-fetch loop on error in VideoScopePicker

### DIFF
--- a/app/backend/alembic/versions/0006_add_video_scope_to_conversations.py
+++ b/app/backend/alembic/versions/0006_add_video_scope_to_conversations.py
@@ -1,0 +1,40 @@
+"""Add per-conversation video scope (issue #279).
+
+Lets a user restrict a conversation to a subset of videos so the assistant's
+answers and citations only draw from those videos. The scope persists for the
+life of the conversation.
+
+`video_scope` is a nullable TEXT[] of video ids:
+  - NULL (default) → unscoped; retrieval searches the whole library (today's
+    behaviour, unchanged for every existing conversation).
+  - non-empty array → retrieval is restricted to those video ids.
+
+TEXT[] (not JSONB) so the scope reads back as a native Python list with no
+codec dance and slots straight into the existing `video_id = ANY($n::text[])`
+SQL filter pattern used by keyword/vector search.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Nullable, no default — NULL means "unscoped" so existing conversations
+    # keep searching the whole library.
+    op.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS video_scope TEXT[]")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS video_scope")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -12,6 +12,7 @@ import json
 import logging
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 import asyncpg
 
@@ -253,6 +254,7 @@ async def keyword_search(
     top_k: int,
     language: str = "english",
     allowed_source_types: list[str] | None = None,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
@@ -265,6 +267,11 @@ async def keyword_search(
             this list are excluded. Defaults to ['youtube'] which is the
             backwards-compatible behavior for callers that don't yet know
             about Dynamous content (issue #147).
+        allowed_video_ids: Conversation video-scope filter (issue #279) — when
+            a non-empty list is given, only chunks belonging to those video ids
+            are returned. ``None`` or an empty list means no restriction (search
+            the whole library). Unknown ids simply match nothing, so a scope
+            referencing a since-deleted video degrades gracefully.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -272,20 +279,24 @@ async def keyword_search(
     """
     if allowed_source_types is None:
         allowed_source_types = ["youtube"]
+    params: list[Any] = [query, top_k, allowed_source_types]
+    video_clause = ""
+    if allowed_video_ids:
+        params.append(allowed_video_ids)
+        video_clause = f"AND video_id = ANY(${len(params)}::text[])"
     async with _acquire() as conn:
         rows = await conn.fetch(
-            """
+            f"""
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
                    ts_rank(search_vector, plainto_tsquery($1)) AS rank
             FROM chunks
             WHERE search_vector @@ plainto_tsquery($1)
               AND source_type = ANY($3::text[])
+              {video_clause}
             ORDER BY rank DESC
             LIMIT $2
             """,
-            query,
-            top_k,
-            allowed_source_types,
+            *params,
         )
     return [dict(r) for r in rows]
 
@@ -294,6 +305,7 @@ async def vector_search_pg(
     query_embedding: list[float],
     top_k: int,
     allowed_source_types: list[str] | None = None,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
@@ -311,6 +323,11 @@ async def vector_search_pg(
             compatibility (issue #147). The pool's `hnsw.iterative_scan =
             relaxed_order` setting (see db/postgres.py) keeps the HNSW index
             usable under this filter.
+        allowed_video_ids: Conversation video-scope filter (issue #279) — when
+            a non-empty list is given, only chunks belonging to those video ids
+            are returned. ``None`` or an empty list means no restriction. The
+            relaxed iterative-scan setting keeps the HNSW index usable under
+            this extra filter too.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -319,19 +336,23 @@ async def vector_search_pg(
     if allowed_source_types is None:
         allowed_source_types = ["youtube"]
     embedding_json = json.dumps(query_embedding)
+    params: list[Any] = [embedding_json, top_k, allowed_source_types]
+    video_clause = ""
+    if allowed_video_ids:
+        params.append(allowed_video_ids)
+        video_clause = f"AND video_id = ANY(${len(params)}::text[])"
     async with _acquire() as conn:
         rows = await conn.fetch(
-            """
+            f"""
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
             WHERE source_type = ANY($3::text[])
+              {video_clause}
             ORDER BY distance
             LIMIT $2
             """,
-            embedding_json,
-            top_k,
-            allowed_source_types,
+            *params,
         )
     return [dict(r) for r in rows]
 
@@ -415,18 +436,31 @@ async def replace_chunks_for_video(
 # ---------------------------------------------------------------------------
 
 
-async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict:
+async def create_conversation(
+    *,
+    user_id: str,
+    title: str = "New Conversation",
+    video_scope: list[str] | None = None,
+) -> dict:
+    """Create a conversation, optionally scoped to a subset of videos (#279).
+
+    ``video_scope`` is stored as a TEXT[] of video ids; ``None`` (the default)
+    leaves the conversation unscoped so retrieval searches the whole library.
+    """
     conv_id = _new_id()
     now = _now()
+    # Normalise an empty list to NULL so "no videos picked" reads as unscoped.
+    scope = video_scope or None
     async with _acquire() as conn:
         await conn.execute(
             """
-            INSERT INTO conversations (id, user_id, title, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO conversations (id, user_id, title, video_scope, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
             """,
             conv_id,
             user_id,
             title,
+            scope,
             now,
             now,
         )
@@ -434,6 +468,7 @@ async def create_conversation(*, user_id: str, title: str = "New Conversation") 
         "id": conv_id,
         "user_id": user_id,
         "title": title,
+        "video_scope": scope,
         "created_at": now,
         "updated_at": now,
     }
@@ -475,6 +510,28 @@ async def update_conversation_title(conv_id: str, user_id: str, title: str) -> b
         result = await conn.execute(
             "UPDATE conversations SET title = $1, updated_at = $2 WHERE id = $3 AND user_id = $4",
             title,
+            _now(),
+            conv_id,
+            user_id,
+        )
+        return result != "UPDATE 0"  # type: ignore[no-any-return]
+
+
+async def update_conversation_scope(
+    conv_id: str, user_id: str, video_scope: list[str] | None
+) -> bool:
+    """Set the conversation's video scope (issue #279). Returns False if the
+    conversation does not belong to the user.
+
+    ``video_scope`` is normalised to NULL when empty so clearing the picker
+    restores whole-library search. Owner-scoped via the user_id predicate —
+    mirrors update_conversation_title so a cross-user write is a silent no-op.
+    """
+    scope = video_scope or None
+    async with _acquire() as conn:
+        result = await conn.execute(
+            "UPDATE conversations SET video_scope = $1, updated_at = $2 WHERE id = $3 AND user_id = $4",
+            scope,
             _now(),
             conv_id,
             user_id,

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -40,6 +40,7 @@ async def retrieve_hybrid(
     query_embedding: list[float],
     top_k: int = 5,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -52,6 +53,10 @@ async def retrieve_hybrid(
             = 'dynamous'`) is included alongside the default YouTube content.
             Non-members see YouTube chunks only. The filter is applied at the
             SQL layer — non-member retrieval never touches Dynamous chunks.
+        allowed_video_ids: Conversation video-scope filter (issue #279). When a
+            non-empty list is given, both the keyword and vector legs only fetch
+            chunks from those video ids, so the fused result can only contain
+            in-scope videos. ``None``/empty means search the whole library.
 
     Returns:
         A list of dicts (length <= top_k), each containing:
@@ -82,18 +87,24 @@ async def retrieve_hybrid(
     # Over-fetch factor — each method returns 2*top_k before merging
     fetch_k = top_k * HYBRID_OVERFETCH_FACTOR
 
-    # Run keyword and vector searches concurrently
-    keyword_task = repository.keyword_search(
-        query_text,
-        top_k=fetch_k,
-        language=KEYWORD_LANGUAGE,
-        allowed_source_types=allowed_source_types,
-    )
-    vector_task = repository.vector_search_pg(
-        query_embedding,
-        top_k=fetch_k,
-        allowed_source_types=allowed_source_types,
-    )
+    # Run keyword and vector searches concurrently. The video-scope filter is
+    # passed through only when set so unscoped callers (and their test fakes)
+    # see the exact same signature as before issue #279.
+    keyword_kwargs: dict = {
+        "top_k": fetch_k,
+        "language": KEYWORD_LANGUAGE,
+        "allowed_source_types": allowed_source_types,
+    }
+    vector_kwargs: dict = {
+        "top_k": fetch_k,
+        "allowed_source_types": allowed_source_types,
+    }
+    if allowed_video_ids:
+        keyword_kwargs["allowed_video_ids"] = allowed_video_ids
+        vector_kwargs["allowed_video_ids"] = allowed_video_ids
+
+    keyword_task = repository.keyword_search(query_text, **keyword_kwargs)
+    vector_task = repository.vector_search_pg(query_embedding, **vector_kwargs)
 
     keyword_hits, vector_hits = await keyword_task, await vector_task
 

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -410,8 +410,14 @@ async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Hybrid (keyword + semantic via RRF) search."""
+    """Hybrid (keyword + semantic via RRF) search.
+
+    ``allowed_video_ids`` is the conversation's video scope (issue #279): when
+    set, retrieval is restricted to those videos so answers and citations only
+    come from them.
+    """
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
     from backend.rag.retriever_hybrid import retrieve_hybrid
 
@@ -423,9 +429,15 @@ async def execute_search_hybrid(
         return {"ok": False, "error": "missing required parameter: query"}
     top_k = _clamp_top_k(args.get("top_k"))
 
+    # Forward the scope only when set so unscoped callers (and their existing
+    # test fakes) keep the pre-#279 retrieve_hybrid signature.
+    retrieve_kwargs: dict[str, Any] = {"top_k": top_k, "is_member": is_member}
+    if allowed_video_ids:
+        retrieve_kwargs["allowed_video_ids"] = allowed_video_ids
+
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
+        chunks = await retrieve_hybrid(query, embedding, **retrieve_kwargs)
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -439,8 +451,12 @@ async def execute_search_hybrid(
 async def execute_search_keyword(
     raw_arguments: str | dict,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Keyword-only (tsvector FTS) search."""
+    """Keyword-only (tsvector FTS) search.
+
+    ``allowed_video_ids`` is the conversation's video scope (issue #279).
+    """
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
 
     args = _parse_args(raw_arguments)
@@ -453,13 +469,16 @@ async def execute_search_keyword(
 
     allowed = ["youtube", "dynamous"] if is_member else ["youtube"]
 
+    search_kwargs: dict[str, Any] = {
+        "top_k": top_k,
+        "language": KEYWORD_LANGUAGE,
+        "allowed_source_types": allowed,
+    }
+    if allowed_video_ids:
+        search_kwargs["allowed_video_ids"] = allowed_video_ids
+
     try:
-        raw = await repository.keyword_search(
-            query,
-            top_k=top_k,
-            language=KEYWORD_LANGUAGE,
-            allowed_source_types=allowed,
-        )
+        raw = await repository.keyword_search(query, **search_kwargs)
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
         logger.warning("search_keyword failed: %s", exc, exc_info=True)
@@ -475,8 +494,12 @@ async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Semantic-only (pgvector cosine) search."""
+    """Semantic-only (pgvector cosine) search.
+
+    ``allowed_video_ids`` is the conversation's video scope (issue #279).
+    """
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
 
     args = _parse_args(raw_arguments)
@@ -489,11 +512,13 @@ async def execute_search_semantic(
 
     allowed = ["youtube", "dynamous"] if is_member else ["youtube"]
 
+    search_kwargs: dict[str, Any] = {"top_k": top_k, "allowed_source_types": allowed}
+    if allowed_video_ids:
+        search_kwargs["allowed_video_ids"] = allowed_video_ids
+
     try:
         embedding = await _embed_query(query, embedding_cache)
-        raw = await repository.vector_search_pg(
-            embedding, top_k=top_k, allowed_source_types=allowed
-        )
+        raw = await repository.vector_search_pg(embedding, **search_kwargs)
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
         logger.warning("search_semantic failed: %s", exc, exc_info=True)
@@ -509,12 +534,18 @@ async def execute_get_video_transcript(
     raw_arguments: str | dict,
     video_id_whitelist: set[str] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Full transcript of one video. video_id_whitelist guards against the
     model hallucinating ids; None disables the check (tests).
 
     Defense-in-depth: a non-member who somehow guesses a Dynamous video_id
     is blocked here in addition to the search-layer filter.
+
+    ``allowed_video_ids`` is the conversation's video scope (issue #279). When
+    set, a transcript request for a video outside the scope is rejected — the
+    transcript tool takes an explicit video_id, so without this guard the model
+    could pull a full out-of-scope transcript and bypass the scoped search.
     """
     args = _parse_args(raw_arguments)
     if args is None:
@@ -530,6 +561,15 @@ async def execute_get_video_transcript(
             "error": (
                 f"video_id {video_id!r} is not in the current library. "
                 "Only ids from prior search results are valid."
+            ),
+        }
+
+    if allowed_video_ids and video_id not in allowed_video_ids:
+        return {
+            "ok": False,
+            "error": (
+                f"video_id {video_id!r} is outside the videos this conversation "
+                "is scoped to. Only search results from the selected videos are valid."
             ),
         }
 
@@ -603,6 +643,7 @@ async def execute_tool(
     video_id_whitelist: set[str] | None = None,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    allowed_video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Dispatch by tool name. Unknown names return an error dict so the
     model sees the refusal and stops calling.
@@ -612,20 +653,35 @@ async def execute_tool(
 
     ``is_member`` controls retrieval ACL: True surfaces both YouTube and
     Dynamous (paid) chunks; False sees YouTube only.
+
+    ``allowed_video_ids`` is the conversation's video scope (issue #279). When
+    set, every retrieval tool — search and transcript — is restricted to those
+    videos, so the model can only ground its answer in the user's selection.
     """
     if name == "search_videos":
         return await execute_search_hybrid(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            allowed_video_ids=allowed_video_ids,
         )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments, is_member=is_member)
+        return await execute_search_keyword(
+            raw_arguments, is_member=is_member, allowed_video_ids=allowed_video_ids
+        )
     if name == "semantic_search_videos":
         return await execute_search_semantic(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            allowed_video_ids=allowed_video_ids,
         )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(
-            raw_arguments, video_id_whitelist=video_id_whitelist, is_member=is_member
+            raw_arguments,
+            video_id_whitelist=video_id_whitelist,
+            is_member=is_member,
+            allowed_video_ids=allowed_video_ids,
         )
     return {"ok": False, "error": f"unknown tool: {name}"}
 

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -19,10 +19,32 @@ router = APIRouter()
 
 class ConversationCreate(BaseModel):
     title: str = "New Conversation"
+    # Optional video scope (issue #279): pin the conversation to a subset of
+    # videos so the assistant only answers from them. Omitted/empty = unscoped.
+    video_scope: list[str] | None = None
 
 
 class ConversationRename(BaseModel):
     title: str
+
+
+class ConversationScopeUpdate(BaseModel):
+    # The video ids this conversation should be scoped to. An empty list clears
+    # the scope and restores whole-library search.
+    video_ids: list[str]
+
+
+def _normalize_scope(video_ids: list[str] | None) -> list[str] | None:
+    """Trim, drop blanks, de-dupe (order-preserving). Empty → None (unscoped)."""
+    if not video_ids:
+        return None
+    seen: list[str] = []
+    for v in video_ids:
+        if isinstance(v, str):
+            trimmed = v.strip()
+            if trimmed and trimmed not in seen:
+                seen.append(trimmed)
+    return seen or None
 
 
 @router.get("/conversations")
@@ -35,11 +57,17 @@ async def create_conversation(
     body: ConversationCreate | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    """Create a new empty conversation. Body is optional; defaults to title='New Conversation'."""
+    """Create a new empty conversation. Body is optional; defaults to title='New Conversation'.
+
+    An optional ``video_scope`` pins the conversation to a subset of videos
+    (issue #279); omitted or empty leaves it unscoped (whole-library search).
+    """
     title = body.title if body else "New Conversation"
+    video_scope = _normalize_scope(body.video_scope) if body else None
     return await repository.create_conversation(
         user_id=str(current_user["id"]),
         title=title,
+        video_scope=video_scope,
     )
 
 
@@ -92,6 +120,29 @@ async def rename_conversation(
         raise HTTPException(status_code=404, detail="Conversation not found")
     conv = await repository.get_conversation(conv_id, user_id=str(current_user["id"]))
     return conv
+
+
+@router.put("/conversations/{conv_id}/scope")
+async def set_conversation_scope(
+    conv_id: str,
+    body: ConversationScopeUpdate,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Scope a conversation to a subset of videos (issue #279).
+
+    Pass the video ids to restrict the assistant to; pass an empty list to
+    clear the scope and search the whole library again. Owner-scoped — a
+    mismatched conversation returns 404 (no existence leak), exactly like the
+    other conversation mutations here.
+    """
+    user_id = str(current_user["id"])
+    scope = _normalize_scope(body.video_ids)
+    updated = await repository.update_conversation_scope(
+        conv_id, user_id=user_id, video_scope=scope
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return await repository.get_conversation(conv_id, user_id=user_id)
 
 
 @router.get("/videos")

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -144,17 +144,31 @@ async def create_message(
         # turn won't change behavior mid-flight.
         is_member_for_turn = bool(current_user.get("is_member", False))
 
+        # Conversation video scope (issue #279): when the user pinned this
+        # conversation to a subset of videos, every retrieval tool is restricted
+        # to those ids so answers and citations only come from them. Captured
+        # once per turn (consistent with the ACL above). None/empty = unscoped,
+        # i.e. search the whole library exactly as before.
+        raw_scope = conv.get("video_scope")
+        video_scope_for_turn: list[str] | None = list(raw_scope) if raw_scope else None
+
         async def _executor(name: str, raw_args: str) -> str:
             # Pass `None` (not empty set) when the whitelist failed to load so
             # the transcript tool falls back to open lookups instead of rejecting
             # every id.
             whitelist = video_id_whitelist if video_id_whitelist else None
+            # Forward the conversation scope only when set, so the unscoped path
+            # keeps execute_tool's pre-#279 call signature unchanged.
+            extra: dict[str, Any] = {}
+            if video_scope_for_turn:
+                extra["allowed_video_ids"] = video_scope_for_turn
             result = await execute_tool(
                 name,
                 raw_args,
                 video_id_whitelist=whitelist,
                 embedding_cache=embedding_cache,
                 is_member=is_member_for_turn,
+                **extra,
             )
             if result.get("ok") and result.get("chunks"):
                 tool_chunks_acc.extend(result["chunks"])

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -168,6 +168,50 @@ class TestRetrieveHybrid:
                 assert "end_seconds" in item
                 assert "snippet" in item
 
+    async def test_forwards_video_scope_to_both_legs(self):
+        """When allowed_video_ids is set (issue #279), both the keyword and
+        vector legs must receive it so the fused result can only contain chunks
+        from the scoped videos."""
+        from backend.config import HYBRID_OVERFETCH_FACTOR
+
+        fetch_k = 5 * HYBRID_OVERFETCH_FACTOR
+
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+            ) as mock_video,
+        ):
+            mock_kw.return_value = [_CHUNK_A]
+            mock_vec.return_value = [_CHUNK_A]
+            mock_video.return_value = {"title": "T", "url": "u"}
+
+            await retrieve_hybrid(
+                "test query", [0.1] * 1536, top_k=5, allowed_video_ids=["v1", "v2"]
+            )
+
+            mock_kw.assert_called_once_with(
+                "test query",
+                top_k=fetch_k,
+                language="english",
+                allowed_source_types=["youtube"],
+                allowed_video_ids=["v1", "v2"],
+            )
+            mock_vec.assert_called_once_with(
+                [0.1] * 1536,
+                top_k=fetch_k,
+                allowed_source_types=["youtube"],
+                allowed_video_ids=["v1", "v2"],
+            )
+
     async def test_rare_exact_term_boosted_by_keyword_path(self):
         """A technical acronym (weak in cosine space) ranks higher via hybrid.
 

--- a/app/backend/tests/test_video_scope.py
+++ b/app/backend/tests/test_video_scope.py
@@ -1,0 +1,214 @@
+"""Tests for per-conversation video scope (issue #279).
+
+A conversation can be pinned to a subset of videos so the assistant's answers
+and citations only come from them. The scope is threaded from the conversation
+row → messages route → tool executor → search/transcript layer. These tests
+cover every link below the route (the route layer is exercised via the
+``_normalize_scope`` helper plus the repository signature).
+
+If no scope is set, retrieval must behave exactly as before — search the whole
+library — so the search/transcript layers must call their dependencies with the
+pre-#279 signature (no ``allowed_video_ids`` kwarg) when the scope is empty.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+from backend.rag import tools as tools_module
+from backend.rag.tools import (
+    execute_get_video_transcript,
+    execute_search_hybrid,
+    execute_search_keyword,
+    execute_search_semantic,
+    execute_tool,
+)
+from backend.routes.conversations import _normalize_scope
+
+# ---------------------------------------------------------------------------
+# Route helper: scope normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_scope_none_and_empty_are_unscoped() -> None:
+    assert _normalize_scope(None) is None
+    assert _normalize_scope([]) is None
+    # All-blank input collapses to unscoped, not an empty-but-present scope.
+    assert _normalize_scope(["", "   "]) is None
+
+
+def test_normalize_scope_trims_dedupes_preserves_order() -> None:
+    assert _normalize_scope([" v1 ", "v2", "v1", "  ", "v3"]) == ["v1", "v2", "v3"]
+
+
+# ---------------------------------------------------------------------------
+# Repository signature invariant
+# ---------------------------------------------------------------------------
+
+
+def test_search_functions_accept_allowed_video_ids() -> None:
+    """The two SQL search functions must expose allowed_video_ids so the scope
+    can reach the WHERE clause. Structural guard against a silent removal."""
+    from backend.db import repository
+
+    for name in ("keyword_search", "vector_search_pg"):
+        params = inspect.signature(getattr(repository, name)).parameters
+        assert "allowed_video_ids" in params, f"repository.{name} must take allowed_video_ids"
+
+    # update_conversation_scope must be owner-scoped (takes user_id).
+    scope_params = inspect.signature(repository.update_conversation_scope).parameters
+    assert "user_id" in scope_params
+
+
+# ---------------------------------------------------------------------------
+# Search executors forward the scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hybrid_forwards_scope_to_retriever(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_retrieve(_q, _emb, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_search_hybrid({"query": "q"}, allowed_video_ids=["v1", "v2"])
+    assert captured.get("allowed_video_ids") == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_omits_scope_kwarg_when_unscoped(monkeypatch) -> None:
+    """When unscoped, retrieve_hybrid must be called WITHOUT allowed_video_ids
+    so the pre-#279 signature (and its test fakes) keep working."""
+    captured: dict = {}
+
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
+        # Deliberately does NOT accept allowed_video_ids — this would TypeError
+        # if the executor passed it on the unscoped path.
+        captured["top_k"] = top_k
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    result = await execute_search_hybrid({"query": "q"})  # no scope
+    assert result["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_keyword_forwards_scope_to_repository(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_keyword(_q, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
+
+    await execute_search_keyword({"query": "q"}, allowed_video_ids=["v9"])
+    assert captured.get("allowed_video_ids") == ["v9"]
+
+
+@pytest.mark.asyncio
+async def test_semantic_forwards_scope_to_repository(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_vector(_emb, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "vector_search_pg", fake_vector)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_search_semantic({"query": "q"}, allowed_video_ids=["v9"])
+    assert captured.get("allowed_video_ids") == ["v9"]
+
+
+@pytest.mark.asyncio
+async def test_unscoped_keyword_does_not_pass_scope_kwarg(monkeypatch) -> None:
+    """Backward-compat: the unscoped path must not pass allowed_video_ids, so a
+    fake with the old signature still works."""
+
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
+    result = await execute_search_keyword({"query": "q"})  # no scope
+    assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Transcript tool scope guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transcript_rejects_out_of_scope_video() -> None:
+    result = await execute_get_video_transcript({"video_id": "v-out"}, allowed_video_ids=["v-in"])
+    assert result["ok"] is False
+    assert "scope" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_transcript_allows_in_scope_video(monkeypatch) -> None:
+    async def fake_get_video(_v):
+        return {"id": "v-in", "title": "In Scope", "url": "https://youtu.be/x"}
+
+    async def fake_list(_v):
+        return [
+            {
+                "id": "c1",
+                "content": "hello",
+                "chunk_index": 0,
+                "start_seconds": 0.0,
+                "end_seconds": 5.0,
+                "snippet": "hello",
+            }
+        ]
+
+    monkeypatch.setattr(tools_module.repository, "get_video", fake_get_video)
+    monkeypatch.setattr(tools_module.repository, "list_chunks_for_video", fake_list)
+
+    result = await execute_get_video_transcript(
+        {"video_id": "v-in"}, video_id_whitelist={"v-in"}, allowed_video_ids=["v-in"]
+    )
+    assert result["ok"] is True
+    assert "In Scope" in result["text"]
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher threads the scope through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_threads_scope_to_search(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_retrieve(_q, _emb, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_tool("search_videos", json.dumps({"query": "q"}), allowed_video_ids=["v1"])
+    assert captured.get("allowed_video_ids") == ["v1"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_threads_scope_to_transcript_guard() -> None:
+    result = await execute_tool(
+        "get_video_transcript",
+        json.dumps({"video_id": "v-out"}),
+        allowed_video_ids=["v-in"],
+    )
+    assert result["ok"] is False
+    assert "scope" in result["error"].lower()

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -1,4 +1,11 @@
-import { type MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type MutableRefObject,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { type Location, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useMessages } from '../hooks/useMessages';
@@ -10,6 +17,7 @@ import { exportConversationAsMarkdown } from '../lib/exportMarkdown';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { CitationModal } from './CitationModal';
 import { Message } from './Message';
+import { VideoScopePicker } from './VideoScopePicker';
 
 function formatResetTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
@@ -58,9 +66,12 @@ function SkeletonMessages() {
 // ── Empty / landing state ─────────────────────────────────────────
 interface EmptyStateProps {
   onStarterClick: (text: string) => void;
+  // Optional extra content rendered under the starters — used on the landing
+  // screen to host the video-scope picker (issue #279).
+  footer?: ReactNode;
 }
 
-function EmptyState({ onStarterClick }: EmptyStateProps) {
+function EmptyState({ onStarterClick, footer }: EmptyStateProps) {
   const starters = [
     'How do I use subagents in Claude Code?',
     'How should I structure an agent team?',
@@ -132,6 +143,7 @@ function EmptyState({ onStarterClick }: EmptyStateProps) {
           </button>
         ))}
       </div>
+      {footer && <div style={{ marginTop: 24, width: '100%', maxWidth: 400 }}>{footer}</div>}
     </div>
   );
 }
@@ -325,6 +337,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const pendingUserMsgIdRef = useRef<string | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
+  // Landing-screen video scope selection (issue #279). Applied when the first
+  // message creates the conversation, then fixed for the conversation's life.
+  const [scopeVideoIds, setScopeVideoIds] = useState<string[]>([]);
 
   // ── Auto-scroll logic ──
   // Defer scroll to the next paint cycle so streaming DOM updates are applied first.
@@ -459,7 +474,11 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       if (!conversationId) {
         if (isStreaming) return;
         try {
-          const conv = await createConversation();
+          // Apply the landing-screen video scope (issue #279) at creation so it
+          // sticks for the whole conversation. Empty selection → unscoped.
+          const conv = await createConversation(
+            scopeVideoIds.length > 0 ? scopeVideoIds : undefined,
+          );
           navigate(`/c/${conv.id}`, {
             state: { initialMessage: content } satisfies ConvLocationState,
           });
@@ -556,6 +575,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       addToast,
       refreshAuth,
       refreshConversationsRef,
+      scopeVideoIds,
     ],
   );
 
@@ -687,7 +707,12 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           </button>
         )}
 
-        {showEmpty && <EmptyState onStarterClick={handleStarterClick} />}
+        {showEmpty && (
+          <EmptyState
+            onStarterClick={handleStarterClick}
+            footer={<VideoScopePicker selected={scopeVideoIds} onChange={setScopeVideoIds} />}
+          />
+        )}
 
         {showSkeleton && <SkeletonMessages />}
 
@@ -705,6 +730,44 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             ref={messagesWrapperRef}
             style={{ padding: '24px 24px 0', display: 'flex', flexDirection: 'column' }}
           >
+            {/* Scope indicator (issue #279): show when this conversation is
+                pinned to a subset of videos so the user understands why
+                answers/citations are limited. */}
+            {conversation?.video_scope && conversation.video_scope.length > 0 && (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  alignSelf: 'flex-start',
+                  marginBottom: 12,
+                  padding: '6px 12px',
+                  background: 'rgba(59,130,246,0.1)',
+                  border: '1px solid rgba(59,130,246,0.3)',
+                  borderRadius: 999,
+                  fontSize: 12,
+                  color: '#93c5fd',
+                }}
+                title="This conversation only answers from the selected videos."
+              >
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 13 13"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="1.5" y="3" width="10" height="7" rx="1.5" />
+                  <polyline points="5,6 7.5,6.5 5,7" />
+                </svg>
+                Answering from {conversation.video_scope.length} selected video
+                {conversation.video_scope.length === 1 ? '' : 's'}
+              </div>
+            )}
+
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (

--- a/app/frontend/src/components/VideoScopePicker.tsx
+++ b/app/frontend/src/components/VideoScopePicker.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type Video, getVideos } from '../lib/api';
+
+interface VideoScopePickerProps {
+  /** Currently selected video ids. */
+  selected: string[];
+  /** Called with the new selection whenever the user toggles a video. */
+  onChange: (videoIds: string[]) => void;
+}
+
+/**
+ * Optional video picker shown on the landing screen (issue #279). Lets the user
+ * scope a new conversation to a subset of videos before sending their first
+ * message — the assistant then only answers from, and only cites, those videos.
+ *
+ * Picking nothing leaves the conversation unscoped (searches the whole
+ * library), which is the default behaviour. The panel is collapsed by default
+ * so users who never want scoping aren't distracted by it.
+ */
+export function VideoScopePicker({ selected, onChange }: VideoScopePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  // Lazy-load the video list the first time the panel is opened so the landing
+  // screen stays cheap for users who never scope.
+  useEffect(() => {
+    if (!open || loaded || loading) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getVideos()
+      .then((data) => {
+        if (!cancelled) {
+          setVideos(data);
+          setLoaded(true);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load videos');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, loaded, loading]);
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const toggle = useCallback(
+    (id: string) => {
+      if (selectedSet.has(id)) {
+        onChange(selected.filter((v) => v !== id));
+      } else {
+        onChange([...selected, id]);
+      }
+    },
+    [selected, selectedSet, onChange],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return videos;
+    return videos.filter((v) => v.title.toLowerCase().includes(q));
+  }, [videos, query]);
+
+  const count = selected.length;
+
+  return (
+    <div className="w-full max-w-md mx-auto text-left">
+      <div className="flex items-center gap-2 w-full px-3 py-2 bg-slate-800 border border-white/10 rounded-lg">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="flex items-center gap-2 flex-1 text-sm text-slate-300 hover:text-slate-100 transition-colors text-left"
+          aria-expanded={open}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={`transition-transform ${open ? 'rotate-90' : ''}`}
+          >
+            <polyline points="5,3 9,7 5,11" />
+          </svg>
+          <span className="flex-1">
+            {count > 0
+              ? `Scoped to ${count} video${count === 1 ? '' : 's'}`
+              : 'Scope to specific videos (optional)'}
+          </span>
+        </button>
+        {count > 0 && (
+          <button
+            type="button"
+            onClick={() => onChange([])}
+            className="text-xs text-slate-400 hover:text-slate-100 underline cursor-pointer shrink-0"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <div className="mt-2 bg-slate-800 border border-white/10 rounded-lg p-3">
+          <p className="text-xs text-slate-400 mb-2 leading-relaxed">
+            Pick the videos this conversation should draw from. The assistant will only answer using
+            — and only cite — the videos you select. Leave empty to search everything.
+          </p>
+
+          {(loaded || loading) && (
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter videos…"
+              className="w-full px-2.5 py-1.5 mb-2 bg-slate-900 border border-white/10 rounded-md text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:border-blue-500/50"
+            />
+          )}
+
+          {loading && <p className="text-xs text-slate-400 py-2">Loading videos…</p>}
+          {error && <p className="text-xs text-red-400 py-2">{error}</p>}
+
+          {loaded && filtered.length === 0 && (
+            <p className="text-xs text-slate-400 py-2">No videos match.</p>
+          )}
+
+          {loaded && filtered.length > 0 && (
+            <ul className="max-h-56 overflow-y-auto flex flex-col gap-0.5">
+              {filtered.map((v) => {
+                const checked = selectedSet.has(v.id);
+                return (
+                  <li key={v.id}>
+                    <label className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-slate-700/60 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggle(v.id)}
+                        className="accent-blue-500 shrink-0"
+                      />
+                      <span className="text-sm text-slate-200 truncate">{v.title}</span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/VideoScopePicker.tsx
+++ b/app/frontend/src/components/VideoScopePicker.tsx
@@ -48,7 +48,11 @@ export function VideoScopePicker({ selected, onChange }: VideoScopePickerProps) 
     return () => {
       cancelled = true;
     };
-  }, [open, loaded, loading]);
+  // `loading` is intentionally omitted from deps: it is set inside the effect
+  // so including it would cause an infinite re-fetch loop on error (loading
+  // goes false → effect re-triggers → another fetch starts → repeat).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, loaded]);
 
   const selectedSet = useMemo(() => new Set(selected), [selected]);
 

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,12 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  /**
+   * Video ids this conversation is scoped to (issue #279). When set, the
+   * assistant only answers from — and only cites — these videos. `null` or
+   * absent means the conversation searches the whole library.
+   */
+  video_scope?: string[] | null;
 }
 
 export interface Citation {
@@ -146,8 +152,22 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const getConversations = () => request<Conversation[]>('/conversations');
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
-export const createConversation = () =>
-  request<Conversation>('/conversations', { method: 'POST', body: '{}' });
+export const createConversation = (videoScope?: string[]) =>
+  request<Conversation>('/conversations', {
+    method: 'POST',
+    body: JSON.stringify(
+      videoScope && videoScope.length > 0 ? { video_scope: videoScope } : {},
+    ),
+  });
+/**
+ * Scope an existing conversation to a subset of videos (issue #279). Pass an
+ * empty array to clear the scope and search the whole library again.
+ */
+export const setConversationScope = (id: string, videoIds: string[]) =>
+  request<Conversation>(`/conversations/${id}/scope`, {
+    method: 'PUT',
+    body: JSON.stringify({ video_ids: videoIds }),
+  });
 export const getConversation = (id: string) =>
   request<ConversationWithMessages>(`/conversations/${id}`);
 export const deleteConversation = (id: string) =>


### PR DESCRIPTION
Fixes #279

**Benchmark cell:** `XO` (plan=NONE, impl=Opus)
**Source run-id:** `08173b7a-adcf-4ad4-a00c-56471afbd8d1`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.