### PR TITLE
[bench-FO] fix(web): stop stream reader and skip onComplete on mid-stream error

### DIFF
--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -614,3 +614,139 @@ describe('sources event — hook state via renderHook', () => {
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ sources: [] }));
   });
 });
+
+describe('mid-stream error payload — issue #244', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects and never calls onComplete on a {"error"} payload', async () => {
+    const sseChunks = [
+      'data: "Partial answer"\n\n',
+      'data: {"error": "upstream exploded"}\n\n',
+      // These must never be consumed/committed once the error is seen
+      'data: " more text"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        'upstream exploded',
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('stops the reader loop promptly instead of draining to done', async () => {
+    const encoder = new TextEncoder();
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode('data: "Partial answer"\n\n'),
+      })
+      .mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode('data: {"error": "upstream exploded"}\n\n'),
+      })
+      .mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode('data: " more text"\n\n'),
+      })
+      .mockResolvedValue({ done: true, value: undefined });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: { getReader: () => ({ read }) },
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        'upstream exploded',
+      );
+    });
+
+    // read() called exactly twice: the token chunk, then the error chunk.
+    // The third (" more text") and beyond are never read — the outer loop exited.
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('runs the finally cleanup exactly once (state fully reset after error)', async () => {
+    const sseChunks = [
+      'data: "Partial answer"\n\n',
+      'data: {"error": "upstream exploded"}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', vi.fn())).rejects.toThrow(
+        'upstream exploded',
+      );
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.streamingSources).toHaveLength(0);
+    expect(result.current.streamingStatus).toBeNull();
+  });
+
+  it('falls back to the default message on malformed error JSON', async () => {
+    const sseChunks = [
+      'data: "Partial answer"\n\n',
+      'data: {"error" not-json\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        'Stream error from server',
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -107,7 +107,7 @@ export function useStreamingResponse(conversationId: string | null) {
         // Buffer for incomplete SSE data between reader.read() calls
         let buffer = '';
 
-        while (true) {
+        readLoop: while (true) {
           const { done, value } = await reader.read();
           if (done) break;
 
@@ -184,7 +184,7 @@ export function useStreamingResponse(conversationId: string | null) {
                 // Use default message
               }
               streamError = new Error(errMsg);
-              break;
+              break readLoop;
             } else if (data) {
               // Tokens are JSON-encoded strings to safely handle newlines/special chars
               let token = data;
@@ -203,8 +203,11 @@ export function useStreamingResponse(conversationId: string | null) {
           }
         }
 
-        // Stream completed successfully
-        onComplete({ fullText, sources });
+        // Only commit the result if the stream finished without a server error —
+        // a mid-stream {"error"} payload must not persist the partial text (issue #244).
+        if (!streamError) {
+          onComplete({ fullText, sources });
+        }
       } finally {
         // Always reset streaming state — React 18 batches this with the onComplete
         // state updates, ensuring a seamless transition to the persisted message.


### PR DESCRIPTION
Fixes #244

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `1232f543-344c-4d6e-8f7e-b28b0c9d298b`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.