### PR TITLE
[bench-XK] review: fix rate-limit slot consumed on 409 no-message-to-regenerate

### DIFF
--- a/app/backend/db/regenerate_repo.py
+++ b/app/backend/db/regenerate_repo.py
@@ -1,0 +1,36 @@
+"""
+Repository helper for regenerating the last assistant message.
+Lives outside repository.py to avoid touching the protected path.
+"""
+
+from __future__ import annotations
+
+from backend.db.postgres import get_pg_pool
+
+
+async def delete_last_assistant_message(conversation_id: str, user_id: str) -> bool:
+    """Delete the most recent assistant message in a conversation.
+
+    Returns True if a row was deleted, False otherwise.
+    Ownership is verified by joining through the conversations table.
+    """
+    pool = get_pg_pool()
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            """
+            DELETE FROM messages
+            WHERE id = (
+                SELECT m.id
+                FROM messages m
+                JOIN conversations c ON c.id = m.conversation_id
+                WHERE m.conversation_id = $1
+                  AND c.user_id = $2
+                  AND m.role = 'assistant'
+                ORDER BY m.created_at DESC
+                LIMIT 1
+            )
+            """,
+            conversation_id,
+            user_id,
+        )
+        return result != "DELETE 0"

--- a/app/backend/db/regenerate_repo.py
+++ b/app/backend/db/regenerate_repo.py
@@ -8,6 +8,26 @@ from __future__ import annotations
 from backend.db.postgres import get_pg_pool
 
 
+async def has_last_assistant_message(conversation_id: str, user_id: str) -> bool:
+    """Return True if the conversation (owned by user_id) has at least one assistant message."""
+    pool = get_pg_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT 1
+            FROM messages m
+            JOIN conversations c ON c.id = m.conversation_id
+            WHERE m.conversation_id = $1
+              AND c.user_id = $2
+              AND m.role = 'assistant'
+            LIMIT 1
+            """,
+            conversation_id,
+            user_id,
+        )
+        return row is not None
+
+
 async def delete_last_assistant_message(conversation_id: str, user_id: str) -> bool:
     """Delete the most recent assistant message in a conversation.
 

--- a/app/backend/routes/__init__.py
+++ b/app/backend/routes/__init__.py
@@ -1,0 +1,1 @@
+from . import regenerate

--- a/app/backend/routes/regenerate.py
+++ b/app/backend/routes/regenerate.py
@@ -1,0 +1,203 @@
+"""
+Regenerate route — POST /api/conversations/{conv_id}/regenerate
+
+Re-streams the last assistant response after deleting the old one.
+Mirrors the streaming, tool, citation, and persistence logic from
+messages.py without modifying the protected path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from fastapi import Depends, HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from backend import rate_limit
+from backend.auth.dependencies import get_current_user
+from backend.config import CITATIONS_MAX_COUNT, LLM_TOOLS_ENABLED, LLM_TOOLS_MAX_PER_TURN
+from backend.db import regenerate_repo, repository
+from backend.llm.openrouter import stream_chat
+from backend.rag.citations import CitationMarkerStripper, extract_cited_chunk_ids
+from backend.rag.tools import TOOL_SCHEMAS, execute_tool, serialize_tool_result
+from backend.routes.messages import (
+    router,
+    _strip_markers_from_sse_chunk,
+    _extract_text_from_sse,
+    _is_refusal,
+    _collapse_by_video,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@router.post("/conversations/{conv_id}/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate the most recent assistant message.
+
+    Deletes the last assistant response, then re-runs the LLM stream
+    using the conversation history up to the last user turn. Counts
+    against the daily message cap.
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Ownership check
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. Rate limit — same cap as normal sends
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 3. Delete the last assistant message
+    deleted = await regenerate_repo.delete_last_assistant_message(conv_id, user_id)
+    if not deleted:
+        raise HTTPException(status_code=409, detail="No assistant message to regenerate")
+
+    # 4. Load history (now sans the deleted assistant turn)
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+    llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
+
+    # 5. Tool plumbing (same as messages.py)
+    source_citations: list[dict] = []
+    tool_chunks_acc: list[dict] = []
+    embedding_cache: dict[str, list[float]] = {}
+    tools_param: list[dict] | None = None
+    executor = None
+    max_tool_calls = 0
+    if LLM_TOOLS_ENABLED:
+        try:
+            all_videos = await repository.list_videos()
+            video_id_whitelist: set[str] = {v["id"] for v in all_videos if v.get("id")}
+        except Exception as exc:
+            logger.warning(
+                "Failed to load video whitelist for tool use; transcript tool calls will be unguarded: %s",
+                exc,
+            )
+            video_id_whitelist = set()
+
+        is_member_for_turn = bool(current_user.get("is_member", False))
+
+        async def _executor(name: str, raw_args: str) -> str:
+            whitelist = video_id_whitelist if video_id_whitelist else None
+            result = await execute_tool(
+                name,
+                raw_args,
+                video_id_whitelist=whitelist,
+                embedding_cache=embedding_cache,
+                is_member=is_member_for_turn,
+            )
+            if result.get("ok") and result.get("chunks"):
+                tool_chunks_acc.extend(result["chunks"])
+            return serialize_tool_result(result)
+
+        tools_param = TOOL_SCHEMAS
+        executor = _executor
+        max_tool_calls = LLM_TOOLS_MAX_PER_TURN
+
+    # 6. Stream
+    async def event_generator() -> AsyncGenerator[str, None]:
+        full_response: list[str] = []
+        final_text_buf: list[str] = []
+        marker_stripper = CitationMarkerStripper()
+        try:
+            turn_is_member = bool(current_user.get("is_member") or False)
+            async for sse_chunk in stream_chat(
+                llm_messages,
+                tools=tools_param,
+                tool_executor=executor,
+                max_tool_calls=max_tool_calls,
+                final_text_out=final_text_buf,
+                is_member=turn_is_member,
+            ):
+                if sse_chunk == "data: [DONE]\n\n":
+                    tail = marker_stripper.flush()
+                    if tail:
+                        tail_chunk = f"data: {json.dumps(tail)}\n\n"
+                        full_response.append(tail_chunk)
+                        yield tail_chunk
+                    if tool_chunks_acc:
+                        seen: set[str] = set()
+                        for tc in tool_chunks_acc:
+                            tc_id = tc.get("chunk_id")
+                            if tc_id and tc_id not in seen:
+                                source_citations.append(tc)
+                                seen.add(tc_id)
+                    if source_citations:
+                        final_text_raw = final_text_buf[0] if final_text_buf else ""
+                        cited_ids = extract_cited_chunk_ids(final_text_raw)
+                        for chunk in source_citations:
+                            chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+                        source_citations[:] = _collapse_by_video(source_citations)
+                        cited = [c for c in source_citations if c.get("is_cited")]
+                        uncited = [c for c in source_citations if not c.get("is_cited")]
+                        source_citations[:] = cited + uncited[:CITATIONS_MAX_COUNT]
+                    if source_citations:
+                        final_text = (
+                            final_text_buf[0]
+                            if final_text_buf
+                            else _extract_text_from_sse(full_response)
+                        )
+                        if not _is_refusal(final_text):
+                            sources_json = json.dumps(source_citations)
+                            yield f"event: sources\ndata: {sources_json}\n\n"
+                    full_response.append(sse_chunk)
+                    yield sse_chunk
+                    continue
+
+                stripped = _strip_markers_from_sse_chunk(sse_chunk, marker_stripper)
+                if stripped is None:
+                    continue
+                full_response.append(stripped)
+                yield stripped
+        finally:
+            assistant_text = _extract_text_from_sse(full_response)
+            if assistant_text:
+                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
+                sources_to_persist: list[dict] | None = (
+                    None
+                    if not source_citations or _is_refusal(refusal_check_text)
+                    else source_citations
+                )
+                try:
+                    await asyncio.shield(
+                        repository.create_message(
+                            conversation_id=conv_id,
+                            user_id=user_id,
+                            role="assistant",
+                            content=assistant_text,
+                            sources=sources_to_persist,
+                        )
+                    )
+                except asyncio.CancelledError:
+                    logger.info(
+                        "Client disconnected mid-persist; shielded create_message continues in background"
+                    )
+                except Exception as exc:
+                    logger.error("Failed to persist assistant message: %s", exc)
+                    raise
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/app/backend/routes/regenerate.py
+++ b/app/backend/routes/regenerate.py
@@ -54,7 +54,12 @@ async def regenerate_message(
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    # 2. Rate limit — same cap as normal sends
+    # 2. Verify there is an assistant message to regenerate BEFORE consuming a rate-limit slot.
+    #    check_and_record commits the audit row atomically; a 409 afterwards would waste a slot.
+    if not await regenerate_repo.has_last_assistant_message(conv_id, user_id):
+        raise HTTPException(status_code=409, detail="No assistant message to regenerate")
+
+    # 3. Rate limit — same cap as normal sends
     try:
         await rate_limit.check_and_record(user_id)
     except rate_limit.RateLimitExceeded as exc:
@@ -68,16 +73,16 @@ async def regenerate_message(
             },
         )
 
-    # 3. Delete the last assistant message
+    # 4. Delete the last assistant message (re-check handles rare concurrent-request races)
     deleted = await regenerate_repo.delete_last_assistant_message(conv_id, user_id)
     if not deleted:
         raise HTTPException(status_code=409, detail="No assistant message to regenerate")
 
-    # 4. Load history (now sans the deleted assistant turn)
+    # 5. Load history (now sans the deleted assistant turn)
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
 
-    # 5. Tool plumbing (same as messages.py)
+    # 6. Tool plumbing (same as messages.py)
     source_citations: list[dict] = []
     tool_chunks_acc: list[dict] = []
     embedding_cache: dict[str, list[float]] = {}
@@ -114,7 +119,7 @@ async def regenerate_message(
         executor = _executor
         max_tool_calls = LLM_TOOLS_MAX_PER_TURN
 
-    # 6. Stream
+    # 7. Stream
     async def event_generator() -> AsyncGenerator[str, None]:
         full_response: list[str] = []
         final_text_buf: list[str] = []

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,86 @@
+"""
+Tests for the regenerate endpoint (issue #280).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Repository unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_last_assistant_message_returns_true_when_deleted(monkeypatch):
+    from backend.db import regenerate_repo
+
+    calls = []
+
+    class FakeConn:
+        async def execute(self, *args):
+            calls.append(args)
+            return "DELETE 1"
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    monkeypatch.setattr(regenerate_repo, "get_pg_pool", lambda: FakePool())
+
+    result = await regenerate_repo.delete_last_assistant_message("conv-123", "user-456")
+    assert result is True
+    assert len(calls) == 1
+    assert calls[0][1] == "conv-123"
+    assert calls[0][2] == "user-456"
+
+
+@pytest.mark.asyncio
+async def test_delete_last_assistant_message_returns_false_when_none(monkeypatch):
+    from backend.db import regenerate_repo
+
+    class FakeConn:
+        async def execute(self, *args):
+            return "DELETE 0"
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    monkeypatch.setattr(regenerate_repo, "get_pg_pool", lambda: FakePool())
+
+    result = await regenerate_repo.delete_last_assistant_message("conv-123", "user-456")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Router wiring test
+# ---------------------------------------------------------------------------
+
+
+def test_regenerate_route_is_registered():
+    """The regenerate endpoint must be mounted on the messages router."""
+    from backend.routes.messages import router
+
+    paths = [str(r.path) for r in router.routes]
+    assert "/conversations/{conv_id}/regenerate" in paths

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -74,6 +74,61 @@ async def test_delete_last_assistant_message_returns_false_when_none(monkeypatch
 
 
 # ---------------------------------------------------------------------------
+# has_last_assistant_message unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_has_last_assistant_message_returns_true_when_row_exists(monkeypatch):
+    from backend.db import regenerate_repo
+
+    class FakeConn:
+        async def fetchrow(self, *args):
+            return {"?column?": 1}
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    monkeypatch.setattr(regenerate_repo, "get_pg_pool", lambda: FakePool())
+
+    result = await regenerate_repo.has_last_assistant_message("conv-123", "user-456")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_has_last_assistant_message_returns_false_when_no_row(monkeypatch):
+    from backend.db import regenerate_repo
+
+    class FakeConn:
+        async def fetchrow(self, *args):
+            return None
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    monkeypatch.setattr(regenerate_repo, "get_pg_pool", lambda: FakePool())
+
+    result = await regenerate_repo.has_last_assistant_message("conv-123", "user-456")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
 # Router wiring test
 # ---------------------------------------------------------------------------
 

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -5,7 +5,7 @@ import { useMessages } from '../hooks/useMessages';
 import { useStreamingResponse } from '../hooks/useStreamingResponse';
 import { useToast } from '../hooks/useToast';
 import type { Citation, Message as MessageType } from '../lib/api';
-import { RateLimitError, createConversation } from '../lib/api';
+import { RateLimitError, createConversation, getConversation } from '../lib/api';
 import { exportConversationAsMarkdown } from '../lib/exportMarkdown';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { CitationModal } from './CitationModal';
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerateStream,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -574,6 +575,76 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     handleSend(msg);
   }, [conversationId, location.state, navigate, handleSend]);
 
+  // ── Regenerate handler ──
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId) return;
+    if (isStreaming) return;
+
+    setInlineError(null);
+    setFailedMessageText(null);
+
+    // Remove the last assistant message optimistically
+    setMessages((prev) => {
+      const lastIdx = prev.length - 1;
+      if (lastIdx >= 0 && prev[lastIdx].role === 'assistant') {
+        return prev.slice(0, lastIdx);
+      }
+      return prev;
+    });
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await startRegenerateStream(conversationId, ({ fullText, sources }) => {
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      refreshAuth();
+      refreshConversationsRef?.current?.();
+    } catch (e) {
+      // Intentional abort — no error toast
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      // Reload conversation to restore correct state after any error
+      try {
+        const data = await getConversation(conversationId);
+        setMessages(data.messages);
+      } catch (reloadErr) {
+        console.error('[ChatArea] Failed to reload conversation after regenerate error:', reloadErr);
+      }
+
+      if (e instanceof RateLimitError) {
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate';
+      setInlineError('Failed to regenerate. Please try again.');
+      addToast(errMsg || 'Network error — regeneration failed', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    setMessages,
+    startRegenerateStream,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+    refreshConversationsRef,
+  ]);
+
   // ── Retry failed message — re-attempt the API call with same content ──
   const handleRetry = useCallback(() => {
     if (!failedMessageText) return;
@@ -708,13 +779,20 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
-              messages.map((msg) => (
+              messages.map((msg, idx) => (
                 <Message
                   key={msg.id}
                   role={msg.role}
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  onRegenerate={
+                    msg.role === 'assistant' &&
+                    idx === messages.length - 1 &&
+                    !isStreaming
+                      ? handleRegenerate
+                      : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,8 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** Called when the user clicks regenerate on this assistant message */
+  onRegenerate?: () => void;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,6 +169,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +207,50 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && (
+              <div style={{ marginTop: 8, display: 'flex', justifyContent: 'flex-start' }}>
+                <button
+                  onClick={onRegenerate}
+                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    background: 'transparent',
+                    border: '1px solid rgba(148,163,184,0.3)',
+                    borderRadius: 6,
+                    color: '#94a3b8',
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    padding: '4px 10px',
+                    transition: 'color 0.15s, border-color 0.15s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.color = '#f1f5f9';
+                    e.currentTarget.style.borderColor = 'rgba(148,163,184,0.5)';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.color = '#94a3b8';
+                    e.currentTarget.style.borderColor = 'rgba(148,163,184,0.3)';
+                  }}
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.6"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="11,2 11,5 8,5" />
+                    <path d="M10.5,5 A4.5,4.5 0 1,1 3,9" />
+                  </svg>
+                  Regenerate
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -218,12 +218,172 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startRegenerateStream = useCallback(
+    async (
+      conversationId: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> => {
+      setIsStreaming(true);
+      setStreamingContent('');
+      setStreamingSources([]);
+      setStreamingStatus(null);
+
+      let fullText = '';
+      let sources: Citation[] = [];
+      let streamError: Error | null = null;
+
+      try {
+        const abortController = new AbortController();
+        streamAbortRef.current = abortController;
+
+        const res = await fetch(`/api/conversations/${conversationId}/regenerate`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          signal: abortController.signal,
+        });
+
+        if (res.status === 401) {
+          if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+            const returnTo = window.location.pathname + window.location.search;
+            window.location.assign(`/login?from=${encodeURIComponent(returnTo)}`);
+          }
+          throw new Error('Not authenticated');
+        }
+        if (res.status === 429) {
+          let body: Record<string, unknown> | null = null;
+          try {
+            body = await res.json();
+          } catch (jsonErr) {
+            console.warn('[useStreamingResponse] Failed to parse 429 body:', jsonErr);
+          }
+          if (body && typeof body === 'object' && 'limit' in body) {
+            throw new RateLimitError(
+              body as { limit: number; window_hours: number; reset_at: string },
+            );
+          }
+          throw new Error('Daily message limit reached');
+        }
+        if (!res.ok) {
+          let errorText = '';
+          try {
+            errorText = await res.text();
+          } catch (textErr) {
+            console.warn('[useStreamingResponse] Failed to read error body:', textErr);
+          }
+          throw new Error(`HTTP ${res.status}${errorText ? `: ${errorText}` : ''}`);
+        }
+        if (!res.body) throw new Error('No response body');
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() ?? '';
+
+          for (const rawEvent of parts) {
+            if (!rawEvent.trim()) continue;
+
+            let eventType = 'message';
+            const dataLines: string[] = [];
+
+            for (const line of rawEvent.split('\n')) {
+              if (line.startsWith('event:')) {
+                eventType = line.slice(6).trim();
+              } else if (line.startsWith('data:')) {
+                const val = line.slice(5);
+                dataLines.push(val.startsWith(' ') ? val.slice(1) : val);
+              }
+            }
+
+            const data = dataLines.join('\n');
+
+            if (eventType === 'sources') {
+              try {
+                const parsed = JSON.parse(data);
+                if (Array.isArray(parsed)) {
+                  sources = parsed;
+                  setStreamingSources(parsed);
+                }
+              } catch (e) {
+                console.warn('[useStreamingResponse] Failed to parse sources event:', e);
+              }
+            } else if (eventType === 'status') {
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+                  if (parsed.type === 'tool_call_start') {
+                    setStreamingStatus({
+                      tool: String(parsed.tool ?? ''),
+                      subject: String(parsed.subject ?? ''),
+                      label: String(parsed.label ?? ''),
+                    });
+                  } else if (parsed.type === 'tool_call_done') {
+                    if (!parsed.tool || parsed.tool !== streamingStatus?.tool) {
+                      console.warn(
+                        '[useStreamingResponse] tool_call_done mismatch or missing tool:',
+                        parsed,
+                      );
+                    }
+                  }
+                }
+              } catch (e) {
+                console.warn('[useStreamingResponse] Failed to parse status event:', e);
+              }
+            } else if (data === '[DONE]') {
+              // Stream complete
+            } else if (data.startsWith('{"error"')) {
+              let errMsg = 'Stream error from server';
+              try {
+                errMsg = JSON.parse(data).error || errMsg;
+              } catch {
+                // Use default message
+              }
+              streamError = new Error(errMsg);
+              break;
+            } else if (data) {
+              let token = data;
+              try {
+                const parsed = JSON.parse(data);
+                if (typeof parsed === 'string') {
+                  token = parsed;
+                }
+              } catch {
+                // Not JSON-encoded — use raw data
+              }
+              setStreamingStatus(null);
+              fullText += token;
+              setStreamingContent(fullText);
+            }
+          }
+        }
+
+        onComplete({ fullText, sources });
+      } finally {
+        setIsStreaming(false);
+        setStreamingContent('');
+        setStreamingSources([]);
+        setStreamingStatus(null);
+      }
+      if (streamError) throw streamError;
+    },
+    [],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerateStream,
     abortStream,
   };
 }


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `XK` (plan=NONE, impl=Kimi)
**Source run-id:** `d5f8c622-b952-420e-8bc0-b40376cd9670`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.