### PR TITLE
[bench-FO] impl: persist sources matching the live stream on interrupted answers

### DIFF
--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -118,11 +118,12 @@ async def create_message(
 
     # 5. Set up tool plumbing. All retrieval happens inside the LLM loop via
     # tool calls — no pre-retrieval runs here. The executor closure collects
-    # every chunk returned by any tool call so the final SSE `sources` event
-    # lists exactly what the model actually read. The video_id whitelist is
-    # only consulted by the transcript tool (it guards against hallucinated
-    # ids); the search tools ignore it.
-    source_citations: list[dict] = []
+    # every chunk returned by any tool call into ``tool_chunks_acc`` (the raw
+    # accumulator) so the final SSE `sources` event lists exactly what the
+    # model actually read. The dedup/collapse/cap/refusal pipeline runs once,
+    # in ``_finalize_sources``, at [DONE]. The video_id whitelist is only
+    # consulted by the transcript tool (it guards against hallucinated ids);
+    # the search tools ignore it.
     tool_chunks_acc: list[dict] = []
     embedding_cache: dict[str, list[float]] = {}
     tools_param: list[dict] | None = None
@@ -165,12 +166,17 @@ async def create_message(
         max_tool_calls = LLM_TOOLS_MAX_PER_TURN
 
     # 6. Stream the response. The model drives retrieval via tool calls;
-    # chunks it pulls flow into source_citations via tool_chunks_acc.
+    # chunks it pulls flow into ``tool_chunks_acc``.
     # ``final_text_buf`` receives the assistant's final-round text so the
     # refusal check ignores inter-round commentary ("let me try semantic").
     async def event_generator() -> AsyncGenerator[str, None]:
         full_response: list[str] = []
         final_text_buf: list[str] = []
+        # The exact source list handed to the client (after _finalize_sources),
+        # or None if no sources event ever reached the client (interrupted,
+        # errored, refused, or no retrieval). This is what gets persisted, so
+        # the reloaded view always matches the live view by construction.
+        emitted_sources: list[dict] | None = None
         # Two-tier citations (issue #176): strip `[c:<id>]` markers from the
         # stream; use them at [DONE] to flag is_cited on retrieved chunks.
         marker_stripper = CitationMarkerStripper()
@@ -195,40 +201,25 @@ async def create_message(
                         tail_chunk = f"data: {json.dumps(tail)}\n\n"
                         full_response.append(tail_chunk)
                         yield tail_chunk
-                    # Dedup tool-loaded chunks into source_citations (existing).
-                    if tool_chunks_acc:
-                        seen: set[str] = set()
-                        for tc in tool_chunks_acc:
-                            tc_id = tc.get("chunk_id")
-                            if tc_id and tc_id not in seen:
-                                source_citations.append(tc)
-                                seen.add(tc_id)
-                    # Mark is_cited from markers in the raw final-round text.
-                    # Marker IDs that don't match any retrieved chunk are
-                    # silently dropped (hallucinations).
-                    if source_citations:
-                        final_text_raw = final_text_buf[0] if final_text_buf else ""
-                        cited_ids = extract_cited_chunk_ids(final_text_raw)
-                        for chunk in source_citations:
-                            chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
-                        # Collapse same-video chunks (issue #208): keep one
-                        # entry per video_id, choosing the earliest-cited
-                        # timestamp as the representative.
-                        source_citations[:] = _collapse_by_video(source_citations)
-                        # Cap fallback (issue #176): cited pass through, non-cited sliced.
-                        cited = [c for c in source_citations if c.get("is_cited")]
-                        uncited = [c for c in source_citations if not c.get("is_cited")]
-                        source_citations[:] = cited + uncited[:CITATIONS_MAX_COUNT]
-                    # Suppress sources on refusal (existing behaviour).
-                    if source_citations:
-                        final_text = (
-                            final_text_buf[0]
-                            if final_text_buf
-                            else _extract_text_from_sse(full_response)
-                        )
-                        if not _is_refusal(final_text):
-                            sources_json = json.dumps(source_citations)
-                            yield f"event: sources\ndata: {sources_json}\n\n"
+                    # Finalize the sources list exactly once (dedup → is_cited →
+                    # collapse-by-video → cap → refusal gate). Emit and persist
+                    # the *same* list, so live and reload always agree.
+                    final_text = (
+                        final_text_buf[0]
+                        if final_text_buf
+                        else _extract_text_from_sse(full_response)
+                    )
+                    finalized = _finalize_sources(tool_chunks_acc, final_text)
+                    if finalized:
+                        sources_json = json.dumps(finalized)
+                        yield f"event: sources\ndata: {sources_json}\n\n"
+                        # Reached only after the consumer pulled the next event,
+                        # i.e. the sources event was actually handed to the
+                        # client. A disconnect that lands on the yield above
+                        # (GeneratorExit/CancelledError) leaves emitted_sources
+                        # = None, so the persisted row matches the nothing the
+                        # user saw.
+                        emitted_sources = finalized
                     full_response.append(sse_chunk)
                     yield sse_chunk
                     continue
@@ -256,22 +247,12 @@ async def create_message(
             # can exit cleanly.
             assistant_text = _extract_text_from_sse(full_response)
             if assistant_text:
-                # Apply the same refusal detection used for the live SSE
-                # `event: sources` suppression so reloading the conversation
-                # later doesn't bring the misleading chip back. Prefer the
-                # final-round text when available — it's what the SSE path
-                # checks — and fall back to the full reconstructed text if
-                # the final_text buffer wasn't populated (e.g. pre-tool
-                # flow). If the message is a refusal we persist sources=None
-                # regardless of what the tool calls retrieved; the frontend
-                # renders the chip based on the stored field, so dropping
-                # it here keeps the reload UX consistent with the stream.
-                refusal_check_text = final_text_buf[0] if final_text_buf else assistant_text
-                sources_to_persist: list[dict] | None = (
-                    None
-                    if not source_citations or _is_refusal(refusal_check_text)
-                    else source_citations
-                )
+                # Persist exactly what was emitted to the client. Interrupted,
+                # errored, or refused streams never reach the emit, so
+                # emitted_sources stays None and the reloaded view matches the
+                # nothing the user saw live. No separate refusal/dedup re-
+                # derivation here — _finalize_sources already decided at [DONE].
+                sources_to_persist: list[dict] | None = emitted_sources or None
                 try:
                     await asyncio.shield(
                         repository.create_message(
@@ -464,6 +445,53 @@ async def _maybe_set_conversation_title(
         else:
             title = first_user_message.strip()
         await repository.update_conversation_title(conv_id, user_id=user_id, title=title)
+
+
+def _finalize_sources(tool_chunks: list[dict[str, Any]], final_text: str) -> list[dict[str, Any]]:
+    """Turn the raw tool-chunk accumulator into the final source-citation list.
+
+    Pure and side-effect-free: the input dicts are never mutated (each kept
+    entry is copied with ``dict(tc)``). This is the single source of truth for
+    what the client sees AND what gets persisted, so the live and reloaded
+    views agree by construction regardless of how the stream ended.
+
+    Pipeline, in order:
+    1. Dedup by ``chunk_id``, preserving first-seen order; skip falsy ids.
+    2. Mark ``is_cited`` from ``[c:<id>]`` markers in ``final_text``. Marker
+       ids that don't match any retrieved chunk are silently dropped
+       (hallucinations).
+    3. Collapse same-video chunks to one entry per video (issue #208).
+    4. Cap (issue #176): cited entries pass through, uncited sliced to
+       ``CITATIONS_MAX_COUNT``.
+    5. Refusal gate: an off-topic refusal persists/emits no sources at all.
+
+    Returns ``[]`` when there are no chunks or the answer is a refusal.
+    """
+    if not tool_chunks:
+        return []
+
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for tc in tool_chunks:
+        tc_id = tc.get("chunk_id")
+        if tc_id and tc_id not in seen:
+            deduped.append(dict(tc))
+            seen.add(tc_id)
+    if not deduped:
+        return []
+
+    cited_ids = extract_cited_chunk_ids(final_text)
+    for chunk in deduped:
+        chunk["is_cited"] = chunk.get("chunk_id") in cited_ids
+
+    collapsed = _collapse_by_video(deduped)
+    cited = [c for c in collapsed if c.get("is_cited")]
+    uncited = [c for c in collapsed if not c.get("is_cited")]
+    capped = cited + uncited[:CITATIONS_MAX_COUNT]
+
+    if _is_refusal(final_text):
+        return []
+    return capped
 
 
 def _collapse_by_video(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -714,6 +714,116 @@ class TestExtractTextFromSse:
         assert _extract_text_from_sse(chunks) == "Hello"
 
 
+class TestFinalizeSources:
+    """Unit tests for _finalize_sources — the single source-finalization
+    pipeline (dedup → is_cited → collapse-by-video → cap → refusal gate).
+
+    Both the live `event: sources` emit and the persisted row come from this
+    one function, so the live and reloaded views always agree (issue #277).
+    """
+
+    def _chunk(self, chunk_id: str, video_id: str, start: float = 0.0) -> dict:
+        return {
+            "chunk_id": chunk_id,
+            "video_id": video_id,
+            "video_title": f"Video {video_id}",
+            "video_url": f"https://youtube.com/watch?v={video_id}",
+            "start_seconds": start,
+            "end_seconds": start + 10.0,
+            "snippet": f"snippet {chunk_id}",
+        }
+
+    def test_empty_input_returns_empty(self) -> None:
+        from backend.routes.messages import _finalize_sources
+
+        assert _finalize_sources([], "any text") == []
+
+    def test_dedup_by_chunk_id(self) -> None:
+        """Same chunk_id appearing twice collapses to a single entry."""
+        from backend.routes.messages import _finalize_sources
+
+        chunks = [
+            self._chunk("c1", "v1"),
+            self._chunk("c1", "v1"),  # duplicate id
+        ]
+        result = _finalize_sources(chunks, "no markers")
+        assert len(result) == 1
+        assert result[0]["chunk_id"] == "c1"
+
+    def test_skips_falsy_chunk_ids(self) -> None:
+        """Chunks with a missing/empty chunk_id are dropped."""
+        from backend.routes.messages import _finalize_sources
+
+        chunks = [
+            {"chunk_id": "", "video_id": "v1", "video_title": "t", "video_url": "u"},
+            {"video_id": "v2", "video_title": "t", "video_url": "u"},  # no chunk_id
+            self._chunk("c3", "v3"),
+        ]
+        result = _finalize_sources(chunks, "no markers")
+        assert len(result) == 1
+        assert result[0]["chunk_id"] == "c3"
+
+    def test_same_video_collapses_with_segment_count(self) -> None:
+        """Two chunks from one video collapse to one entry carrying
+        segment_count == 2."""
+        from backend.routes.messages import _finalize_sources
+
+        chunks = [
+            self._chunk("c1", "v1", start=10.0),
+            self._chunk("c2", "v1", start=20.0),
+        ]
+        result = _finalize_sources(chunks, "no markers")
+        assert len(result) == 1
+        assert result[0]["video_id"] == "v1"
+        assert result[0]["segment_count"] == 2
+
+    def test_is_cited_marked_from_markers(self) -> None:
+        """A [c:<id>] marker in the final text flags the matching entry."""
+        from backend.routes.messages import _finalize_sources
+
+        chunks = [self._chunk("c1", "v1"), self._chunk("c2", "v2")]
+        result = _finalize_sources(chunks, "As shown [c:c1] this works.")
+        by_video = {r["video_id"]: r for r in result}
+        assert by_video["v1"]["is_cited"] is True
+        assert by_video["v2"]["is_cited"] is False
+
+    def test_cap_uncited_sliced_cited_pass_through(self) -> None:
+        """Cited entries always pass through; uncited are sliced to
+        CITATIONS_MAX_COUNT."""
+        from backend.config import CITATIONS_MAX_COUNT
+        from backend.routes.messages import _finalize_sources
+
+        # 3 cited videos + (CAP + 5) uncited videos, all distinct video_ids.
+        cited_chunks = [self._chunk(f"cited{i}", f"cv{i}") for i in range(3)]
+        uncited_chunks = [self._chunk(f"unc{i}", f"uv{i}") for i in range(CITATIONS_MAX_COUNT + 5)]
+        markers = " ".join(f"[c:cited{i}]" for i in range(3))
+        result = _finalize_sources(cited_chunks + uncited_chunks, f"answer {markers}")
+
+        cited = [r for r in result if r.get("is_cited")]
+        uncited = [r for r in result if not r.get("is_cited")]
+        assert len(cited) == 3
+        assert len(uncited) == CITATIONS_MAX_COUNT
+
+    def test_refusal_returns_empty_even_with_chunks(self) -> None:
+        """A refusal answer persists/emits no sources, regardless of chunks."""
+        from backend.routes.messages import _finalize_sources
+
+        chunks = [self._chunk("c1", "v1")]
+        refusal = "I'm sorry, the video library does not cover that topic."
+        assert _finalize_sources(chunks, refusal) == []
+
+    def test_does_not_mutate_input(self) -> None:
+        """The accumulator dicts are copied, never mutated (purity guard)."""
+        from backend.routes.messages import _finalize_sources
+
+        chunk = self._chunk("c1", "v1")
+        original = dict(chunk)
+        _finalize_sources([chunk], "As shown [c:c1].")
+        assert chunk == original
+        assert "is_cited" not in chunk
+        assert "segment_count" not in chunk
+
+
 class TestRefusalSourcesSuppressionIntegration:
     """Integration tests for SSE sources suppression on refusals.
 

--- a/app/backend/tests/test_sources_interrupted.py
+++ b/app/backend/tests/test_sources_interrupted.py
@@ -1,0 +1,309 @@
+"""
+Regression tests for issue #277 — a saved answer's sources must match what the
+user saw streaming live, regardless of whether the stream completed cleanly or
+was interrupted/errored mid-answer.
+
+The invariant under test: the source list persisted with the assistant message
+is *exactly* the list that was handed to the client via the `event: sources`
+SSE event (after dedup → is_cited → collapse-by-video → cap → refusal gate), or
+``None`` when no sources event ever reached the client. There is no second,
+divergent finalization path in the persist branch.
+
+These reuse the mock harness from test_sources_event.py: ASGITransport +
+AsyncClient, patched stream_chat / execute_tool / repository functions, and an
+AsyncMock on create_message to capture the persisted kwargs.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.auth.tokens import encode_token
+from backend.main import app
+
+
+def _two_chunks() -> list[dict]:
+    return [
+        {
+            "chunk_id": "c1",
+            "video_id": "v1",
+            "video_title": "Test Video 1",
+            "video_url": "https://youtube.com/watch?v=abc",
+            "start_seconds": 10.0,
+            "end_seconds": 20.0,
+            "snippet": "Snippet 1",
+        },
+        {
+            "chunk_id": "c2",
+            "video_id": "v2",
+            "video_title": "Test Video 2",
+            "video_url": "https://youtube.com/watch?v=def",
+            "start_seconds": 5.0,
+            "end_seconds": 15.0,
+            "snippet": "Snippet 2",
+        },
+    ]
+
+
+def _patches(mock_stream_chat, mock_create, chunks):
+    """Build the standard patch set for a messages-route integration test."""
+    test_user_id = str(uuid4())
+    test_conv_id = str(uuid4())
+    valid_token = encode_token(test_user_id)
+
+    async def mock_get_user_by_id(user_id):
+        return {
+            "id": test_user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    async def mock_get_conversation(conv_id, user_id):
+        return {
+            "id": test_conv_id,
+            "user_id": test_user_id,
+            "title": "Test",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    async def mock_execute_tool(
+        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+    ):
+        return {"ok": True, "text": "context", "chunks": chunks}
+
+    async def mock_list_messages(conv_id, user_id):
+        return []
+
+    async def mock_list_videos():
+        return [
+            {"id": "v1", "title": "Test Video 1", "url": "u1"},
+            {"id": "v2", "title": "Test Video 2", "url": "u2"},
+        ]
+
+    ctx = (
+        patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+        patch("backend.db.repository.get_conversation", mock_get_conversation),
+        patch("backend.db.repository.create_message", mock_create),
+        patch("backend.db.repository.list_messages", mock_list_messages),
+        patch("backend.db.repository.list_videos", mock_list_videos),
+        patch("backend.routes.messages.stream_chat", mock_stream_chat),
+        patch("backend.routes.messages.execute_tool", mock_execute_tool),
+    )
+    return ctx, test_conv_id, valid_token
+
+
+async def test_interrupted_stream_persists_sources_none() -> None:
+    """Upstream errors mid-answer (error payload, no [DONE]). The live view
+    never saw an `event: sources`, so the persisted row must have
+    sources=None. Direct regression test for issue #277."""
+    partial_text = "Here is the start of the answer"
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        # Tool executor populates tool_chunks_acc with 2 chunks.
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(partial_text)}\n\n"
+        # Upstream flakes: emit an error payload and return WITHOUT [DONE] and
+        # without populating final_text_out (mirrors openrouter.py on error).
+        yield 'data: {"error": "upstream flaked"}\n\n'
+
+    mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+    ctx, conv_id, token = _patches(mock_stream_chat, mock_create, _two_chunks())
+
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/conversations/{conv_id}/messages",
+                json={"content": "a question"},
+                headers={"Cookie": f"session={token}"},
+            )
+
+    assert "event: sources" not in response.text
+
+    assert mock_create.call_count == 2
+    assistant_kwargs = mock_create.call_args_list[1].kwargs
+    assert assistant_kwargs["role"] == "assistant"
+    assert assistant_kwargs["sources"] is None
+    assert assistant_kwargs["content"] == partial_text
+
+
+async def test_midstream_exception_persists_sources_none() -> None:
+    """An exception raised mid-stream still triggers the shielded persist in
+    the finally block; because no `event: sources` was emitted, sources=None."""
+    partial_text = "Partial answer before the crash"
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(partial_text)}\n\n"
+        raise RuntimeError("upstream connection dropped")
+
+    mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+    ctx, conv_id, token = _patches(mock_stream_chat, mock_create, _two_chunks())
+
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            with pytest.raises(RuntimeError):
+                async with client.stream(
+                    "POST",
+                    f"/api/conversations/{conv_id}/messages",
+                    json={"content": "a question"},
+                    headers={"Cookie": f"session={token}"},
+                ) as response:
+                    async for _ in response.aiter_bytes():
+                        pass
+
+    # The shielded persist in finally still ran (user msg + assistant msg).
+    assert mock_create.call_count == 2
+    assistant_kwargs = mock_create.call_args_list[1].kwargs
+    assert assistant_kwargs["role"] == "assistant"
+    assert assistant_kwargs["sources"] is None
+
+
+async def test_emitted_sources_equal_persisted_exactly() -> None:
+    """On a clean completion, the persisted sources kwarg is byte-for-byte the
+    same list that was emitted via `event: sources` — deduped, collapsed, and
+    capped identically. Pins the by-construction invariant."""
+    # 3 chunks across 2 videos (c1 and c3 share v1). The answer cites c1.
+    chunks = [
+        {
+            "chunk_id": "c1",
+            "video_id": "v1",
+            "video_title": "Video 1",
+            "video_url": "https://youtube.com/watch?v=abc",
+            "start_seconds": 10.0,
+            "end_seconds": 20.0,
+            "snippet": "Snippet 1",
+        },
+        {
+            "chunk_id": "c2",
+            "video_id": "v2",
+            "video_title": "Video 2",
+            "video_url": "https://youtube.com/watch?v=def",
+            "start_seconds": 5.0,
+            "end_seconds": 15.0,
+            "snippet": "Snippet 2",
+        },
+        {
+            "chunk_id": "c3",
+            "video_id": "v1",
+            "video_title": "Video 1",
+            "video_url": "https://youtube.com/watch?v=abc",
+            "start_seconds": 30.0,
+            "end_seconds": 40.0,
+            "snippet": "Snippet 3",
+        },
+    ]
+    answer_text = "The first video explains it [c:c1]."
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(answer_text)}\n\n"
+        if final_text_out is not None:
+            final_text_out.append(answer_text)
+        yield "data: [DONE]\n\n"
+
+    mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+    ctx, conv_id, token = _patches(mock_stream_chat, mock_create, chunks)
+
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/conversations/{conv_id}/messages",
+                json={"content": "a question"},
+                headers={"Cookie": f"session={token}"},
+            )
+
+    # Parse the emitted sources event out of the raw SSE body.
+    emitted = None
+    for line in response.text.split("\n"):
+        if line.startswith("data: ") and not line.startswith("data: [DONE]"):
+            candidate = line[len("data: ") :]
+            try:
+                parsed = json.loads(candidate)
+            except ValueError:
+                continue
+            if isinstance(parsed, list):
+                emitted = parsed
+                break
+    assert emitted is not None, f"no sources event found in: {response.text!r}"
+
+    assert mock_create.call_count == 2
+    persisted = mock_create.call_args_list[1].kwargs["sources"]
+
+    # Persisted == emitted, element for element.
+    assert persisted == emitted
+
+    # Collapsed to one entry per video (v1's two chunks merged).
+    video_ids = [s["video_id"] for s in persisted]
+    assert len(video_ids) == len(set(video_ids)), "duplicate video_id persisted"
+    v1_entry = next(s for s in persisted if s["video_id"] == "v1")
+    assert v1_entry["segment_count"] == 2
+    assert v1_entry["is_cited"] is True
+
+
+async def test_interrupted_refusal_persists_sources_none() -> None:
+    """A refusal cut off mid-phrase (error payload, no [DONE]) must never
+    attach source chips on reload — chips never decorate a declined answer."""
+    # Refusal phrase cut mid-word; the stream errors before [DONE].
+    truncated_refusal = "Sorry, the video library does not co"
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(truncated_refusal)}\n\n"
+        yield 'data: {"error": "upstream flaked"}\n\n'
+
+    mock_create = AsyncMock(side_effect=[{"id": str(uuid4())}, {"id": str(uuid4())}])
+    ctx, conv_id, token = _patches(mock_stream_chat, mock_create, _two_chunks())
+
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/conversations/{conv_id}/messages",
+                json={"content": "off-topic question"},
+                headers={"Cookie": f"session={token}"},
+            )
+
+    assert "event: sources" not in response.text
+
+    assert mock_create.call_count == 2
+    assistant_kwargs = mock_create.call_args_list[1].kwargs
+    assert assistant_kwargs["sources"] is None


### PR DESCRIPTION
Fixes #277

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `03b3d028-b713-439c-9f43-da2efb2e0017`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.