### PR TITLE
[bench-XO] feat: filter conversation history by date range and video

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -35,6 +35,22 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
+def _parse_dt(value: datetime | str) -> datetime:
+    """Coerce an ISO-8601 string (or passthrough datetime) to an aware datetime.
+
+    asyncpg binds TIMESTAMPTZ parameters as datetime objects — passing a raw
+    string raises DataError at bind-time (see _now). Frontend date-range
+    filters arrive as ISO-8601 strings (often with a trailing 'Z'), so
+    normalise them here before they hit a `WHERE updated_at >= $n` comparison.
+    """
+    if isinstance(value, datetime):
+        return value
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text)
+
+
 def _acquire() -> asyncpg.pool.PoolAcquireContext:
     """Return the pool's acquire context manager.
 
@@ -450,22 +466,63 @@ async def get_conversation(conv_id: str, user_id: str) -> dict | None:
     return dict(row) if row else None
 
 
-async def list_conversations(user_id: str) -> list[dict]:
-    async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT c.*,
-                   (SELECT content
-                    FROM messages
-                    WHERE conversation_id = c.id
-                    ORDER BY created_at DESC
-                    LIMIT 1) AS preview
-            FROM conversations c
-            WHERE c.user_id = $1
-            ORDER BY c.updated_at DESC
-            """,
-            user_id,
+async def list_conversations(
+    user_id: str,
+    *,
+    query: str | None = None,
+    start_date: datetime | str | None = None,
+    end_date: datetime | str | None = None,
+    video_id: str | None = None,
+) -> list[dict]:
+    """List a user's conversations, newest-first, with optional filters.
+
+    Every filter is additive (ANDed) on top of the mandatory owner scope, so
+    the user_id boundary from MISSION §10 #3 is never weakened. Supported
+    filters:
+      - query: case-insensitive substring match on the conversation title.
+      - start_date / end_date: inclusive bounds on updated_at (the "when" of
+        the conversation). Accept an aware datetime or an ISO-8601 string.
+      - video_id: keep only conversations with at least one message citing the
+        given video. messages.sources is a JSONB array of citation objects,
+        each carrying a video_id; the @> containment test is naturally safe on
+        NULL sources (it yields NULL, i.e. excluded).
+
+    Only placeholder indices (never user values) are interpolated into the SQL
+    text — every value is bound through asyncpg parameters.
+    """
+    conditions = ["c.user_id = $1"]
+    params: list[object] = [user_id]
+
+    if query:
+        params.append(f"%{query}%")
+        conditions.append(f"c.title ILIKE ${len(params)}")
+    if start_date is not None:
+        params.append(_parse_dt(start_date))
+        conditions.append(f"c.updated_at >= ${len(params)}")
+    if end_date is not None:
+        params.append(_parse_dt(end_date))
+        conditions.append(f"c.updated_at <= ${len(params)}")
+    if video_id:
+        params.append(video_id)
+        conditions.append(
+            "EXISTS (SELECT 1 FROM messages m WHERE m.conversation_id = c.id "
+            f"AND m.sources @> jsonb_build_array(jsonb_build_object('video_id', ${len(params)}::text)))"
         )
+
+    where_clause = " AND ".join(conditions)
+    sql = f"""
+        SELECT c.*,
+               (SELECT content
+                FROM messages
+                WHERE conversation_id = c.id
+                ORDER BY created_at DESC
+                LIMIT 1) AS preview
+        FROM conversations c
+        WHERE {where_clause}
+        ORDER BY c.updated_at DESC
+    """
+    async with _acquire() as conn:
+        rows = await conn.fetch(sql, *params)
     return [dict(r) for r in rows]
 
 

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -26,8 +26,27 @@ class ConversationRename(BaseModel):
 
 
 @router.get("/conversations")
-async def list_conversations(current_user: dict[str, Any] = Depends(get_current_user)):
-    return await repository.list_conversations(user_id=str(current_user["id"]))
+async def list_conversations(
+    q: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    video_id: str | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """List the current user's conversations, newest-first.
+
+    Optional query params narrow the list and combine (AND); the owner scope is
+    always enforced. `q` matches the title (case-insensitive substring),
+    `start_date`/`end_date` are ISO-8601 inclusive bounds on updated_at, and
+    `video_id` keeps only conversations that cite that video.
+    """
+    return await repository.list_conversations(
+        user_id=str(current_user["id"]),
+        query=q,
+        start_date=start_date,
+        end_date=end_date,
+        video_id=video_id,
+    )
 
 
 @router.post("/conversations", status_code=201)

--- a/app/backend/tests/test_conversation_filters.py
+++ b/app/backend/tests/test_conversation_filters.py
@@ -1,0 +1,74 @@
+"""Route-level tests for conversation-history filters (issue #294).
+
+These exercise GET /api/conversations and assert the optional date / video /
+text query params are parsed and forwarded to the repository. The repository
+call is monkeypatched and the auth dependency is overridden, so no database is
+touched (httpx ASGITransport does not run the lifespan that would connect PG).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+from backend.auth.dependencies import get_current_user  # noqa: E402
+from backend.db import repository  # noqa: E402
+from backend.main import app  # noqa: E402
+
+
+@pytest.fixture
+def filter_client(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_list_conversations(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(repository, "list_conversations", fake_list_conversations)
+    app.dependency_overrides[get_current_user] = lambda: {"id": "user-1"}
+    transport = httpx.ASGITransport(app=app)
+    client = httpx.AsyncClient(transport=transport, base_url="http://test")
+    try:
+        yield captured, client
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+async def test_list_conversations_without_filters(filter_client):
+    captured, client = filter_client
+    async with client:
+        resp = await client.get("/api/conversations")
+    assert resp.status_code == 200
+    assert captured == {
+        "user_id": "user-1",
+        "query": None,
+        "start_date": None,
+        "end_date": None,
+        "video_id": None,
+    }
+
+
+async def test_list_conversations_forwards_all_filters(filter_client):
+    captured, client = filter_client
+    async with client:
+        resp = await client.get(
+            "/api/conversations",
+            params={
+                "q": "rag",
+                "start_date": "2026-01-01T00:00:00.000Z",
+                "end_date": "2026-02-01T23:59:59.999Z",
+                "video_id": "vid-1",
+            },
+        )
+    assert resp.status_code == 200
+    assert captured["user_id"] == "user-1"
+    assert captured["query"] == "rag"
+    assert captured["start_date"] == "2026-01-01T00:00:00.000Z"
+    assert captured["end_date"] == "2026-02-01T23:59:59.999Z"
+    assert captured["video_id"] == "vid-1"

--- a/app/frontend/src/__tests__/conversationFilters.test.ts
+++ b/app/frontend/src/__tests__/conversationFilters.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getConversations } from '../lib/api';
+
+function mockFetch() {
+  const fn = vi.fn(
+    async () =>
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  );
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('getConversations query-string serialization (issue #294)', () => {
+  it('hits the bare endpoint when no filters are given', async () => {
+    const fetchFn = mockFetch();
+    await getConversations();
+    expect(fetchFn).toHaveBeenCalledWith('/api/conversations', expect.anything());
+  });
+
+  it('maps camelCase filters to snake_case query params', async () => {
+    const fetchFn = mockFetch();
+    await getConversations({
+      q: 'rag',
+      startDate: '2026-01-01T00:00:00.000Z',
+      endDate: '2026-02-01T23:59:59.999Z',
+      videoId: 'vid-1',
+    });
+    const url = (fetchFn.mock.calls[0]?.[0] ?? '') as string;
+    expect(url.startsWith('/api/conversations?')).toBe(true);
+    const qs = new URLSearchParams(url.split('?')[1]);
+    expect(qs.get('q')).toBe('rag');
+    expect(qs.get('start_date')).toBe('2026-01-01T00:00:00.000Z');
+    expect(qs.get('end_date')).toBe('2026-02-01T23:59:59.999Z');
+    expect(qs.get('video_id')).toBe('vid-1');
+  });
+
+  it('omits empty / undefined filter values', async () => {
+    const fetchFn = mockFetch();
+    await getConversations({ videoId: 'only-this' });
+    const url = (fetchFn.mock.calls[0]?.[0] ?? '') as string;
+    const qs = new URLSearchParams(url.split('?')[1]);
+    expect(qs.get('video_id')).toBe('only-this');
+    expect(qs.has('q')).toBe(false);
+    expect(qs.has('start_date')).toBe(false);
+    expect(qs.has('end_date')).toBe(false);
+  });
+});

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,9 @@
-import { type MutableRefObject, type RefObject, useEffect, useRef, useState } from 'react';
+import { type MutableRefObject, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import { type Conversation, type Video, createConversation, deleteConversation, getVideos } from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
 
 // ── Relative time helper ─────────────────────────────────────────
@@ -413,8 +413,27 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  // Conversation-history filters (issue #294): a date range and a video, which
+  // combine with the text search above. Dates are YYYY-MM-DD (native input).
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [videoId, setVideoId] = useState('');
+  const [videos, setVideos] = useState<Video[]>([]);
+  const hasActiveFilters = Boolean(startDate || endDate || videoId);
+
+  // Convert the local YYYY-MM-DD inputs into UTC ISO-8601 day bounds so the
+  // range is inclusive of both endpoints when compared against TIMESTAMPTZ.
+  const serverFilters = useMemo(
+    () => ({
+      startDate: startDate ? `${startDate}T00:00:00.000Z` : undefined,
+      endDate: endDate ? `${endDate}T23:59:59.999Z` : undefined,
+      videoId: videoId || undefined,
+    }),
+    [startDate, endDate, videoId],
+  );
+
   const { conversations, loading, refetch, rename, filteredConversations } =
-    useConversations(debouncedQuery);
+    useConversations(debouncedQuery, serverFilters);
   const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -430,6 +449,37 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  // Populate the video filter dropdown. Failure is non-fatal — the dropdown
+  // just stays empty and date/text filtering keep working (issue #294).
+  useEffect(() => {
+    let cancelled = false;
+    getVideos()
+      .then((v) => {
+        if (!cancelled) setVideos(v);
+      })
+      .catch(() => {
+        /* dropdown degrades gracefully to no options */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ── History filters ──
+  const applyDatePreset = (days: number) => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setUTCDate(start.getUTCDate() - days);
+    setStartDate(start.toISOString().slice(0, 10));
+    setEndDate(now.toISOString().slice(0, 10));
+  };
+
+  const clearFilters = () => {
+    setStartDate('');
+    setEndDate('');
+    setVideoId('');
+  };
 
   // Store refetch in the shared ref so ChatArea can trigger it
   useEffect(() => {
@@ -601,6 +651,124 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           />
         </div>
 
+        {/* ── History filters: date range + video (issue #294) ── */}
+        <div style={{ padding: '0 12px 8px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <button
+              type="button"
+              onClick={() => applyDatePreset(7)}
+              style={{
+                flex: 1,
+                background: 'transparent',
+                border: '1px solid #334155',
+                borderRadius: 6,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                fontSize: 12,
+                padding: '5px 6px',
+              }}
+            >
+              This week
+            </button>
+            <button
+              type="button"
+              onClick={() => applyDatePreset(30)}
+              style={{
+                flex: 1,
+                background: 'transparent',
+                border: '1px solid #334155',
+                borderRadius: 6,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                fontSize: 12,
+                padding: '5px 6px',
+              }}
+            >
+              Last month
+            </button>
+            {hasActiveFilters && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                style={{
+                  background: 'transparent',
+                  border: '1px solid rgba(239,68,68,0.4)',
+                  borderRadius: 6,
+                  color: '#ef4444',
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  padding: '5px 8px',
+                }}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input
+              type="date"
+              aria-label="Filter from date"
+              value={startDate}
+              max={endDate || undefined}
+              onChange={(e) => setStartDate(e.target.value)}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                padding: '6px 8px',
+                borderRadius: 6,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 12,
+                outline: 'none',
+              }}
+            />
+            <span style={{ color: '#475569', fontSize: 12 }}>–</span>
+            <input
+              type="date"
+              aria-label="Filter to date"
+              value={endDate}
+              min={startDate || undefined}
+              onChange={(e) => setEndDate(e.target.value)}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                padding: '6px 8px',
+                borderRadius: 6,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 12,
+                outline: 'none',
+              }}
+            />
+          </div>
+
+          <select
+            aria-label="Filter by video"
+            value={videoId}
+            onChange={(e) => setVideoId(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              borderRadius: 6,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: videoId ? '#f1f5f9' : '#94a3b8',
+              fontSize: 12,
+              outline: 'none',
+            }}
+          >
+            <option value="">All videos</option>
+            {videos.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.title}
+              </option>
+            ))}
+          </select>
+        </div>
+
         {/* ── Conversation list ── */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {loading ? (
@@ -630,9 +798,16 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              {debouncedQuery.trim() ? (
+              {debouncedQuery.trim() || hasActiveFilters ? (
                 <p style={{ margin: 0, fontSize: 13 }}>
-                  No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
+                  {debouncedQuery.trim() ? (
+                    <>
+                      No matches for{' '}
+                      <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
+                    </>
+                  ) : (
+                    'No conversations match these filters'
+                  )}
                 </p>
               ) : (
                 <>

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Conversation, getConversations, renameConversation } from '../lib/api';
+import { type Conversation, type ConversationFilters, getConversations, renameConversation } from '../lib/api';
 
-export function useConversations(searchQuery?: string) {
+interface ServerFilters {
+  startDate?: string;
+  endDate?: string;
+  videoId?: string;
+}
+
+export function useConversations(searchQuery?: string, serverFilters?: ServerFilters) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -9,11 +15,27 @@ export function useConversations(searchQuery?: string) {
   // when the user types faster than the network replies.
   const fetchIdRef = useRef(0);
 
+  // Date/video filters are applied server-side (the full conversation set must
+  // be queried to honour them), while the free-text query stays client-side so
+  // typing remains instant. Read the individual values so the load callback
+  // only re-creates — and the effect only refetches — when one truly changes.
+  const startDate = serverFilters?.startDate ?? '';
+  const endDate = serverFilters?.endDate ?? '';
+  const videoId = serverFilters?.videoId ?? '';
+
   const load = useCallback(async () => {
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = await getConversations();
+      const filters: ConversationFilters | undefined =
+        startDate || endDate || videoId
+          ? {
+              startDate: startDate || undefined,
+              endDate: endDate || undefined,
+              videoId: videoId || undefined,
+            }
+          : undefined;
+      const data = await getConversations(filters);
       if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
       if (myId === fetchIdRef.current) {
@@ -22,7 +44,7 @@ export function useConversations(searchQuery?: string) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, []);
+  }, [startDate, endDate, videoId]);
 
   useEffect(() => {
     load();

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -143,7 +143,28 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 }
 
 // Conversations
-export const getConversations = () => request<Conversation[]>('/conversations');
+/**
+ * Optional filters for the conversation list. They combine (AND) on the server
+ * and results always come back newest-first. `startDate`/`endDate` are ISO-8601
+ * strings and map to the snake_case `start_date`/`end_date` query params;
+ * `videoId` maps to `video_id`.
+ */
+export interface ConversationFilters {
+  q?: string;
+  startDate?: string;
+  endDate?: string;
+  videoId?: string;
+}
+
+export const getConversations = (filters?: ConversationFilters) => {
+  const params = new URLSearchParams();
+  if (filters?.q) params.set('q', filters.q);
+  if (filters?.startDate) params.set('start_date', filters.startDate);
+  if (filters?.endDate) params.set('end_date', filters.endDate);
+  if (filters?.videoId) params.set('video_id', filters.videoId);
+  const qs = params.toString();
+  return request<Conversation[]>(`/conversations${qs ? `?${qs}` : ''}`);
+};
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
 export const createConversation = () =>


### PR DESCRIPTION
Fixes #294

**Benchmark cell:** `XO` (plan=NONE, impl=Opus)
**Source run-id:** `f3afef28-f844-463f-a580-a8a19b47c1ec`

Held-constant: explore + self-review on Sonnet. No planning step.

Produced by the mixed-provider routing benchmark (no-plan baseline).
See `benchmark-evaluator` workflow for the scored verdict.