### PR TITLE
[bench-FF] fix(integrations): Circle paid-membership check fails closed when active field absent

### DIFF
--- a/app/backend/integrations/circle.py
+++ b/app/backend/integrations/circle.py
@@ -64,8 +64,10 @@ async def verify_paid_member(email: str) -> bool:
             member = _extract_member(r.json())
             if member is None:
                 return False
-            if not member.get("active", True):
-                # Inactive members lose access immediately.
+            if not member.get("active", False):
+                # Inactive members lose access immediately. A missing `active` field
+                # also denies: this is a paid-access gate and the contract is
+                # fail-closed — no explicit active signal means no access.
                 return False
             member_id = member.get("id")
             if not member_id:

--- a/app/backend/tests/test_circle.py
+++ b/app/backend/tests/test_circle.py
@@ -7,6 +7,7 @@ The function MUST never raise — it always returns a bool. We exercise:
 - non-200 from access_groups (fail-closed)
 - timeout (fail-closed)
 - inactive member
+- member with no `active` field (fail-closed)
 - member exists but NOT in paid access group
 - empty / malformed config
 - malformed response shape
@@ -107,6 +108,30 @@ async def test_inactive_member_returns_false():
     )
 
     assert await circle.verify_paid_member("inactive@example.com") is False
+
+
+@respx.mock
+async def test_member_missing_active_field_fails_closed():
+    """No `active` key on the member object must deny (fail-closed paid gate).
+
+    The access_groups endpoint is deliberately NOT mocked: a correct fix
+    short-circuits before step 2, so respx would raise on any call to it.
+    """
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"id": 999})
+    )
+
+    assert await circle.verify_paid_member("unknown-status@example.com") is False
+
+
+@respx.mock
+async def test_records_wrapped_member_missing_active_fails_closed():
+    """Same as above for the `records`-wrapped search shape, which often omits status."""
+    respx.get("https://app.circle.so/api/admin/v2/community_members/search").mock(
+        return_value=httpx.Response(200, json={"records": [{"id": 999}]})
+    )
+
+    assert await circle.verify_paid_member("unknown-status@example.com") is False
 
 
 @respx.mock


### PR DESCRIPTION
Fixes #243

**Benchmark cell:** `FF` (plan=Fable, impl=Fable)
**Source run-id:** `6d5d09e1-d23b-49a2-9f3d-e8d06919bb7c`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark (Fable 5 workshop dress rehearsal).
See `benchmark-evaluator` workflow for the scored verdict.
