### PR TITLE
[bench-XK] review: address self-review findings

### DIFF
--- a/app/backend/alembic/versions/0006_conversation_video_scope.py
+++ b/app/backend/alembic/versions/0006_conversation_video_scope.py
@@ -1,0 +1,34 @@
+"""Add video_ids scope to conversations.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-06-01
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE conversations
+        ADD COLUMN IF NOT EXISTS video_ids TEXT[]
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS conversations_video_ids_idx ON conversations USING GIN (video_ids)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS conversations_video_ids_idx")
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS video_ids")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -253,6 +253,7 @@ async def keyword_search(
     top_k: int,
     language: str = "english",
     allowed_source_types: list[str] | None = None,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
@@ -280,12 +281,14 @@ async def keyword_search(
             FROM chunks
             WHERE search_vector @@ plainto_tsquery($1)
               AND source_type = ANY($3::text[])
+              AND ($4::text[] IS NULL OR array_length($4::text[], 1) IS NULL OR video_id = ANY($4::text[]))
             ORDER BY rank DESC
             LIMIT $2
             """,
             query,
             top_k,
             allowed_source_types,
+            allowed_video_ids,
         )
     return [dict(r) for r in rows]
 
@@ -294,6 +297,7 @@ async def vector_search_pg(
     query_embedding: list[float],
     top_k: int,
     allowed_source_types: list[str] | None = None,
+    allowed_video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
@@ -326,12 +330,14 @@ async def vector_search_pg(
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
             WHERE source_type = ANY($3::text[])
+              AND ($4::text[] IS NULL OR array_length($4::text[], 1) IS NULL OR video_id = ANY($4::text[]))
             ORDER BY distance
             LIMIT $2
             """,
             embedding_json,
             top_k,
             allowed_source_types,
+            allowed_video_ids,
         )
     return [dict(r) for r in rows]
 
@@ -415,18 +421,24 @@ async def replace_chunks_for_video(
 # ---------------------------------------------------------------------------
 
 
-async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict:
+async def create_conversation(
+    *,
+    user_id: str,
+    title: str = "New Conversation",
+    video_ids: list[str] | None = None,
+) -> dict:
     conv_id = _new_id()
     now = _now()
     async with _acquire() as conn:
         await conn.execute(
             """
-            INSERT INTO conversations (id, user_id, title, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO conversations (id, user_id, title, video_ids, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
             """,
             conv_id,
             user_id,
             title,
+            video_ids,
             now,
             now,
         )
@@ -434,6 +446,7 @@ async def create_conversation(*, user_id: str, title: str = "New Conversation") 
         "id": conv_id,
         "user_id": user_id,
         "title": title,
+        "video_ids": video_ids,
         "created_at": now,
         "updated_at": now,
     }
@@ -443,7 +456,7 @@ async def get_conversation(conv_id: str, user_id: str) -> dict | None:
     """Return the conversation only if it belongs to the given user."""
     async with _acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM conversations WHERE id = $1 AND user_id = $2",
+            "SELECT id, user_id, title, video_ids, created_at, updated_at FROM conversations WHERE id = $1 AND user_id = $2",
             conv_id,
             user_id,
         )
@@ -454,7 +467,7 @@ async def list_conversations(user_id: str) -> list[dict]:
     async with _acquire() as conn:
         rows = await conn.fetch(
             """
-            SELECT c.*,
+            SELECT c.id, c.user_id, c.title, c.video_ids, c.created_at, c.updated_at,
                    (SELECT content
                     FROM messages
                     WHERE conversation_id = c.id
@@ -475,6 +488,21 @@ async def update_conversation_title(conv_id: str, user_id: str, title: str) -> b
         result = await conn.execute(
             "UPDATE conversations SET title = $1, updated_at = $2 WHERE id = $3 AND user_id = $4",
             title,
+            _now(),
+            conv_id,
+            user_id,
+        )
+        return result != "UPDATE 0"  # type: ignore[no-any-return]
+
+
+async def update_conversation_video_ids(
+    conv_id: str, user_id: str, video_ids: list[str] | None
+) -> bool:
+    """Update the video scope for a conversation. Returns False if it does not belong to the user."""
+    async with _acquire() as conn:
+        result = await conn.execute(
+            "UPDATE conversations SET video_ids = $1, updated_at = $2 WHERE id = $3 AND user_id = $4",
+            video_ids,
             _now(),
             conv_id,
             user_id,

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -40,6 +40,7 @@ async def retrieve_hybrid(
     query_embedding: list[float],
     top_k: int = 5,
     is_member: bool = False,
+    video_id_whitelist: set[str] | None = None,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -78,6 +79,7 @@ async def retrieve_hybrid(
         )
 
     allowed_source_types = ["youtube", "dynamous"] if is_member else ["youtube"]
+    allowed_video_ids = list(video_id_whitelist) if video_id_whitelist else None
 
     # Over-fetch factor — each method returns 2*top_k before merging
     fetch_k = top_k * HYBRID_OVERFETCH_FACTOR
@@ -88,11 +90,13 @@ async def retrieve_hybrid(
         top_k=fetch_k,
         language=KEYWORD_LANGUAGE,
         allowed_source_types=allowed_source_types,
+        allowed_video_ids=allowed_video_ids,
     )
     vector_task = repository.vector_search_pg(
         query_embedding,
         top_k=fetch_k,
         allowed_source_types=allowed_source_types,
+        allowed_video_ids=allowed_video_ids,
     )
 
     keyword_hits, vector_hits = await keyword_task, await vector_task

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -410,6 +410,7 @@ async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_id_whitelist: set[str] | None = None,
 ) -> dict[str, Any]:
     """Hybrid (keyword + semantic via RRF) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -425,7 +426,9 @@ async def execute_search_hybrid(
 
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
+        chunks = await retrieve_hybrid(
+            query, embedding, top_k=top_k, is_member=is_member, video_id_whitelist=video_id_whitelist
+        )
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -439,6 +442,7 @@ async def execute_search_hybrid(
 async def execute_search_keyword(
     raw_arguments: str | dict,
     is_member: bool = False,
+    video_id_whitelist: set[str] | None = None,
 ) -> dict[str, Any]:
     """Keyword-only (tsvector FTS) search."""
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
@@ -452,6 +456,7 @@ async def execute_search_keyword(
     top_k = _clamp_top_k(args.get("top_k"))
 
     allowed = ["youtube", "dynamous"] if is_member else ["youtube"]
+    allowed_video_ids = list(video_id_whitelist) if video_id_whitelist else None
 
     try:
         raw = await repository.keyword_search(
@@ -459,6 +464,7 @@ async def execute_search_keyword(
             top_k=top_k,
             language=KEYWORD_LANGUAGE,
             allowed_source_types=allowed,
+            allowed_video_ids=allowed_video_ids,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -475,6 +481,7 @@ async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_id_whitelist: set[str] | None = None,
 ) -> dict[str, Any]:
     """Semantic-only (pgvector cosine) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -488,11 +495,15 @@ async def execute_search_semantic(
     top_k = _clamp_top_k(args.get("top_k"))
 
     allowed = ["youtube", "dynamous"] if is_member else ["youtube"]
+    allowed_video_ids = list(video_id_whitelist) if video_id_whitelist else None
 
     try:
         embedding = await _embed_query(query, embedding_cache)
         raw = await repository.vector_search_pg(
-            embedding, top_k=top_k, allowed_source_types=allowed
+            embedding,
+            top_k=top_k,
+            allowed_source_types=allowed,
+            allowed_video_ids=allowed_video_ids,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -615,13 +626,21 @@ async def execute_tool(
     """
     if name == "search_videos":
         return await execute_search_hybrid(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_id_whitelist=video_id_whitelist,
         )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments, is_member=is_member)
+        return await execute_search_keyword(
+            raw_arguments, is_member=is_member, video_id_whitelist=video_id_whitelist
+        )
     if name == "semantic_search_videos":
         return await execute_search_semantic(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_id_whitelist=video_id_whitelist,
         )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -22,10 +22,6 @@ class ConversationCreate(BaseModel):
     video_ids: list[str] | None = None
 
 
-class ConversationRename(BaseModel):
-    title: str
-
-
 class ConversationUpdate(BaseModel):
     title: str | None = None
     video_ids: list[str] | None = None
@@ -107,6 +103,8 @@ async def update_conversation(
         if not updated:
             raise HTTPException(status_code=404, detail="Conversation not found")
     conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
     return conv
 
 

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -19,10 +19,16 @@ router = APIRouter()
 
 class ConversationCreate(BaseModel):
     title: str = "New Conversation"
+    video_ids: list[str] | None = None
 
 
 class ConversationRename(BaseModel):
     title: str
+
+
+class ConversationUpdate(BaseModel):
+    title: str | None = None
+    video_ids: list[str] | None = None
 
 
 @router.get("/conversations")
@@ -37,9 +43,11 @@ async def create_conversation(
 ):
     """Create a new empty conversation. Body is optional; defaults to title='New Conversation'."""
     title = body.title if body else "New Conversation"
+    video_ids = body.video_ids if body else None
     return await repository.create_conversation(
         user_id=str(current_user["id"]),
         title=title,
+        video_ids=video_ids,
     )
 
 
@@ -80,17 +88,25 @@ async def delete_conversation(
 
 
 @router.patch("/conversations/{conv_id}")
-async def rename_conversation(
+async def update_conversation(
     conv_id: str,
-    body: ConversationRename,
+    body: ConversationUpdate,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    updated = await repository.update_conversation_title(
-        conv_id, user_id=str(current_user["id"]), title=body.title
-    )
-    if not updated:
-        raise HTTPException(status_code=404, detail="Conversation not found")
-    conv = await repository.get_conversation(conv_id, user_id=str(current_user["id"]))
+    user_id = str(current_user["id"])
+    if body.title is not None:
+        updated = await repository.update_conversation_title(
+            conv_id, user_id=user_id, title=body.title
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+    if body.video_ids is not None:
+        updated = await repository.update_conversation_video_ids(
+            conv_id, user_id=user_id, video_ids=body.video_ids or None
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
     return conv
 
 

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -120,8 +120,8 @@ async def create_message(
     # tool calls — no pre-retrieval runs here. The executor closure collects
     # every chunk returned by any tool call so the final SSE `sources` event
     # lists exactly what the model actually read. The video_id whitelist is
-    # only consulted by the transcript tool (it guards against hallucinated
-    # ids); the search tools ignore it.
+    # consulted by both the transcript tool (guards against hallucinated ids)
+    # and the search tools (scopes retrieval to the conversation's videos).
     source_citations: list[dict] = []
     tool_chunks_acc: list[dict] = []
     embedding_cache: dict[str, list[float]] = {}
@@ -129,9 +129,18 @@ async def create_message(
     executor = None
     max_tool_calls = 0
     if LLM_TOOLS_ENABLED:
+        # Build the video_id whitelist: if the conversation has a scoped set of
+        # video_ids, restrict all tools to those ids. Otherwise fall back to
+        # the full library so the transcript tool can still guard against
+        # hallucinations.
+        conv_video_ids = conv.get("video_ids")
+        scoped_video_ids: list[str] | None = conv_video_ids if conv_video_ids else None
         try:
-            all_videos = await repository.list_videos()
-            video_id_whitelist: set[str] = {v["id"] for v in all_videos if v.get("id")}
+            if scoped_video_ids:
+                video_id_whitelist: set[str] = set(scoped_video_ids)
+            else:
+                all_videos = await repository.list_videos()
+                video_id_whitelist = {v["id"] for v in all_videos if v.get("id")}
         except Exception as exc:
             logger.warning(
                 "Failed to load video whitelist for tool use; transcript tool calls will be unguarded: %s",

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -152,10 +152,10 @@ class TestRetrieveHybrid:
 
             # Verify correct arguments passed (over-fetch factor applied)
             mock_kw.assert_called_once_with(
-                "test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"]
+                "test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"], allowed_video_ids=None
             )
             mock_vec.assert_called_once_with(
-                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"]
+                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"], allowed_video_ids=None
             )
 
             # Verify result shape has all required citation fields

--- a/app/backend/tests/test_tools.py
+++ b/app/backend/tests/test_tools.py
@@ -96,7 +96,7 @@ _FAKE_CHUNKS = [
 
 @pytest.mark.asyncio
 async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
-    async def fake_retrieve(_q, _emb, top_k=5, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_id_whitelist=None):
         assert top_k == 10
         return _FAKE_CHUNKS
 
@@ -112,7 +112,7 @@ async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None):
         return [
             {
                 "id": "c1",
@@ -140,7 +140,7 @@ async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, allowed_video_ids=None):
         return [
             {
                 "id": "c2",
@@ -169,7 +169,7 @@ async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None):
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -257,7 +257,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
         for i in range(6)
     ]
 
-    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, video_id_whitelist=None):
         return many_chunks
 
     monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
@@ -273,7 +273,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
 async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_keyword."""
 
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None):
         return [
             {
                 "id": f"c{i}",
@@ -303,7 +303,7 @@ async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> Non
 async def test_execute_search_semantic_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_semantic."""
 
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, allowed_video_ids=None):
         return [
             {
                 "id": f"c{i}",

--- a/app/backend/tests/test_video_scope.py
+++ b/app/backend/tests/test_video_scope.py
@@ -1,0 +1,253 @@
+"""Tests for conversation-level video scoping (issue #279).
+
+Verifies that:
+- create_conversation accepts video_ids
+- keyword_search and vector_search_pg filter by allowed_video_ids
+- retrieve_hybrid threads video_id_whitelist to both searches
+- Tool executors respect video_id_whitelist
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.db import repository
+from backend.rag import tools as tools_module
+from backend.rag.retriever_hybrid import retrieve_hybrid
+from backend.rag.tools import (
+    execute_search_hybrid,
+    execute_search_keyword,
+    execute_search_semantic,
+    execute_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Repository-level filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keyword_search_filters_by_allowed_video_ids():
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(repository, "_acquire", return_value=mock_acquire):
+        await repository.keyword_search(
+            "hello", top_k=5, allowed_video_ids=["v1", "v2"]
+        )
+
+    call_args = mock_conn.fetch.call_args[0]
+    sql = call_args[0]
+    assert "video_id = ANY($4::text[])" in sql
+    assert call_args[4] == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_vector_search_pg_filters_by_allowed_video_ids():
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(repository, "_acquire", return_value=mock_acquire):
+        await repository.vector_search_pg(
+            [0.1] * 1536, top_k=5, allowed_video_ids=["v1"]
+        )
+
+    call_args = mock_conn.fetch.call_args[0]
+    sql = call_args[0]
+    assert "video_id = ANY($4::text[])" in sql
+    assert call_args[4] == ["v1"]
+
+
+@pytest.mark.asyncio
+async def test_keyword_search_allows_null_allowed_video_ids():
+    """When allowed_video_ids is None, no video filter is applied."""
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(repository, "_acquire", return_value=mock_acquire):
+        await repository.keyword_search("hello", top_k=5, allowed_video_ids=None)
+
+    call_args = mock_conn.fetch.call_args[0]
+    assert call_args[4] is None
+
+
+@pytest.mark.asyncio
+async def test_vector_search_pg_allows_null_allowed_video_ids():
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(repository, "_acquire", return_value=mock_acquire):
+        await repository.vector_search_pg([0.1] * 1536, top_k=5, allowed_video_ids=None)
+
+    call_args = mock_conn.fetch.call_args[0]
+    assert call_args[4] is None
+
+
+# ---------------------------------------------------------------------------
+# create_conversation with video_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_with_video_ids():
+    mock_conn = AsyncMock()
+    mock_conn.execute = AsyncMock(return_value="INSERT 0 1")
+
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(repository, "_acquire", return_value=mock_acquire):
+        result = await repository.create_conversation(
+            user_id="u1", title="Scoped Chat", video_ids=["v1", "v2"]
+        )
+
+    assert result["video_ids"] == ["v1", "v2"]
+    call_args = mock_conn.execute.call_args[0]
+    assert "video_ids" in call_args[0]
+    assert call_args[4] == ["v1", "v2"]
+
+
+# ---------------------------------------------------------------------------
+# Tool-level filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_search_hybrid_respects_video_id_whitelist(monkeypatch):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_id_whitelist=None):
+        assert video_id_whitelist == {"v1"}
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    result = await execute_search_hybrid(
+        {"query": "rag"}, video_id_whitelist={"v1"}
+    )
+    assert result["ok"] is True
+    assert "No relevant chunks found" in result["text"]
+
+
+@pytest.mark.asyncio
+async def test_execute_search_keyword_respects_video_id_whitelist(monkeypatch):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None):
+        assert allowed_video_ids == ["v1", "v2"]
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
+
+    result = await execute_search_keyword(
+        {"query": "test"}, video_id_whitelist={"v1", "v2"}
+    )
+    assert result["ok"] is True
+    assert "No relevant chunks found" in result["text"]
+
+
+@pytest.mark.asyncio
+async def test_execute_search_semantic_respects_video_id_whitelist(monkeypatch):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, allowed_video_ids=None):
+        assert allowed_video_ids == ["v1"]
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "vector_search_pg", fake_vector)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    result = await execute_search_semantic(
+        {"query": "concept"}, video_id_whitelist={"v1"}
+    )
+    assert result["ok"] is True
+    assert "No relevant chunks found" in result["text"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_threads_video_id_whitelist_to_all_searches(monkeypatch):
+    calls = []
+
+    async def fake_hybrid(raw, embedding_cache=None, is_member=False, video_id_whitelist=None):
+        calls.append(("hybrid", video_id_whitelist))
+        return {"ok": True, "text": "hybrid result", "chunks": []}
+
+    async def fake_keyword(raw, is_member=False, video_id_whitelist=None):
+        calls.append(("keyword", video_id_whitelist))
+        return {"ok": True, "text": "keyword result", "chunks": []}
+
+    async def fake_semantic(raw, embedding_cache=None, is_member=False, video_id_whitelist=None):
+        calls.append(("semantic", video_id_whitelist))
+        return {"ok": True, "text": "semantic result", "chunks": []}
+
+    async def fake_transcript(raw, video_id_whitelist=None, is_member=False):
+        calls.append(("transcript", video_id_whitelist))
+        return {"ok": True, "text": "transcript result", "chunks": []}
+
+    monkeypatch.setattr(tools_module, "execute_search_hybrid", fake_hybrid)
+    monkeypatch.setattr(tools_module, "execute_search_keyword", fake_keyword)
+    monkeypatch.setattr(tools_module, "execute_search_semantic", fake_semantic)
+    monkeypatch.setattr(tools_module, "execute_get_video_transcript", fake_transcript)
+
+    whitelist = {"v1", "v2"}
+    await execute_tool("search_videos", {"query": "x"}, video_id_whitelist=whitelist)
+    await execute_tool("keyword_search_videos", {"query": "x"}, video_id_whitelist=whitelist)
+    await execute_tool("semantic_search_videos", {"query": "x"}, video_id_whitelist=whitelist)
+    await execute_tool("get_video_transcript", {"video_id": "v1"}, video_id_whitelist=whitelist)
+
+    assert calls == [
+        ("hybrid", whitelist),
+        ("keyword", whitelist),
+        ("semantic", whitelist),
+        ("transcript", whitelist),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# retrieve_hybrid threads video_id_whitelist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retrieve_hybrid_threads_video_id_whitelist(monkeypatch):
+    keyword_spy = []
+    vector_spy = []
+
+    async def fake_keyword(*args, **kwargs):
+        keyword_spy.append(kwargs)
+        return []
+
+    async def fake_vector(*args, **kwargs):
+        vector_spy.append(kwargs)
+        return []
+
+    from backend.db import repository as repo
+
+    monkeypatch.setattr(repo, "keyword_search", fake_keyword)
+    monkeypatch.setattr(repo, "vector_search_pg", fake_vector)
+
+    await retrieve_hybrid(
+        "query",
+        [0.1] * 1536,
+        top_k=5,
+        video_id_whitelist={"v1", "v2"},
+    )
+
+    assert keyword_spy[0]["allowed_video_ids"] == ["v1", "v2"]
+    assert vector_spy[0]["allowed_video_ids"] == ["v1", "v2"]

--- a/app/backend/tests/test_video_scope.py
+++ b/app/backend/tests/test_video_scope.py
@@ -152,7 +152,7 @@ async def test_execute_search_hybrid_respects_video_id_whitelist(monkeypatch):
 @pytest.mark.asyncio
 async def test_execute_search_keyword_respects_video_id_whitelist(monkeypatch):
     async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, allowed_video_ids=None):
-        assert allowed_video_ids == ["v1", "v2"]
+        assert sorted(allowed_video_ids) == ["v1", "v2"]
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -249,5 +249,5 @@ async def test_retrieve_hybrid_threads_video_id_whitelist(monkeypatch):
         video_id_whitelist={"v1", "v2"},
     )
 
-    assert keyword_spy[0]["allowed_video_ids"] == ["v1", "v2"]
-    assert vector_spy[0]["allowed_video_ids"] == ["v1", "v2"]
+    assert sorted(keyword_spy[0]["allowed_video_ids"]) == ["v1", "v2"]
+    assert sorted(vector_spy[0]["allowed_video_ids"]) == ["v1", "v2"]

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import { type Conversation, createConversation, deleteConversation, getVideos, type Video } from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
 
 // ── Relative time helper ─────────────────────────────────────────
@@ -170,16 +170,35 @@ function ConvItem({
         </div>
       )}
 
-      {/* Timestamp */}
+      {/* Timestamp + scope indicator */}
       <div
         style={{
           fontSize: 12,
           color: '#94a3b8',
           marginTop: 2,
           marginBottom: preview ? 3 : 0,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
         }}
       >
         {formatRelativeTime(conv.updated_at)}
+        {conv.video_ids && conv.video_ids.length > 0 && (
+          <span
+            title={`Scoped to ${conv.video_ids.length} video${conv.video_ids.length === 1 ? '' : 's'}`}
+            style={{
+              fontSize: 10,
+              color: '#3b82f6',
+              background: 'rgba(59,130,246,0.12)',
+              borderRadius: 4,
+              padding: '1px 5px',
+              fontWeight: 600,
+              letterSpacing: 0.3,
+            }}
+          >
+            {conv.video_ids.length} video{conv.video_ids.length === 1 ? '' : 's'}
+          </span>
+        )}
       </div>
 
       {/* Preview */}
@@ -423,6 +442,11 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const [deleteError, setDeleteError] = useState(false);
   const [explorerOpen, setExplorerOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
+  const [scopePickerOpen, setScopePickerOpen] = useState(false);
+  const [scopeVideos, setScopeVideos] = useState<Video[]>([]);
+  const [scopeLoading, setScopeLoading] = useState(false);
+  const [scopeQuery, setScopeQuery] = useState('');
+  const [selectedScopeIds, setSelectedScopeIds] = useState<Set<string>>(new Set());
   const { addToast } = useToast();
 
   // Debounce search query — 250ms per issue #92
@@ -449,10 +473,30 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
         return;
       }
     }
-    setCreatingNew(true);
+    // Open scope picker; load videos if not already loaded
+    setScopePickerOpen(true);
     setNewChatError(null);
+    if (scopeVideos.length === 0 && !scopeLoading) {
+      setScopeLoading(true);
+      try {
+        const data = await getVideos();
+        setScopeVideos(data);
+      } catch {
+        // ignore — picker will show empty state
+      } finally {
+        setScopeLoading(false);
+      }
+    }
+  };
+
+  const handleCreateScopedChat = async () => {
+    const videoIds = selectedScopeIds.size > 0 ? Array.from(selectedScopeIds) : null;
+    setCreatingNew(true);
+    setScopePickerOpen(false);
     try {
-      const conv = await createConversation();
+      const conv = await createConversation(videoIds);
+      setSelectedScopeIds(new Set());
+      setScopeQuery('');
       await refetch();
       navigate(`/c/${conv.id}`);
       onClose();
@@ -462,6 +506,25 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
       setCreatingNew(false);
     }
   };
+
+  const toggleScopeVideo = (id: string) => {
+    setSelectedScopeIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const filteredScopeVideos = scopeQuery.trim()
+    ? scopeVideos.filter((v) =>
+        [v.title, v.channel_title, v.description]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+          .includes(scopeQuery.trim().toLowerCase()),
+      )
+    : scopeVideos;
 
   // ── Delete flow ──
   const handleDeleteRequest = (id: string) => {
@@ -850,6 +913,152 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           deleting={deleting}
           error={deleteError}
         />
+      )}
+
+      {/* ── Video Scope Picker dialog ── */}
+      {scopePickerOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.6)',
+            zIndex: 50,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            style={{
+              background: '#1e293b',
+              border: '1px solid rgba(255,255,255,0.1)',
+              borderRadius: 12,
+              padding: 24,
+              width: 420,
+              maxWidth: 'calc(100vw - 48px)',
+              maxHeight: '80vh',
+              display: 'flex',
+              flexDirection: 'column',
+              boxShadow: '0 25px 50px -12px rgba(0,0,0,0.5)',
+            }}
+          >
+            <p style={{ margin: '0 0 4px', fontWeight: 600, color: '#f1f5f9' }}>New Chat</p>
+            <p style={{ margin: '0 0 16px', fontSize: 13, color: '#94a3b8' }}>
+              Choose videos to scope this conversation to, or leave all unchecked to search the
+              full library.
+            </p>
+            <input
+              type="search"
+              placeholder="Search videos…"
+              value={scopeQuery}
+              onChange={(e) => setScopeQuery(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                borderRadius: 8,
+                background: '#0f172a',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 13,
+                outline: 'none',
+                marginBottom: 12,
+              }}
+            />
+            <div style={{ flex: 1, overflowY: 'auto', marginBottom: 16 }}>
+              {scopeLoading ? (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <div className="skeleton" style={{ height: 32, width: '100%' }} />
+                  <div className="skeleton" style={{ height: 32, width: '100%' }} />
+                  <div className="skeleton" style={{ height: 32, width: '100%' }} />
+                </div>
+              ) : filteredScopeVideos.length === 0 ? (
+                <p style={{ margin: 0, fontSize: 13, color: '#475569', textAlign: 'center' }}>
+                  No videos found
+                </p>
+              ) : (
+                filteredScopeVideos.map((v) => (
+                  <label
+                    key={v.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '8px 4px',
+                      cursor: 'pointer',
+                      borderRadius: 6,
+                      transition: 'background 0.15s',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.background = 'rgba(255,255,255,0.04)')
+                    }
+                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedScopeIds.has(v.id)}
+                      onChange={() => toggleScopeVideo(v.id)}
+                      style={{ cursor: 'pointer' }}
+                    />
+                    <span
+                      style={{
+                        fontSize: 13,
+                        color: '#f1f5f9',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                      title={v.title}
+                    >
+                      {v.title}
+                    </span>
+                  </label>
+                ))
+              )}
+            </div>
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => {
+                  setScopePickerOpen(false);
+                  setSelectedScopeIds(new Set());
+                  setScopeQuery('');
+                }}
+                className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                style={{
+                  background: 'transparent',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  borderRadius: 8,
+                  color: '#94a3b8',
+                  cursor: 'pointer',
+                  padding: '8px 16px',
+                  fontSize: 14,
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreateScopedChat}
+                disabled={creatingNew}
+                className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                style={{
+                  background: '#3b82f6',
+                  border: 'none',
+                  borderRadius: 8,
+                  color: '#fff',
+                  cursor: creatingNew ? 'not-allowed' : 'pointer',
+                  padding: '8px 16px',
+                  fontSize: 14,
+                  opacity: creatingNew ? 0.7 : 1,
+                }}
+              >
+                {creatingNew
+                  ? 'Creating…'
+                  : selectedScopeIds.size > 0
+                    ? `Create scoped chat (${selectedScopeIds.size})`
+                    : 'Create chat'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* ── Video Explorer panel ── */}

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,7 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  video_ids?: string[] | null;
 }
 
 export interface Citation {
@@ -146,8 +147,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const getConversations = () => request<Conversation[]>('/conversations');
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
-export const createConversation = () =>
-  request<Conversation>('/conversations', { method: 'POST', body: '{}' });
+export const createConversation = (video_ids?: string[] | null) =>
+  request<Conversation>('/conversations', {
+    method: 'POST',
+    body: JSON.stringify({ video_ids: video_ids ?? undefined }),
+  });
 export const getConversation = (id: string) =>
   request<ConversationWithMessages>(`/conversations/${id}`);
 export const deleteConversation = (id: string) =>


### PR DESCRIPTION
Fixes #279

**Benchmark cell:** `XK` (plan=NONE, impl=Kimi)
**Source run-id:** `bd10cb3a-a2bb-4a97-abf2-0c6170a1e1e9`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.