### PR TITLE
[bench-FO] fix(rag): keep boundary timestamps for zero-duration segments

### DIFF
--- a/.archon/workflows/benchmark-FF.yaml
+++ b/.archon/workflows/benchmark-FF.yaml
@@ -1,0 +1,155 @@
+name: benchmark-FF
+description: |
+  Benchmark cell: plan=Fable, impl=Fable (claude-fable-5 both slots).
+  The premium-tier ceiling. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FF"
+      CELL_DESC="plan=Fable, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FK.yaml
+++ b/.archon/workflows/benchmark-FK.yaml
@@ -1,0 +1,156 @@
+name: benchmark-FK
+description: |
+  Benchmark cell: plan=Fable, impl=Kimi (K2.6 via Pi). The value play —
+  premium-tier planning, cheap implementation. Directly compares to OK (Opus
+  plan) from the prior run. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: pi
+    model: kimi-coding/kimi-for-coding
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FK"
+      CELL_DESC="plan=Fable, impl=Kimi"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FO.yaml
+++ b/.archon/workflows/benchmark-FO.yaml
@@ -1,0 +1,154 @@
+name: benchmark-FO
+description: |
+  Benchmark cell: plan=Fable, impl=Opus. Tests whether Fable's edge lives in
+  the PLANNING step. See benchmark-OO.yaml for the full design notes. This file
+  differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: opus
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FO"
+      CELL_DESC="plan=Fable, impl=Opus"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-OF.yaml
+++ b/.archon/workflows/benchmark-OF.yaml
@@ -1,0 +1,154 @@
+name: benchmark-OF
+description: |
+  Benchmark cell: plan=Opus, impl=Fable. Tests whether Fable's edge lives in
+  the IMPLEMENTATION step. See benchmark-OO.yaml for the full design notes. This
+  file differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: opus
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="OF"
+      CELL_DESC="plan=Opus, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/app/backend/rag/chunker.py
+++ b/app/backend/rag/chunker.py
@@ -165,10 +165,14 @@ def chunk_video_timestamped(segments: list[TimestampedSegment]) -> tuple[list[di
             # proportional timestamps, which are explicitly accepted).
             if len(sub_chunks) > 1:
                 duration = end_s - start_s
-                step = duration / len(sub_chunks)
-                for i, sc in enumerate(sub_chunks):
-                    sc["start_seconds"] = start_s + i * step
-                    sc["end_seconds"] = start_s + (i + 1) * step
+                # Zero/negative duration (e.g. a zero-width final segment) makes even
+                # distribution meaningless — keep each sub-chunk on the original
+                # [start_s, end_s] boundary instead of collapsing every timestamp.
+                if duration > 0:
+                    step = duration / len(sub_chunks)
+                    for i, sc in enumerate(sub_chunks):
+                        sc["start_seconds"] = start_s + i * step
+                        sc["end_seconds"] = start_s + (i + 1) * step
 
             results.extend(sub_chunks)
         except Exception as exc:

--- a/app/backend/tests/test_chunker_timestamps.py
+++ b/app/backend/tests/test_chunker_timestamps.py
@@ -8,7 +8,17 @@ Verifies:
   - chunk_video_fallback evenly distributes estimated duration across chunks
 """
 
+import pytest
+
 from backend.rag.chunker import chunk_video_fallback, chunk_video_timestamped
+
+# Long, varied text well above the 512-token chunk budget so HybridChunker is
+# guaranteed to split a single segment into multiple sub-chunks (exercising the
+# timestamp-distribution branch). Varied (not a single repeated word) so the
+# tokenizer genuinely overflows max_tokens.
+_LONG_TEXT = " ".join(
+    f"Sentence number {i} of the transcript talks about topic {i}." for i in range(400)
+)
 
 
 class TestChunkVideoTimestamped:
@@ -54,6 +64,43 @@ class TestChunkVideoTimestamped:
         result, _ = chunk_video_timestamped(segments)
         # Should not produce any chunks from the empty segment
         assert all("Real content" in c["content"] or "Real content" in c["snippet"] for c in result)
+
+    def test_zero_duration_segment_keeps_boundary_timestamps(self) -> None:
+        """A zero-width segment (end == start) that splits into multiple sub-chunks
+        keeps each sub-chunk on the original boundary instead of collapsing every
+        timestamp with a zero step."""
+        segments = [{"start": 120.0, "end": 120.0, "text": _LONG_TEXT}]
+        result, _ = chunk_video_timestamped(segments)
+
+        # The distribution branch is only exercised when the segment splits.
+        assert len(result) > 1
+        for chunk in result:
+            assert chunk["start_seconds"] == 120.0
+            assert chunk["end_seconds"] == 120.0
+
+    def test_negative_duration_segment_keeps_boundary_timestamps(self) -> None:
+        """A malformed segment (end < start) is not redistributed; each sub-chunk
+        keeps the original boundary values."""
+        segments = [{"start": 50.0, "end": 40.0, "text": _LONG_TEXT}]
+        result, _ = chunk_video_timestamped(segments)
+
+        assert len(result) > 1
+        for chunk in result:
+            assert chunk["start_seconds"] == 50.0
+            assert chunk["end_seconds"] == 40.0
+
+    def test_positive_duration_segment_distributes_evenly(self) -> None:
+        """Normal positive-duration segments keep their even-distribution behavior."""
+        segments = [{"start": 0.0, "end": 100.0, "text": _LONG_TEXT}]
+        result, _ = chunk_video_timestamped(segments)
+
+        assert len(result) > 1
+        assert result[0]["start_seconds"] == pytest.approx(0.0)
+        assert result[-1]["end_seconds"] == pytest.approx(100.0)
+        for i, chunk in enumerate(result):
+            assert chunk["end_seconds"] > chunk["start_seconds"]
+            if i > 0:
+                assert chunk["start_seconds"] == pytest.approx(result[i - 1]["end_seconds"])
 
 
 class TestChunkVideoFallback:


### PR DESCRIPTION
Fixes #245

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `d850aeca-209a-4a78-a4a4-c1b096fe0793`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.