### PR TITLE
[bench-OO] fix(messages): finalize sources identically on interrupted streams

### DIFF
--- a/.archon/workflows/benchmark-FF.yaml
+++ b/.archon/workflows/benchmark-FF.yaml
@@ -1,0 +1,155 @@
+name: benchmark-FF
+description: |
+  Benchmark cell: plan=Fable, impl=Fable (claude-fable-5 both slots).
+  The premium-tier ceiling. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FF"
+      CELL_DESC="plan=Fable, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FK.yaml
+++ b/.archon/workflows/benchmark-FK.yaml
@@ -1,0 +1,156 @@
+name: benchmark-FK
+description: |
+  Benchmark cell: plan=Fable, impl=Kimi (K2.6 via Pi). The value play —
+  premium-tier planning, cheap implementation. Directly compares to OK (Opus
+  plan) from the prior run. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: pi
+    model: kimi-coding/kimi-for-coding
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FK"
+      CELL_DESC="plan=Fable, impl=Kimi"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FO.yaml
+++ b/.archon/workflows/benchmark-FO.yaml
@@ -1,0 +1,154 @@
+name: benchmark-FO
+description: |
+  Benchmark cell: plan=Fable, impl=Opus. Tests whether Fable's edge lives in
+  the PLANNING step. See benchmark-OO.yaml for the full design notes. This file
+  differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: opus
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FO"
+      CELL_DESC="plan=Fable, impl=Opus"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-OF.yaml
+++ b/.archon/workflows/benchmark-OF.yaml
@@ -1,0 +1,154 @@
+name: benchmark-OF
+description: |
+  Benchmark cell: plan=Opus, impl=Fable. Tests whether Fable's edge lives in
+  the IMPLEMENTATION step. See benchmark-OO.yaml for the full design notes. This
+  file differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: opus
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="OF"
+      CELL_DESC="plan=Opus, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -122,7 +122,6 @@ async def create_message(
     # lists exactly what the model actually read. The video_id whitelist is
     # only consulted by the transcript tool (it guards against hallucinated
     # ids); the search tools ignore it.
-    source_citations: list[dict] = []
     tool_chunks_acc: list[dict] = []
     embedding_cache: dict[str, list[float]] = {}
     tools_param: list[dict] | None = None
@@ -165,7 +164,8 @@ async def create_message(
         max_tool_calls = LLM_TOOLS_MAX_PER_TURN
 
     # 6. Stream the response. The model drives retrieval via tool calls;
-    # chunks it pulls flow into source_citations via tool_chunks_acc.
+    # chunks it pulls flow into tool_chunks_acc and are finalized into the
+    # source citation list via _finalize_source_citations.
     # ``final_text_buf`` receives the assistant's final-round text so the
     # refusal check ignores inter-round commentary ("let me try semantic").
     async def event_generator() -> AsyncGenerator[str, None]:
@@ -195,40 +195,17 @@ async def create_message(
                         tail_chunk = f"data: {json.dumps(tail)}\n\n"
                         full_response.append(tail_chunk)
                         yield tail_chunk
-                    # Dedup tool-loaded chunks into source_citations (existing).
-                    if tool_chunks_acc:
-                        seen: set[str] = set()
-                        for tc in tool_chunks_acc:
-                            tc_id = tc.get("chunk_id")
-                            if tc_id and tc_id not in seen:
-                                source_citations.append(tc)
-                                seen.add(tc_id)
-                    # Mark is_cited from markers in the raw final-round text.
-                    # Marker IDs that don't match any retrieved chunk are
-                    # silently dropped (hallucinations).
-                    if source_citations:
-                        final_text_raw = final_text_buf[0] if final_text_buf else ""
-                        cited_ids = extract_cited_chunk_ids(final_text_raw)
-                        for chunk in source_citations:
-                            chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
-                        # Collapse same-video chunks (issue #208): keep one
-                        # entry per video_id, choosing the earliest-cited
-                        # timestamp as the representative.
-                        source_citations[:] = _collapse_by_video(source_citations)
-                        # Cap fallback (issue #176): cited pass through, non-cited sliced.
-                        cited = [c for c in source_citations if c.get("is_cited")]
-                        uncited = [c for c in source_citations if not c.get("is_cited")]
-                        source_citations[:] = cited + uncited[:CITATIONS_MAX_COUNT]
-                    # Suppress sources on refusal (existing behaviour).
-                    if source_citations:
-                        final_text = (
-                            final_text_buf[0]
-                            if final_text_buf
-                            else _extract_text_from_sse(full_response)
-                        )
-                        if not _is_refusal(final_text):
-                            sources_json = json.dumps(source_citations)
-                            yield f"event: sources\ndata: {sources_json}\n\n"
+                    # Finalize the raw tool chunks through the shared pipeline
+                    # so the live `event: sources` payload matches exactly what
+                    # the `finally` block persists (issue #277).
+                    final_text = (
+                        final_text_buf[0]
+                        if final_text_buf
+                        else _extract_text_from_sse(full_response)
+                    )
+                    finalized = _finalize_source_citations(tool_chunks_acc, final_text)
+                    if finalized:
+                        yield f"event: sources\ndata: {json.dumps(finalized)}\n\n"
                     full_response.append(sse_chunk)
                     yield sse_chunk
                     continue
@@ -256,21 +233,17 @@ async def create_message(
             # can exit cleanly.
             assistant_text = _extract_text_from_sse(full_response)
             if assistant_text:
-                # Apply the same refusal detection used for the live SSE
-                # `event: sources` suppression so reloading the conversation
-                # later doesn't bring the misleading chip back. Prefer the
-                # final-round text when available — it's what the SSE path
-                # checks — and fall back to the full reconstructed text if
-                # the final_text buffer wasn't populated (e.g. pre-tool
-                # flow). If the message is a refusal we persist sources=None
-                # regardless of what the tool calls retrieved; the frontend
-                # renders the chip based on the stored field, so dropping
-                # it here keeps the reload UX consistent with the stream.
-                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
-                sources_to_persist: list[dict] | None = (
-                    None
-                    if not source_citations or _is_refusal(refusal_check_text)
-                    else source_citations
+                # Finalize the raw tool chunks through the SAME shared helper
+                # the live `event: sources` path uses, so the persisted
+                # sources are identical to what the user saw — deduplicated,
+                # same-video-collapsed, capped, and refusal-suppressed —
+                # whether the stream reached `[DONE]` or was interrupted /
+                # errored mid-stream (issue #277). Prefer the final-round text
+                # when available (what the SSE path checks); fall back to the
+                # full reconstructed text if the buffer wasn't populated.
+                final_text = final_text_buf[0] if final_text_buf else assistant_text
+                sources_to_persist: list[dict] | None = _finalize_source_citations(
+                    tool_chunks_acc, final_text
                 )
                 try:
                     await asyncio.shield(
@@ -506,3 +479,60 @@ def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
         collapsed.append(entry)
 
     return collapsed
+
+
+def _finalize_source_citations(
+    raw_chunks: list[dict[str, Any]], final_text: str
+) -> list[dict[str, Any]] | None:
+    """Finalize the raw tool-loaded chunks into the source citation list.
+
+    This is the single source of truth for turning the raw ``tool_chunks_acc``
+    accumulator into the citation list shown to the user and persisted to the
+    DB. It is applied **identically** on both the clean ``[DONE]`` path (to
+    build the live ``event: sources`` payload) and the ``finally`` persist
+    path (to compute what gets saved). Issue #277: previously the dedup /
+    citation-marking / collapse / cap / refusal-suppress pipeline only ran in
+    the ``[DONE]`` branch, so an interrupted or errored stream (no ``[DONE]``)
+    persisted a list that was never finalized the same way as the live view —
+    the live and reloaded views disagreed (raw/duplicate chunks, same-video
+    duplicates, chips on refusals). Routing both call sites through this pure
+    helper guarantees the persisted sources are identical to the finalized
+    live view regardless of how the stream ended.
+
+    Returns ``None`` when there is nothing to show (no chunks, or a refusal),
+    matching the persisted ``sources=None`` sentinel.
+    """
+    if not raw_chunks:
+        return None
+
+    # Dedup tool-loaded chunks by chunk_id, preserving first-seen order.
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for tc in raw_chunks:
+        tc_id = tc.get("chunk_id")
+        if tc_id and tc_id not in seen:
+            deduped.append(tc)
+            seen.add(tc_id)
+    if not deduped:
+        return None
+
+    # Mark is_cited from `[c:<id>]` markers in the raw final-round text.
+    # Marker IDs that don't match any retrieved chunk are silently dropped
+    # (hallucinations).
+    cited_ids = extract_cited_chunk_ids(final_text)
+    for chunk in deduped:
+        chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+
+    # Collapse same-video chunks (issue #208): one entry per video_id.
+    collapsed = _collapse_by_video(deduped)
+
+    # Cap fallback (issue #176): cited pass through, non-cited sliced.
+    cited = [c for c in collapsed if c.get("is_cited")]
+    uncited = [c for c in collapsed if not c.get("is_cited")]
+    finalized = cited + uncited[:CITATIONS_MAX_COUNT]
+
+    # Suppress sources on refusal (existing behaviour).
+    if _is_refusal(final_text):
+        return None
+
+    return finalized or None

--- a/app/backend/tests/test_interrupted_sources.py
+++ b/app/backend/tests/test_interrupted_sources.py
@@ -1,0 +1,274 @@
+"""
+Regression tests for issue #277 — saved sources must match the live view even
+when the stream is interrupted or errors mid-stream (no ``[DONE]``).
+
+Before the fix, the dedup / citation-marking / same-video-collapse / cap /
+refusal-suppress pipeline ran **only** inside the ``if sse_chunk ==
+"data: [DONE]\\n\\n":`` branch of ``event_generator()``. When the upstream
+model flaked, ``stream_chat()`` yielded a ``data: {"error": ...}`` chunk and
+returned without ``[DONE]``; the ``finally`` block then persisted a list that
+had never been finalized — duplicate chunk_ids, multiple chips per video, and
+chips on answers that actually refused. The live and reloaded views disagreed.
+
+The fix routes BOTH the live ``event: sources`` path and the persist path
+through the shared pure helper ``_finalize_source_citations``, so persistence
+is identical to the finalized live view regardless of how the stream ended.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.auth.tokens import encode_token
+from backend.main import app
+from backend.routes.messages import _finalize_source_citations
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures — raw chunks the executor returns across two overlapping
+# tool rounds: a duplicate chunk_id ("c1" twice) and two chunks from the same
+# video ("v1": c1/c2). The finalized list must dedup c1 and collapse v1 to one.
+# ---------------------------------------------------------------------------
+
+_ROUND_ONE_CHUNKS = [
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Video 1",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "snippet one",
+    },
+    {
+        "chunk_id": "c2",
+        "video_id": "v1",
+        "video_title": "Video 1",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 30.0,
+        "end_seconds": 40.0,
+        "snippet": "snippet two",
+    },
+]
+
+_ROUND_TWO_CHUNKS = [
+    # Duplicate of c1 (same chunk re-fetched in a later round).
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Video 1",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "snippet one",
+    },
+    {
+        "chunk_id": "c3",
+        "video_id": "v2",
+        "video_title": "Video 2",
+        "video_url": "https://youtube.com/watch?v=def",
+        "start_seconds": 5.0,
+        "end_seconds": 15.0,
+        "snippet": "snippet three",
+    },
+]
+
+# Raw accumulator after both rounds: 4 entries (c1 dup, c2, c3), 3 unique
+# chunk_ids across 2 videos -> finalized to 2 collapsed entries.
+_RAW_ACCUMULATED = _ROUND_ONE_CHUNKS + _ROUND_TWO_CHUNKS
+
+
+def _make_overlapping_stream(answer_text: str, *, refusal: bool, append_final: bool):
+    """Build a ``mock_stream_chat`` that runs two overlapping tool rounds, yields
+    one content token, then errors WITHOUT ``[DONE]`` (interrupted stream)."""
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "round one"}))
+            await tool_executor("search_videos", json.dumps({"query": "round two"}))
+        yield f"data: {json.dumps(answer_text)}\n\n"
+        if append_final and final_text_out is not None:
+            final_text_out.append(answer_text)
+        # Upstream flakes: error payload, then return WITHOUT [DONE].
+        yield 'data: {"error": "upstream flaked"}\n\n'
+
+    return mock_stream_chat
+
+
+def _round_executor():
+    """An execute_tool mock that returns round-one chunks on the first call and
+    round-two chunks on the second, simulating overlapping retrieval."""
+    calls = {"n": 0}
+
+    async def mock_execute_tool(
+        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+    ):
+        calls["n"] += 1
+        chunks = _ROUND_ONE_CHUNKS if calls["n"] == 1 else _ROUND_TWO_CHUNKS
+        return {"ok": True, "text": "context", "chunks": chunks}
+
+    return mock_execute_tool
+
+
+async def _drive_request(mock_stream_chat, mock_execute_tool):
+    """Drive a single message POST through the ASGI app with all boundaries
+    mocked. Returns (response, mock_create) so callers can inspect persistence."""
+    test_user_id = str(uuid4())
+    test_conv_id = str(uuid4())
+    valid_token = encode_token(test_user_id)
+
+    async def mock_get_user_by_id(user_id):
+        return {
+            "id": test_user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    async def mock_get_conversation(conv_id, user_id):
+        return {
+            "id": test_conv_id,
+            "user_id": test_user_id,
+            "title": "Test",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    # First call: user message. Second call: assistant message in finally.
+    mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+
+    async def mock_list_messages(conv_id, user_id):
+        return []
+
+    async def mock_list_videos():
+        return [
+            {"id": "v1", "title": "Video 1", "url": "https://youtube.com/watch?v=abc"},
+            {"id": "v2", "title": "Video 2", "url": "https://youtube.com/watch?v=def"},
+        ]
+
+    with (
+        patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+        patch("backend.db.repository.get_conversation", mock_get_conversation),
+        patch("backend.db.repository.create_message", mock_create),
+        patch("backend.db.repository.list_messages", mock_list_messages),
+        patch("backend.db.repository.list_videos", mock_list_videos),
+        patch("backend.routes.messages.stream_chat", mock_stream_chat),
+        patch("backend.routes.messages.execute_tool", mock_execute_tool),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/conversations/{test_conv_id}/messages",
+                json={"content": "question about video"},
+                headers={"Cookie": f"session={valid_token}"},
+            )
+
+    return response, mock_create
+
+
+class TestInterruptedStreamPersistence:
+    """The persist path must finalize the raw accumulator identically to the
+    live path even when the stream never reaches ``[DONE]``."""
+
+    async def test_interrupted_stream_persists_deduped_collapsed_sources(self) -> None:
+        """An errored stream (no [DONE]) persists deduplicated, same-video
+        collapsed sources — not the raw/duplicate accumulator."""
+        answer = "The video explains it works."
+        mock_stream_chat = _make_overlapping_stream(answer, refusal=False, append_final=True)
+        response, mock_create = await _drive_request(mock_stream_chat, _round_executor())
+
+        assert response.status_code == 200
+        # user msg + assistant msg
+        assert mock_create.call_count == 2, f"expected 2 calls, got {mock_create.call_count}"
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+
+        sources = assistant_kwargs["sources"]
+        assert sources is not None
+        # No duplicate chunk_ids survived.
+        chunk_ids = [s.get("chunk_id") for s in sources]
+        assert len(chunk_ids) == len(set(chunk_ids)), f"duplicate chunk_ids persisted: {chunk_ids}"
+        # One entry per video_id (collapsed).
+        video_ids = [s.get("video_id") for s in sources]
+        assert len(video_ids) == len(set(video_ids)), f"same-video not collapsed: {video_ids}"
+        assert set(video_ids) == {"v1", "v2"}
+        # Each collapsed entry carries segment_count.
+        assert all("segment_count" in s for s in sources)
+        # Strictly fewer than the raw accumulated count (4 raw -> 2 finalized).
+        assert len(sources) < len(_RAW_ACCUMULATED)
+        assert len(sources) == 2
+
+    async def test_interrupted_stream_matches_finalized_helper(self) -> None:
+        """Persisted sources equal what the shared finalizer produces from the
+        raw accumulated chunks — locking persist to the same pipeline as live."""
+        answer = "The video explains it works."
+        mock_stream_chat = _make_overlapping_stream(answer, refusal=False, append_final=True)
+        response, mock_create = await _drive_request(mock_stream_chat, _round_executor())
+
+        assert response.status_code == 200
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        expected = _finalize_source_citations(list(_RAW_ACCUMULATED), answer)
+        assert assistant_kwargs["sources"] == expected
+
+    async def test_interrupted_refusal_persists_sources_none(self) -> None:
+        """When the interrupted answer is a refusal, persisted sources is None —
+        no misleading chip on reload, matching the live suppression."""
+        refusal = "Those topics are not covered in any of the videos."
+        mock_stream_chat = _make_overlapping_stream(refusal, refusal=True, append_final=True)
+        response, mock_create = await _drive_request(mock_stream_chat, _round_executor())
+
+        assert response.status_code == 200
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] is None, (
+            f"interrupted refusal should persist sources=None; "
+            f"got {assistant_kwargs['sources']!r}"
+        )
+
+
+class TestFinalizeSourceCitationsUnit:
+    """Direct unit tests of the shared finalizer."""
+
+    def test_empty_input_returns_none(self) -> None:
+        assert _finalize_source_citations([], "any text") is None
+
+    def test_dedups_duplicate_chunk_ids(self) -> None:
+        chunks = [
+            {"chunk_id": "c1", "video_id": "v1", "start_seconds": 1.0},
+            {"chunk_id": "c1", "video_id": "v1", "start_seconds": 1.0},
+        ]
+        result = _finalize_source_citations(chunks, "")
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["chunk_id"] == "c1"
+
+    def test_collapses_same_video(self) -> None:
+        chunks = [
+            {"chunk_id": "c1", "video_id": "v1", "start_seconds": 10.0},
+            {"chunk_id": "c2", "video_id": "v1", "start_seconds": 30.0},
+            {"chunk_id": "c3", "video_id": "v2", "start_seconds": 5.0},
+        ]
+        result = _finalize_source_citations(chunks, "")
+        assert result is not None
+        video_ids = sorted(s["video_id"] for s in result)
+        assert video_ids == ["v1", "v2"]
+        # v1 collapsed two segments.
+        v1 = next(s for s in result if s["video_id"] == "v1")
+        assert v1["segment_count"] == 2
+
+    def test_refusal_text_returns_none(self) -> None:
+        chunks = [{"chunk_id": "c1", "video_id": "v1", "start_seconds": 1.0}]
+        refusal = "Those topics are not covered in any of the videos."
+        assert _finalize_source_citations(chunks, refusal) is None
+
+    def test_chunks_without_chunk_id_return_none(self) -> None:
+        chunks = [{"video_id": "v1", "start_seconds": 1.0}]
+        assert _finalize_source_citations(chunks, "") is None


### PR DESCRIPTION
Fixes #277

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `6e3391b8-954c-4394-b484-37171d66b173`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.