### PR TITLE
[bench-FF] impl: address issue

### DIFF
--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -537,6 +537,113 @@ describe('conversationId reset — state clears on navigation', () => {
   });
 });
 
+describe('mid-stream error event', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects without calling onComplete when an error payload arrives after partial tokens', async () => {
+    const sseChunks = [
+      'data: "Partial "\n\n',
+      'data: {"error": "upstream model failure"}\n\n',
+      'data: "should never be appended"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        /upstream model failure/,
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+    // finally cleanup still ran exactly once
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.streamingStatus).toBeNull();
+  });
+
+  it('stops reading promptly after the error event instead of draining the stream', async () => {
+    const enc = new TextEncoder();
+    const remaining = [
+      'data: "Partial "\n\n',
+      'data: {"error": "upstream model failure"}\n\n',
+      'data: "sentinel"\n\n',
+      'data: [DONE]\n\n',
+    ];
+    // Pull-based stream: chunks are only handed out as the consumer reads.
+    // If the reader loop kept spinning after the error, the [DONE] chunk
+    // would be pulled; with the fix it must remain unread.
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const chunk = remaining.shift();
+        if (chunk === undefined) {
+          controller.close();
+        } else {
+          controller.enqueue(enc.encode(chunk));
+        }
+      },
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: stream,
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        /upstream model failure/,
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(remaining).toContain('data: [DONE]\n\n');
+  });
+
+  it('falls back to the default message when the error payload is malformed JSON', async () => {
+    const sseChunks = ['data: {"error" oops\n\n'];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        /Stream error from server/,
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});
+
 describe('sources event — hook state via renderHook', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -107,7 +107,7 @@ export function useStreamingResponse(conversationId: string | null) {
         // Buffer for incomplete SSE data between reader.read() calls
         let buffer = '';
 
-        while (true) {
+        readLoop: while (true) {
           const { done, value } = await reader.read();
           if (done) break;
 
@@ -184,7 +184,9 @@ export function useStreamingResponse(conversationId: string | null) {
                 // Use default message
               }
               streamError = new Error(errMsg);
-              break;
+              // Stop reading entirely — the rest of the stream (and any buffered
+              // remainder) is intentionally discarded on a server error.
+              break readLoop;
             } else if (data) {
               // Tokens are JSON-encoded strings to safely handle newlines/special chars
               let token = data;
@@ -203,8 +205,10 @@ export function useStreamingResponse(conversationId: string | null) {
           }
         }
 
-        // Stream completed successfully
-        onComplete({ fullText, sources });
+        // Only commit the result if the stream completed without a server error
+        if (!streamError) {
+          onComplete({ fullText, sources });
+        }
       } finally {
         // Always reset streaming state — React 18 batches this with the onComplete
         // state updates, ensuring a seamless transition to the persisted message.


### PR DESCRIPTION
Fixes #244

**Benchmark cell:** `FF` (plan=Fable, impl=Fable)
**Source run-id:** `5c015562-0f91-4db4-966a-fbb150e4652c`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.