### PR TITLE
[bench-OF] impl: address issue

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -171,6 +171,7 @@ async def create_message(
     async def event_generator() -> AsyncGenerator[str, None]:
         full_response: list[str] = []
         final_text_buf: list[str] = []
+        persisted_sources: list[dict] | None = None
         # Two-tier citations (issue #176): strip `[c:<id>]` markers from the
         # stream; use them at [DONE] to flag is_cited on retrieved chunks.
         marker_stripper = CitationMarkerStripper()
@@ -229,6 +230,15 @@ async def create_message(
                         if not _is_refusal(final_text):
                             sources_json = json.dumps(source_citations)
                             yield f"event: sources\ndata: {sources_json}\n\n"
+                            # Single source of truth: persist exactly what we
+                            # emitted live. Set AFTER the yield so that if the
+                            # consumer (Starlette) fails to send this chunk and
+                            # aborts the generator at the suspended yield, this
+                            # line never runs and we persist sources=None —
+                            # matching the client, which never received the
+                            # event. If the send succeeds the generator is
+                            # resumed for the next chunk and this line runs.
+                            persisted_sources = source_citations
                     full_response.append(sse_chunk)
                     yield sse_chunk
                     continue
@@ -256,22 +266,14 @@ async def create_message(
             # can exit cleanly.
             assistant_text = _extract_text_from_sse(full_response)
             if assistant_text:
-                # Apply the same refusal detection used for the live SSE
-                # `event: sources` suppression so reloading the conversation
-                # later doesn't bring the misleading chip back. Prefer the
-                # final-round text when available — it's what the SSE path
-                # checks — and fall back to the full reconstructed text if
-                # the final_text buffer wasn't populated (e.g. pre-tool
-                # flow). If the message is a refusal we persist sources=None
-                # regardless of what the tool calls retrieved; the frontend
-                # renders the chip based on the stored field, so dropping
-                # it here keeps the reload UX consistent with the stream.
-                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
-                sources_to_persist: list[dict] | None = (
-                    None
-                    if not source_citations or _is_refusal(refusal_check_text)
-                    else source_citations
-                )
+                # Persist exactly the sources that were emitted live (set right
+                # after the `event: sources` yield succeeded). If no sources
+                # event reached the client — interrupted before [DONE]
+                # finalization, errored mid-stream, or suppressed as a
+                # refusal — this stays None, so reload matches the live view.
+                # This replaces the previous independent re-derivation, which
+                # could diverge from what was actually shown.
+                sources_to_persist: list[dict] | None = persisted_sources
                 try:
                     await asyncio.shield(
                         repository.create_message(

--- a/app/backend/tests/test_message_persist_shield.py
+++ b/app/backend/tests/test_message_persist_shield.py
@@ -218,3 +218,253 @@ class TestEventGeneratorPersistsOnCancel:
         second_call_kwargs = mock_create.call_args_list[1].kwargs
         assert second_call_kwargs["role"] == "assistant"
         assert "Hello world" in second_call_kwargs["content"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #277 — persisted sources must match what was emitted live
+# ---------------------------------------------------------------------------
+
+# Two chunks from the same video so the [DONE] pipeline's collapse step is
+# exercised: the emitted/persisted payload must contain a single collapsed
+# entry with segment_count == 2.
+_SOURCE_CHUNKS: list[dict[str, Any]] = [
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Test Video",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 30.0,
+        "end_seconds": 40.0,
+        "snippet": "Snippet one",
+    },
+    {
+        "chunk_id": "c2",
+        "video_id": "v1",
+        "video_title": "Test Video",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "Snippet two",
+    },
+]
+
+
+async def _fake_execute_tool(name: str, raw_args: str, **kwargs: Any) -> dict[str, Any]:
+    # Return fresh copies — the route mutates chunk dicts (is_cited).
+    return {"ok": True, "text": "ctx", "chunks": [dict(c) for c in _SOURCE_CHUNKS]}
+
+
+def _route_patches(
+    fake_conv: dict[str, Any],
+    fake_stream: Any,
+    mock_create: AsyncMock,
+) -> contextlib.ExitStack:
+    """Enter the standard patch set for driving event_generator manually."""
+    stack = contextlib.ExitStack()
+    stack.enter_context(
+        patch(
+            "backend.routes.messages.repository.get_conversation",
+            new_callable=AsyncMock,
+            return_value=fake_conv,
+        )
+    )
+    stack.enter_context(patch("backend.routes.messages.repository.create_message", mock_create))
+    stack.enter_context(
+        patch(
+            "backend.routes.messages.repository.list_messages",
+            new_callable=AsyncMock,
+            return_value=[{"role": "user", "content": "hi"}],
+        )
+    )
+    stack.enter_context(
+        patch(
+            "backend.routes.messages.repository.list_videos",
+            new_callable=AsyncMock,
+            return_value=[{"id": "v1"}],
+        )
+    )
+    stack.enter_context(
+        patch("backend.routes.messages.rate_limit.check_and_record", new_callable=AsyncMock)
+    )
+    stack.enter_context(patch("backend.routes.messages.stream_chat", side_effect=fake_stream))
+    stack.enter_context(patch("backend.routes.messages.execute_tool", _fake_execute_tool))
+    stack.enter_context(
+        patch("backend.routes.messages._maybe_set_conversation_title", new_callable=AsyncMock)
+    )
+    return stack
+
+
+class TestSourcesPersistMatchesEmitted:
+    """Regression tests for issue #277: the sources persisted with an
+    assistant message must be exactly the sources emitted via the live
+    `event: sources` SSE event — and None when that event never reached
+    the client (interrupted or errored mid-stream)."""
+
+    @staticmethod
+    async def _fake_stream_clean(*args: Any, **kwargs: Any):
+        tool_executor = kwargs.get("tool_executor")
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps('Grounded answer about the video.')}\n\n"
+        final_text_out = kwargs.get("final_text_out")
+        if final_text_out is not None:
+            final_text_out.append("Grounded answer about the video.")
+        yield "data: [DONE]\n\n"
+
+    @staticmethod
+    async def _fake_stream_error(*args: Any, **kwargs: Any):
+        # The flaky-upstream case: an error chunk instead of [DONE].
+        tool_executor = kwargs.get("tool_executor")
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps('Partial answer')}\n\n"
+        yield 'data: {"error": "upstream model failure"}\n\n'
+
+    def _setup(self, fake_user: dict[str, Any], fake_stream: Any):
+        fake_conv = {
+            "id": str(uuid4()),
+            "user_id": fake_user["id"],
+            "title": "New Conversation",
+        }
+        mock_create = AsyncMock(
+            side_effect=[
+                {"id": str(uuid4())},  # user-message insert
+                {"id": str(uuid4())},  # assistant-message insert (finally)
+            ]
+        )
+        return fake_conv, mock_create, _route_patches(fake_conv, fake_stream, mock_create)
+
+    @staticmethod
+    def _parse_sources_payload(chunk: str) -> list[dict[str, Any]]:
+        assert chunk.startswith("event: sources\ndata: ")
+        payload = json.loads(chunk.split("data: ", 1)[1].strip())
+        assert isinstance(payload, list)
+        return payload
+
+    async def test_persisted_sources_equal_live_sources_on_clean_completion(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """Clean completion: persist == emitted, both collapsed/deduped."""
+        from backend.routes.messages import MessageCreate, create_message
+
+        fake_conv, mock_create, patches = self._setup(bypass_auth, self._fake_stream_clean)
+        with patches:
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=bypass_auth,
+            )
+            chunks = [c async for c in resp.body_iterator]
+            await asyncio.sleep(0.1)
+
+        sources_chunks = [c for c in chunks if c.startswith("event: sources")]
+        assert len(sources_chunks) == 1, f"expected one sources event, got {chunks!r}"
+        emitted = self._parse_sources_payload(sources_chunks[0])
+        # The two same-video chunks collapsed into one entry.
+        assert len(emitted) == 1
+        assert emitted[0]["segment_count"] == 2
+
+        assert mock_create.call_count == 2
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] == emitted, (
+            "persisted sources must deep-equal the live-emitted payload"
+        )
+
+    async def test_interrupt_before_sources_sent_persists_none(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """The reported bug: the generator is aborted at the sources yield
+        (the chunk never reached the client), so persistence must be None —
+        not the collapsed source set the old re-derivation would save."""
+        from backend.routes.messages import MessageCreate, create_message
+
+        fake_conv, mock_create, patches = self._setup(bypass_auth, self._fake_stream_clean)
+        with patches:
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=bypass_auth,
+            )
+            body_iter = resp.body_iterator
+            chunk = ""
+            for _ in range(10):
+                chunk = await body_iter.__anext__()
+                if chunk.startswith("event: sources"):
+                    break
+            assert chunk.startswith("event: sources"), "sources event never produced"
+            # Generator is suspended AT the sources yield — the capture line
+            # after it has not run. Closing here models the consumer failing
+            # to send that chunk.
+            await body_iter.aclose()
+            await asyncio.sleep(0.1)
+
+        assert mock_create.call_count == 2
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] is None, (
+            f"sources event never delivered → must persist None, "
+            f"got {assistant_kwargs['sources']!r}"
+        )
+
+    async def test_sources_sent_then_interrupted_persists_sources(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """Once the consumer pulled past the sources yield (event delivered),
+        an interruption must still persist the emitted sources."""
+        from backend.routes.messages import MessageCreate, create_message
+
+        fake_conv, mock_create, patches = self._setup(bypass_auth, self._fake_stream_clean)
+        with patches:
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=bypass_auth,
+            )
+            body_iter = resp.body_iterator
+            sources_chunk = ""
+            for _ in range(10):
+                sources_chunk = await body_iter.__anext__()
+                if sources_chunk.startswith("event: sources"):
+                    break
+            assert sources_chunk.startswith("event: sources")
+            # Pull one more chunk: the resume past the sources yield runs the
+            # capture, and the generator suspends at the [DONE] yield.
+            done_chunk = await body_iter.__anext__()
+            assert done_chunk == "data: [DONE]\n\n"
+            await body_iter.aclose()
+            await asyncio.sleep(0.1)
+
+        emitted = self._parse_sources_payload(sources_chunk)
+        assert mock_create.call_count == 2
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert assistant_kwargs["sources"] == emitted, (
+            "client received the sources event → persistence must keep it"
+        )
+
+    async def test_error_midstream_before_done_persists_none(
+        self, bypass_auth: dict[str, Any]
+    ) -> None:
+        """Upstream error instead of [DONE]: no sources event is emitted,
+        so the persisted partial answer must carry sources=None."""
+        from backend.routes.messages import MessageCreate, create_message
+
+        fake_conv, mock_create, patches = self._setup(bypass_auth, self._fake_stream_error)
+        with patches:
+            resp = await create_message(
+                conv_id=fake_conv["id"],
+                body=MessageCreate(content="hi"),
+                current_user=bypass_auth,
+            )
+            chunks = [c async for c in resp.body_iterator]
+            await asyncio.sleep(0.1)
+
+        assert not any(c.startswith("event: sources") for c in chunks), (
+            f"no sources event expected on mid-stream error, got {chunks!r}"
+        )
+        assert mock_create.call_count == 2
+        assistant_kwargs = mock_create.call_args_list[1].kwargs
+        assert assistant_kwargs["role"] == "assistant"
+        assert "Partial answer" in assistant_kwargs["content"]
+        assert assistant_kwargs["sources"] is None


### PR DESCRIPTION
Fixes #277

**Benchmark cell:** `OF` (plan=Opus, impl=Fable)
**Source run-id:** `e774a0f9-3eeb-48c4-b00b-68cb382fd25b`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.