### PR TITLE
[bench-OF] review: address self-review findings

### DIFF
--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -614,3 +614,124 @@ describe('sources event — hook state via renderHook', () => {
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ sources: [] }));
   });
 });
+
+describe('mid-stream {"error"} payload — issue #244', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call onComplete and throws the server error', async () => {
+    const sseChunks = [
+      'data: "Partial answer"\n\n',
+      'data: {"error":"upstream failed"}\n\n',
+      // Content after the error must not resurrect the stream as a success
+      'data: " more text"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        'upstream failed',
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('stops reading promptly — does not drain the stream past the error payload', async () => {
+    // The chunk after the error is gated behind a promise that is never released.
+    // If the reader loop kept draining after the error (the old bug), startStream
+    // would block on reader.read() forever and this test would time out.
+    const gate = new Promise<void>(() => {});
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const enc = new TextEncoder();
+        controller.enqueue(enc.encode('data: "Partial answer"\n\n'));
+        controller.enqueue(enc.encode('data: {"error":"upstream failed"}\n\n'));
+        await gate;
+        controller.enqueue(enc.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: stream,
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        'upstream failed',
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('finally still resets all streaming state after a mid-stream error', async () => {
+    const sseChunks = ['data: "Partial"\n\n', 'data: {"error":"boom"}\n\n'];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', vi.fn())).rejects.toThrow('boom');
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.streamingSources).toHaveLength(0);
+    expect(result.current.streamingStatus).toBeNull();
+  });
+
+  it('uses the default error message when the error payload is unparseable', async () => {
+    const sseChunks = ['data: {"error"\n\n'];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startStream('conv-1', 'hi', onComplete)).rejects.toThrow(
+        'Stream error from server',
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -107,7 +107,7 @@ export function useStreamingResponse(conversationId: string | null) {
         // Buffer for incomplete SSE data between reader.read() calls
         let buffer = '';
 
-        while (true) {
+        streamLoop: while (true) {
           const { done, value } = await reader.read();
           if (done) break;
 
@@ -184,7 +184,9 @@ export function useStreamingResponse(conversationId: string | null) {
                 // Use default message
               }
               streamError = new Error(errMsg);
-              break;
+              // Exit the outer reader loop too — keep neither reading nor draining
+              // the rest of the stream after a server-reported failure.
+              break streamLoop;
             } else if (data) {
               // Tokens are JSON-encoded strings to safely handle newlines/special chars
               let token = data;
@@ -203,8 +205,10 @@ export function useStreamingResponse(conversationId: string | null) {
           }
         }
 
-        // Stream completed successfully
-        onComplete({ fullText, sources });
+        // Stream completed successfully — do not commit a failed stream as a success.
+        if (!streamError) {
+          onComplete({ fullText, sources });
+        }
       } finally {
         // Always reset streaming state — React 18 batches this with the onComplete
         // state updates, ensuring a seamless transition to the persisted message.

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -184,8 +184,7 @@ export function useStreamingResponse(conversationId: string | null) {
                 // Use default message
               }
               streamError = new Error(errMsg);
-              // Exit the outer reader loop too — keep neither reading nor draining
-              // the rest of the stream after a server-reported failure.
+              // Break the outer loop too — do not drain the rest of a failed stream.
               break streamLoop;
             } else if (data) {
               // Tokens are JSON-encoded strings to safely handle newlines/special chars


### PR DESCRIPTION
Fixes #244

**Benchmark cell:** `OF` (plan=Opus, impl=Fable)
**Source run-id:** `a3e081d6-3117-404b-bcdb-b0f8f81653e3`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.