### PR TITLE
[bench-OO] fix(rag): skip even-distribution for zero-duration segments

### DIFF
--- a/.archon/workflows/benchmark-FF.yaml
+++ b/.archon/workflows/benchmark-FF.yaml
@@ -1,0 +1,155 @@
+name: benchmark-FF
+description: |
+  Benchmark cell: plan=Fable, impl=Fable (claude-fable-5 both slots).
+  The premium-tier ceiling. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FF"
+      CELL_DESC="plan=Fable, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FK.yaml
+++ b/.archon/workflows/benchmark-FK.yaml
@@ -1,0 +1,156 @@
+name: benchmark-FK
+description: |
+  Benchmark cell: plan=Fable, impl=Kimi (K2.6 via Pi). The value play —
+  premium-tier planning, cheap implementation. Directly compares to OK (Opus
+  plan) from the prior run. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: pi
+    model: kimi-coding/kimi-for-coding
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FK"
+      CELL_DESC="plan=Fable, impl=Kimi"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FO.yaml
+++ b/.archon/workflows/benchmark-FO.yaml
@@ -1,0 +1,154 @@
+name: benchmark-FO
+description: |
+  Benchmark cell: plan=Fable, impl=Opus. Tests whether Fable's edge lives in
+  the PLANNING step. See benchmark-OO.yaml for the full design notes. This file
+  differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: opus
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FO"
+      CELL_DESC="plan=Fable, impl=Opus"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-OF.yaml
+++ b/.archon/workflows/benchmark-OF.yaml
@@ -1,0 +1,154 @@
+name: benchmark-OF
+description: |
+  Benchmark cell: plan=Opus, impl=Fable. Tests whether Fable's edge lives in
+  the IMPLEMENTATION step. See benchmark-OO.yaml for the full design notes. This
+  file differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: opus
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="OF"
+      CELL_DESC="plan=Opus, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/app/backend/rag/chunker.py
+++ b/app/backend/rag/chunker.py
@@ -162,9 +162,14 @@ def chunk_video_timestamped(segments: list[TimestampedSegment]) -> tuple[list[di
 
             # Distribute timestamps evenly across sub-chunks when HybridChunker
             # splits a segment into multiple pieces (no worse than fallback's
-            # proportional timestamps, which are explicitly accepted).
-            if len(sub_chunks) > 1:
-                duration = end_s - start_s
+            # proportional timestamps, which are explicitly accepted). Only do
+            # this when the segment has a positive duration. For zero/negative-
+            # duration segments (e.g. the final transcript segment where
+            # end == start) an even split is meaningless and would collapse
+            # every sub-chunk to a zero-width span, so we keep each sub-chunk on
+            # the original [start_s, end_s] boundary set at construction.
+            duration = end_s - start_s
+            if len(sub_chunks) > 1 and duration > 0:
                 step = duration / len(sub_chunks)
                 for i, sc in enumerate(sub_chunks):
                     sc["start_seconds"] = start_s + i * step

--- a/app/backend/tests/test_chunker_timestamps.py
+++ b/app/backend/tests/test_chunker_timestamps.py
@@ -55,6 +55,32 @@ class TestChunkVideoTimestamped:
         # Should not produce any chunks from the empty segment
         assert all("Real content" in c["content"] or "Real content" in c["snippet"] for c in result)
 
+    def test_zero_duration_segment_does_not_collapse_timestamps(self) -> None:
+        """A zero-duration segment that splits into multiple sub-chunks keeps the
+        original [start_s, end_s] bounds instead of collapsing to a zero-width span.
+
+        The final transcript segment can have end == start (see _parse_segments).
+        When such a segment is long enough to split, the even-distribution branch
+        must be skipped (duration <= 0) so timestamps are not all pinned to the
+        same instant by a step of 0.
+        """
+        start_s = 42.0
+        # Long, varied text to push HybridChunker into producing >1 sub-chunk.
+        text = " ".join(
+            f"Sentence number {i} describes a distinct topic worth retrieving and citing."
+            for i in range(200)
+        )
+        segments = [{"start": start_s, "end": start_s, "text": text}]
+        result, _ = chunk_video_timestamped(segments)
+
+        assert len(result) >= 1
+        # Every chunk retains the original equal bounds; none received a distributed
+        # value, and the end is never before the start.
+        for chunk in result:
+            assert chunk["start_seconds"] == start_s
+            assert chunk["end_seconds"] == start_s
+            assert chunk["end_seconds"] >= chunk["start_seconds"]
+
 
 class TestChunkVideoFallback:
     def test_produces_monotonic_timestamps(self) -> None:


### PR DESCRIPTION
Fixes #245

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `b0f51a39-b567-4919-a14f-590114ffd4eb`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.