### PR TITLE
[bench-FO] impl: address issue

### DIFF
--- a/app/backend/alembic/versions/0006_add_conversation_video_scope.py
+++ b/app/backend/alembic/versions/0006_add_conversation_video_scope.py
@@ -1,0 +1,34 @@
+"""Add per-conversation video scope to conversations.
+
+Schema change for issue #279 (scope a conversation to specific videos):
+- conversations: scoped_video_ids TEXT[] (nullable, no default)
+
+NULL (or an empty array, normalized to NULL at write time) means the
+conversation is unscoped and retrieval searches the whole library — today's
+behavior. A non-null array restricts retrieval and citations to those video
+ids. The column is nullable with no default so all existing rows upgrade
+in-place as unscoped.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS scoped_video_ids TEXT[]")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS scoped_video_ids")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -253,6 +253,7 @@ async def keyword_search(
     top_k: int,
     language: str = "english",
     allowed_source_types: list[str] | None = None,
+    video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
@@ -265,6 +266,11 @@ async def keyword_search(
             this list are excluded. Defaults to ['youtube'] which is the
             backwards-compatible behavior for callers that don't yet know
             about Dynamous content (issue #147).
+        video_ids: Per-conversation video scope (issue #279). When non-empty,
+            restrict matches to chunks whose video_id is in this list. None or
+            an empty list means no scope filter (search the whole library).
+            This composes with `allowed_source_types` via AND — scoping can
+            never widen the source-type ACL.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -273,20 +279,38 @@ async def keyword_search(
     if allowed_source_types is None:
         allowed_source_types = ["youtube"]
     async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
-            FROM chunks
-            WHERE search_vector @@ plainto_tsquery($1)
-              AND source_type = ANY($3::text[])
-            ORDER BY rank DESC
-            LIMIT $2
-            """,
-            query,
-            top_k,
-            allowed_source_types,
-        )
+        if video_ids:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                FROM chunks
+                WHERE search_vector @@ plainto_tsquery($1)
+                  AND source_type = ANY($3::text[])
+                  AND video_id = ANY($4::text[])
+                ORDER BY rank DESC
+                LIMIT $2
+                """,
+                query,
+                top_k,
+                allowed_source_types,
+                video_ids,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       ts_rank(search_vector, plainto_tsquery($1)) AS rank
+                FROM chunks
+                WHERE search_vector @@ plainto_tsquery($1)
+                  AND source_type = ANY($3::text[])
+                ORDER BY rank DESC
+                LIMIT $2
+                """,
+                query,
+                top_k,
+                allowed_source_types,
+            )
     return [dict(r) for r in rows]
 
 
@@ -294,6 +318,7 @@ async def vector_search_pg(
     query_embedding: list[float],
     top_k: int,
     allowed_source_types: list[str] | None = None,
+    video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
@@ -311,6 +336,10 @@ async def vector_search_pg(
             compatibility (issue #147). The pool's `hnsw.iterative_scan =
             relaxed_order` setting (see db/postgres.py) keeps the HNSW index
             usable under this filter.
+        video_ids: Per-conversation video scope (issue #279). When non-empty,
+            restrict matches to chunks whose video_id is in this list. None or
+            an empty list means no scope filter (search the whole library).
+            Composes with `allowed_source_types` via AND.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -320,19 +349,36 @@ async def vector_search_pg(
         allowed_source_types = ["youtube"]
     embedding_json = json.dumps(query_embedding)
     async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
-                   embedding::vector <=> $1::vector AS distance
-            FROM chunks
-            WHERE source_type = ANY($3::text[])
-            ORDER BY distance
-            LIMIT $2
-            """,
-            embedding_json,
-            top_k,
-            allowed_source_types,
-        )
+        if video_ids:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       embedding::vector <=> $1::vector AS distance
+                FROM chunks
+                WHERE source_type = ANY($3::text[])
+                  AND video_id = ANY($4::text[])
+                ORDER BY distance
+                LIMIT $2
+                """,
+                embedding_json,
+                top_k,
+                allowed_source_types,
+                video_ids,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                       embedding::vector <=> $1::vector AS distance
+                FROM chunks
+                WHERE source_type = ANY($3::text[])
+                ORDER BY distance
+                LIMIT $2
+                """,
+                embedding_json,
+                top_k,
+                allowed_source_types,
+            )
     return [dict(r) for r in rows]
 
 
@@ -475,6 +521,29 @@ async def update_conversation_title(conv_id: str, user_id: str, title: str) -> b
         result = await conn.execute(
             "UPDATE conversations SET title = $1, updated_at = $2 WHERE id = $3 AND user_id = $4",
             title,
+            _now(),
+            conv_id,
+            user_id,
+        )
+        return result != "UPDATE 0"  # type: ignore[no-any-return]
+
+
+async def update_conversation_scope(
+    conv_id: str, user_id: str, video_ids: list[str] | None
+) -> bool:
+    """Set (or clear) the per-conversation video scope (issue #279).
+
+    An empty list is normalized to NULL so a cleared scope behaves identically
+    to a never-scoped conversation (search the whole library). Owner-scoped
+    like ``update_conversation_title``: returns False if the conversation does
+    not belong to the user.
+    """
+    scope = video_ids if video_ids else None
+    async with _acquire() as conn:
+        result = await conn.execute(
+            "UPDATE conversations SET scoped_video_ids = $1, updated_at = $2 "
+            "WHERE id = $3 AND user_id = $4",
+            scope,
             _now(),
             conv_id,
             user_id,

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -40,6 +40,7 @@ async def retrieve_hybrid(
     query_embedding: list[float],
     top_k: int = 5,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -52,6 +53,10 @@ async def retrieve_hybrid(
             = 'dynamous'`) is included alongside the default YouTube content.
             Non-members see YouTube chunks only. The filter is applied at the
             SQL layer — non-member retrieval never touches Dynamous chunks.
+        video_ids: Per-conversation video scope (issue #279). When non-empty,
+            both the keyword and vector legs are restricted to these video ids
+            so the RRF merge cannot surface out-of-scope chunks. None or empty
+            means no scope filter (search the whole library).
 
     Returns:
         A list of dicts (length <= top_k), each containing:
@@ -88,11 +93,13 @@ async def retrieve_hybrid(
         top_k=fetch_k,
         language=KEYWORD_LANGUAGE,
         allowed_source_types=allowed_source_types,
+        video_ids=video_ids,
     )
     vector_task = repository.vector_search_pg(
         query_embedding,
         top_k=fetch_k,
         allowed_source_types=allowed_source_types,
+        video_ids=video_ids,
     )
 
     keyword_hits, vector_hits = await keyword_task, await vector_task

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -410,6 +410,7 @@ async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Hybrid (keyword + semantic via RRF) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -425,7 +426,9 @@ async def execute_search_hybrid(
 
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
+        chunks = await retrieve_hybrid(
+            query, embedding, top_k=top_k, is_member=is_member, video_ids=video_ids
+        )
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -439,6 +442,7 @@ async def execute_search_hybrid(
 async def execute_search_keyword(
     raw_arguments: str | dict,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Keyword-only (tsvector FTS) search."""
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
@@ -459,6 +463,7 @@ async def execute_search_keyword(
             top_k=top_k,
             language=KEYWORD_LANGUAGE,
             allowed_source_types=allowed,
+            video_ids=video_ids,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -475,6 +480,7 @@ async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Semantic-only (pgvector cosine) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -492,7 +498,7 @@ async def execute_search_semantic(
     try:
         embedding = await _embed_query(query, embedding_cache)
         raw = await repository.vector_search_pg(
-            embedding, top_k=top_k, allowed_source_types=allowed
+            embedding, top_k=top_k, allowed_source_types=allowed, video_ids=video_ids
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -603,6 +609,7 @@ async def execute_tool(
     video_id_whitelist: set[str] | None = None,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Dispatch by tool name. Unknown names return an error dict so the
     model sees the refusal and stops calling.
@@ -612,16 +619,27 @@ async def execute_tool(
 
     ``is_member`` controls retrieval ACL: True surfaces both YouTube and
     Dynamous (paid) chunks; False sees YouTube only.
+
+    ``video_ids`` is the per-conversation video scope (issue #279): when set,
+    the three search tools restrict retrieval to those video ids. The
+    transcript tool does not take it — its scope is enforced via
+    ``video_id_whitelist``, which the caller intersects with the scope.
     """
     if name == "search_videos":
         return await execute_search_hybrid(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_ids=video_ids,
         )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments, is_member=is_member)
+        return await execute_search_keyword(raw_arguments, is_member=is_member, video_ids=video_ids)
     if name == "semantic_search_videos":
         return await execute_search_semantic(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_ids=video_ids,
         )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -25,6 +25,16 @@ class ConversationRename(BaseModel):
     title: str
 
 
+class ConversationScopeUpdate(BaseModel):
+    """Per-conversation video scope (issue #279).
+
+    ``video_ids`` is the set of video ids the conversation should draw from.
+    None or an empty list clears the scope (search the whole library).
+    """
+
+    video_ids: list[str] | None = None
+
+
 @router.get("/conversations")
 async def list_conversations(current_user: dict[str, Any] = Depends(get_current_user)):
     return await repository.list_conversations(user_id=str(current_user["id"]))
@@ -92,6 +102,41 @@ async def rename_conversation(
         raise HTTPException(status_code=404, detail="Conversation not found")
     conv = await repository.get_conversation(conv_id, user_id=str(current_user["id"]))
     return conv
+
+
+@router.patch("/conversations/{conv_id}/scope")
+async def update_conversation_scope(
+    conv_id: str,
+    body: ConversationScopeUpdate,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Set or clear the videos a conversation is scoped to (issue #279).
+
+    An empty list (or null) clears the scope so retrieval searches the whole
+    library again. A non-null list is validated against the library — unknown
+    ids are rejected with 422 to avoid the silent "scope matches nothing" trap.
+    Owner-scoped: a conversation that doesn't exist or isn't owned returns 404
+    (no existence leak), matching the rename handler's semantics.
+    """
+    user_id = str(current_user["id"])
+
+    # Normalize [] → None: a cleared scope is identical to never-scoped.
+    video_ids = body.video_ids or None
+
+    if video_ids is not None:
+        all_videos = await repository.list_videos()
+        known_ids = {v["id"] for v in all_videos if v.get("id")}
+        unknown = [vid for vid in video_ids if vid not in known_ids]
+        if unknown:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown video id(s): {', '.join(unknown)}",
+            )
+
+    updated = await repository.update_conversation_scope(conv_id, user_id, video_ids)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return await repository.get_conversation(conv_id, user_id=user_id)
 
 
 @router.get("/videos")

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -139,6 +139,19 @@ async def create_message(
             )
             video_id_whitelist = set()
 
+        # Per-conversation video scope (issue #279). asyncpg returns TEXT[] as a
+        # Python list; `or None` collapses an empty array to "unscoped". When a
+        # scope is set, the search tools restrict retrieval to it and the
+        # transcript whitelist is intersected with it so neither retrieval nor a
+        # full-transcript pull can reach an out-of-scope video.
+        scoped_video_ids: list[str] | None = conv.get("scoped_video_ids") or None
+        if scoped_video_ids is not None:
+            scope_set = set(scoped_video_ids)
+            # Intersect with the library whitelist when it loaded; otherwise fall
+            # back to the scope set itself as the guard rather than leaving the
+            # transcript tool unguarded.
+            video_id_whitelist = video_id_whitelist & scope_set if video_id_whitelist else scope_set
+
         # Captured at the start of the turn so the entire tool sequence sees
         # consistent ACL — even if /me later flips is_member, the in-flight
         # turn won't change behavior mid-flight.
@@ -147,7 +160,9 @@ async def create_message(
         async def _executor(name: str, raw_args: str) -> str:
             # Pass `None` (not empty set) when the whitelist failed to load so
             # the transcript tool falls back to open lookups instead of rejecting
-            # every id.
+            # every id. NB: when a scope is set the whitelist is never empty
+            # (it's at minimum the scope set), so scoped transcript pulls stay
+            # guarded even if the library load failed.
             whitelist = video_id_whitelist if video_id_whitelist else None
             result = await execute_tool(
                 name,
@@ -155,6 +170,7 @@ async def create_message(
                 video_id_whitelist=whitelist,
                 embedding_cache=embedding_cache,
                 is_member=is_member_for_turn,
+                video_ids=scoped_video_ids,
             )
             if result.get("ok") and result.get("chunks"):
                 tool_chunks_acc.extend(result["chunks"])

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -117,7 +117,12 @@ async def _post_message(*, answer_tokens: list[str], retrieved_chunks: list[dict
         yield "data: [DONE]\n\n"
 
     async def mock_execute_tool(
-        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        name,
+        raw_args,
+        video_id_whitelist=None,
+        embedding_cache=None,
+        is_member=False,
+        video_ids=None,
     ):
         return {"ok": True, "text": "ctx", "chunks": retrieved_chunks}
 

--- a/app/backend/tests/test_conversation_video_scope.py
+++ b/app/backend/tests/test_conversation_video_scope.py
@@ -1,0 +1,367 @@
+"""Tests for per-conversation video scope (issue #279).
+
+Covers:
+  - PATCH /conversations/{id}/scope happy path, [] normalization, unknown-id
+    422, and non-owner/missing 404.
+  - Message flow: a scoped conversation threads video_ids into execute_tool and
+    intersects the transcript whitelist with the scope.
+  - Whitelist-load-failure + scoped conversation still guards the transcript
+    tool with the scope set (never None).
+
+Mock-based per existing conventions (see test_sources_event.py for the
+route-level mocking pattern).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.auth.tokens import encode_token
+from backend.main import app
+
+
+def _mock_user(user_id: str):
+    async def mock_get_user_by_id(_uid):
+        return {
+            "id": user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    return mock_get_user_by_id
+
+
+# ---------------------------------------------------------------------------
+# PATCH /conversations/{id}/scope
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateScopeEndpoint:
+    async def test_happy_path_sets_scope_and_returns_row(self) -> None:
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+
+        async def mock_list_videos():
+            return [{"id": "v1"}, {"id": "v2"}, {"id": "v3"}]
+
+        update_mock = AsyncMock(return_value=True)
+
+        async def mock_get_conversation(cid, user_id):
+            return {
+                "id": conv_id,
+                "user_id": user_id,
+                "title": "Test",
+                "scoped_video_ids": ["v1", "v2"],
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _mock_user(user_id)),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.update_conversation_scope", update_mock),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                r = await client.patch(
+                    f"/api/conversations/{conv_id}/scope",
+                    json={"video_ids": ["v1", "v2"]},
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["scoped_video_ids"] == ["v1", "v2"]
+        # The repository writer received exactly the requested scope.
+        update_mock.assert_awaited_once()
+        assert update_mock.call_args.args[2] == ["v1", "v2"]
+
+    async def test_empty_list_normalizes_to_none(self) -> None:
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+
+        update_mock = AsyncMock(return_value=True)
+
+        async def mock_get_conversation(cid, user_id):
+            return {
+                "id": conv_id,
+                "user_id": user_id,
+                "title": "Test",
+                "scoped_video_ids": None,
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        # list_videos should NOT be needed when clearing — but patch it anyway
+        # so the test doesn't hit a real pool if behavior changes.
+        async def mock_list_videos():
+            return []
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _mock_user(user_id)),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.update_conversation_scope", update_mock),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                r = await client.patch(
+                    f"/api/conversations/{conv_id}/scope",
+                    json={"video_ids": []},
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["scoped_video_ids"] is None
+        # [] must reach the writer as None (unscoped).
+        assert update_mock.call_args.args[2] is None
+
+    async def test_unknown_video_id_returns_422(self) -> None:
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+
+        async def mock_list_videos():
+            return [{"id": "v1"}]
+
+        update_mock = AsyncMock(return_value=True)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _mock_user(user_id)),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.update_conversation_scope", update_mock),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                r = await client.patch(
+                    f"/api/conversations/{conv_id}/scope",
+                    json={"video_ids": ["v1", "ghost"]},
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert r.status_code == 422, r.text
+        assert "ghost" in r.json()["detail"]
+        # Must not have written anything when validation fails.
+        update_mock.assert_not_awaited()
+
+    async def test_non_owner_or_missing_returns_404(self) -> None:
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+
+        async def mock_list_videos():
+            return [{"id": "v1"}]
+
+        # update returns False → not found / not owner.
+        update_mock = AsyncMock(return_value=False)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _mock_user(user_id)),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.update_conversation_scope", update_mock),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                r = await client.patch(
+                    f"/api/conversations/{conv_id}/scope",
+                    json={"video_ids": ["v1"]},
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert r.status_code == 404, r.text
+
+
+# ---------------------------------------------------------------------------
+# Message flow — scope threaded into execute_tool + transcript whitelist
+# ---------------------------------------------------------------------------
+
+
+class TestScopedMessageFlow:
+    async def _run_message(self, conv_row: dict, library: list[dict]):
+        """Drive POST /messages once, returning the captured execute_tool
+        kwargs and the video_id_whitelist passed to it."""
+        user_id = conv_row["user_id"]
+        conv_id = conv_row["id"]
+        token = encode_token(user_id)
+
+        captured: dict = {}
+
+        async def mock_stream_chat(
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
+        ):
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "test"}))
+            yield 'data: "ok"\n\n'
+            if final_text_out is not None:
+                final_text_out.append("ok")
+            yield "data: [DONE]\n\n"
+
+        async def mock_execute_tool(
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            video_ids=None,
+        ):
+            captured["video_ids"] = video_ids
+            captured["video_id_whitelist"] = video_id_whitelist
+            return {"ok": True, "text": "context", "chunks": []}
+
+        async def mock_get_conversation(cid, user_id):
+            return conv_row
+
+        async def mock_create_message(**kwargs):
+            return {"id": str(uuid4()), **kwargs}
+
+        async def mock_list_messages(cid, user_id):
+            return []
+
+        async def mock_list_videos():
+            return library
+
+        async def mock_check_and_record(uid):
+            return None
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _mock_user(user_id)),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.create_message", mock_create_message),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.rate_limit.check_and_record", mock_check_and_record),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                await client.post(
+                    f"/api/conversations/{conv_id}/messages",
+                    json={"content": "a question"},
+                    headers={"Cookie": f"session={token}"},
+                )
+        return captured
+
+    async def test_scope_threaded_and_whitelist_intersected(self) -> None:
+        user_id = str(uuid4())
+        conv = {
+            "id": str(uuid4()),
+            "user_id": user_id,
+            "title": "Scoped",
+            "scoped_video_ids": ["v1", "v2"],
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        library = [{"id": "v1"}, {"id": "v2"}, {"id": "v3"}]
+
+        captured = await self._run_message(conv, library)
+
+        assert captured["video_ids"] == ["v1", "v2"]
+        # Whitelist is the intersection of the library and the scope.
+        assert captured["video_id_whitelist"] == {"v1", "v2"}
+
+    async def test_unscoped_conversation_passes_none(self) -> None:
+        user_id = str(uuid4())
+        conv = {
+            "id": str(uuid4()),
+            "user_id": user_id,
+            "title": "Unscoped",
+            "scoped_video_ids": None,
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        library = [{"id": "v1"}, {"id": "v2"}]
+
+        captured = await self._run_message(conv, library)
+
+        assert captured["video_ids"] is None
+        # Full library whitelist, no scope intersection.
+        assert captured["video_id_whitelist"] == {"v1", "v2"}
+
+    async def test_whitelist_load_failure_falls_back_to_scope_set(self) -> None:
+        """If the library load fails but a scope is set, the transcript tool
+        must still be guarded by the scope set — never left unguarded (None)."""
+        user_id = str(uuid4())
+        conv_id = str(uuid4())
+        token = encode_token(user_id)
+        conv = {
+            "id": conv_id,
+            "user_id": user_id,
+            "title": "Scoped",
+            "scoped_video_ids": ["v1", "v2"],
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+        captured: dict = {}
+
+        async def mock_stream_chat(
+            messages,
+            tools=None,
+            tool_executor=None,
+            max_tool_calls=0,
+            final_text_out=None,
+            **_kwargs,
+        ):
+            if tool_executor is not None:
+                await tool_executor("search_videos", json.dumps({"query": "test"}))
+            yield 'data: "ok"\n\n'
+            if final_text_out is not None:
+                final_text_out.append("ok")
+            yield "data: [DONE]\n\n"
+
+        async def mock_execute_tool(
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            video_ids=None,
+        ):
+            captured["video_ids"] = video_ids
+            captured["video_id_whitelist"] = video_id_whitelist
+            return {"ok": True, "text": "context", "chunks": []}
+
+        async def mock_get_conversation(cid, user_id):
+            return conv
+
+        async def mock_create_message(**kwargs):
+            return {"id": str(uuid4()), **kwargs}
+
+        async def mock_list_messages(cid, user_id):
+            return []
+
+        async def failing_list_videos():
+            raise RuntimeError("pool down")
+
+        async def mock_check_and_record(uid):
+            return None
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _mock_user(user_id)),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.create_message", mock_create_message),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", failing_list_videos),
+            patch("backend.rate_limit.check_and_record", mock_check_and_record),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                await client.post(
+                    f"/api/conversations/{conv_id}/messages",
+                    json={"content": "a question"},
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert captured["video_ids"] == ["v1", "v2"]
+        # Even though the library load failed, the scope set guards the tool.
+        assert captured["video_id_whitelist"] == {"v1", "v2"}

--- a/app/backend/tests/test_repository_hybrid_search.py
+++ b/app/backend/tests/test_repository_hybrid_search.py
@@ -93,6 +93,42 @@ class TestKeywordSearch:
         args = call_args[0]
         assert args[2] == 3
 
+    async def test_keyword_search_applies_video_id_scope(self):
+        """When video_ids is given, keyword_search adds AND video_id = ANY(...)
+        and binds the list as $4 (issue #279)."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("test", top_k=5, video_ids=["v1", "v2"])
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        assert "video_id = ANY($4::text[])" in sql
+        args = call_args[0]
+        assert args[4] == ["v1", "v2"]
+
+    async def test_keyword_search_omits_scope_clause_when_none_or_empty(self):
+        """None or [] video_ids must NOT add the video_id filter (unscoped)."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        for scope in (None, []):
+            with patch.object(repository, "_acquire", return_value=mock_acquire):
+                await repository.keyword_search("test", top_k=5, video_ids=scope)
+            sql = mock_conn.fetch.call_args[0][0]
+            assert "video_id = ANY" not in sql
+            # No $4 bound — only sql, query, top_k, allowed_source_types.
+            assert len(mock_conn.fetch.call_args[0]) == 4
+
 
 class TestVectorSearchPg:
     """Tests for vector_search_pg() SQL execution."""
@@ -191,3 +227,39 @@ class TestVectorSearchPg:
 
         parsed = json.loads(args[1])
         assert parsed == embedding
+
+    async def test_vector_search_pg_applies_video_id_scope(self):
+        """When video_ids is given, vector_search_pg adds AND video_id = ANY(...)
+        and binds the list as $4 (issue #279)."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5, video_ids=["v1", "v2"])
+
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        assert "video_id = ANY($4::text[])" in sql
+        args = call_args[0]
+        assert args[4] == ["v1", "v2"]
+
+    async def test_vector_search_pg_omits_scope_clause_when_none_or_empty(self):
+        """None or [] video_ids must NOT add the video_id filter (unscoped)."""
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
+
+        mock_acquire = AsyncMock()
+        mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_acquire.__aexit__ = AsyncMock(return_value=None)
+
+        for scope in (None, []):
+            with patch.object(repository, "_acquire", return_value=mock_acquire):
+                await repository.vector_search_pg([0.1] * 1536, top_k=5, video_ids=scope)
+            sql = mock_conn.fetch.call_args[0][0]
+            assert "video_id = ANY" not in sql
+            # No $4 bound — only sql, embedding_json, top_k, allowed_source_types.
+            assert len(mock_conn.fetch.call_args[0]) == 4

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -152,10 +152,14 @@ class TestRetrieveHybrid:
 
             # Verify correct arguments passed (over-fetch factor applied)
             mock_kw.assert_called_once_with(
-                "test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"]
+                "test query",
+                top_k=fetch_k,
+                language="english",
+                allowed_source_types=["youtube"],
+                video_ids=None,
             )
             mock_vec.assert_called_once_with(
-                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"]
+                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"], video_ids=None
             )
 
             # Verify result shape has all required citation fields
@@ -167,6 +171,57 @@ class TestRetrieveHybrid:
                 assert "start_seconds" in item
                 assert "end_seconds" in item
                 assert "snippet" in item
+
+    async def test_forwards_video_ids_to_both_legs(self):
+        """retrieve_hybrid(video_ids=[...]) forwards the scope to both the
+        keyword and vector search calls (issue #279)."""
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+            ) as mock_video,
+        ):
+            mock_kw.return_value = [_CHUNK_A]
+            mock_vec.return_value = [_CHUNK_A]
+            mock_video.return_value = {"title": "T", "url": "u"}
+
+            await retrieve_hybrid("test query", [0.1] * 1536, top_k=5, video_ids=["v1", "v2"])
+
+            assert mock_kw.call_args.kwargs["video_ids"] == ["v1", "v2"]
+            assert mock_vec.call_args.kwargs["video_ids"] == ["v1", "v2"]
+
+    async def test_video_ids_defaults_to_none(self):
+        """Without video_ids, both legs receive video_ids=None (unscoped)."""
+        with (
+            patch(
+                "backend.rag.retriever_hybrid.repository.keyword_search",
+                new_callable=AsyncMock,
+            ) as mock_kw,
+            patch(
+                "backend.rag.retriever_hybrid.repository.vector_search_pg",
+                new_callable=AsyncMock,
+            ) as mock_vec,
+            patch(
+                "backend.rag.retriever_hybrid.repository.get_video",
+                new_callable=AsyncMock,
+            ) as mock_video,
+        ):
+            mock_kw.return_value = []
+            mock_vec.return_value = []
+            mock_video.return_value = {"title": "T", "url": "u"}
+
+            await retrieve_hybrid("test query", [0.1] * 1536, top_k=5)
+
+            assert mock_kw.call_args.kwargs["video_ids"] is None
+            assert mock_vec.call_args.kwargs["video_ids"] is None
 
     async def test_rare_exact_term_boosted_by_keyword_path(self):
         """A technical acronym (weak in cosine space) ranks higher via hybrid.

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -767,7 +767,12 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -871,7 +876,12 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -976,7 +986,12 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -1091,7 +1106,12 @@ class TestChunkExpansionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name,
+            raw_args,
+            video_id_whitelist=None,
+            embedding_cache=None,
+            is_member=False,
+            video_ids=None,
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 

--- a/app/backend/tests/test_tools.py
+++ b/app/backend/tests/test_tools.py
@@ -96,7 +96,7 @@ _FAKE_CHUNKS = [
 
 @pytest.mark.asyncio
 async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
-    async def fake_retrieve(_q, _emb, top_k=5, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_ids=None):
         assert top_k == 10
         return _FAKE_CHUNKS
 
@@ -112,7 +112,9 @@ async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, video_ids=None
+    ):
         return [
             {
                 "id": "c1",
@@ -140,7 +142,7 @@ async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_ids=None):
         return [
             {
                 "id": "c2",
@@ -169,7 +171,9 @@ async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, video_ids=None
+    ):
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -178,6 +182,71 @@ async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
     assert result["ok"] is True
     assert "No relevant chunks found" in result["text"]
     assert result["chunks"] == []
+
+
+# --- Per-conversation video scope (issue #279) ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_search_hybrid_forwards_video_ids(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, video_ids=None):
+        captured["video_ids"] = video_ids
+        return _FAKE_CHUNKS
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_search_hybrid(json.dumps({"query": "q"}), video_ids=["v1", "v2"])
+    assert captured["video_ids"] == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_execute_search_keyword_forwards_video_ids(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, video_ids=None
+    ):
+        captured["video_ids"] = video_ids
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
+
+    await execute_search_keyword({"query": "q"}, video_ids=["v1"])
+    assert captured["video_ids"] == ["v1"]
+
+
+@pytest.mark.asyncio
+async def test_execute_search_semantic_forwards_video_ids(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_ids=None):
+        captured["video_ids"] = video_ids
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "vector_search_pg", fake_vector)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_search_semantic({"query": "q"}, video_ids=["v2"])
+    assert captured["video_ids"] == ["v2"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_dispatches_video_ids_to_search(monkeypatch) -> None:
+    """execute_tool forwards video_ids to each search executor."""
+    captured: dict = {}
+
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, video_ids=None):
+        captured["video_ids"] = video_ids
+        return _FAKE_CHUNKS
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_tool("search_videos", json.dumps({"query": "q"}), video_ids=["v9"])
+    assert captured["video_ids"] == ["v9"]
 
 
 # --- Per-video diversity cap ----------------------------------------------
@@ -257,7 +326,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
         for i in range(6)
     ]
 
-    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, video_ids=None):
         return many_chunks
 
     monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
@@ -273,7 +342,9 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
 async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_keyword."""
 
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, video_ids=None
+    ):
         return [
             {
                 "id": f"c{i}",
@@ -303,7 +374,7 @@ async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> Non
 async def test_execute_search_semantic_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_semantic."""
 
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_ids=None):
         return [
             {
                 "id": f"c{i}",

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -5,11 +5,12 @@ import { useMessages } from '../hooks/useMessages';
 import { useStreamingResponse } from '../hooks/useStreamingResponse';
 import { useToast } from '../hooks/useToast';
 import type { Citation, Message as MessageType } from '../lib/api';
-import { RateLimitError, createConversation } from '../lib/api';
+import { RateLimitError, createConversation, updateConversationScope } from '../lib/api';
 import { exportConversationAsMarkdown } from '../lib/exportMarkdown';
 import { ChatInput, type ChatInputHandle } from './ChatInput';
 import { CitationModal } from './CitationModal';
 import { Message } from './Message';
+import { VideoScopePicker } from './VideoScopePicker';
 
 function formatResetTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
@@ -292,9 +293,8 @@ interface ConvLocationState {
 export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaProps) {
   const navigate = useNavigate();
   const location = useLocation() as Location & { state: ConvLocationState | null };
-  const { messages, setMessages, loading, error, notFound, conversation } = useMessages(
-    conversationId || null,
-  );
+  const { messages, setMessages, loading, error, notFound, conversation, setConversation } =
+    useMessages(conversationId || null);
   const {
     streamingContent,
     streamingSources,
@@ -325,6 +325,8 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const pendingUserMsgIdRef = useRef<string | null>(null);
   // Citation modal state
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(null);
+  // Video scope picker state (issue #279)
+  const [showScopePicker, setShowScopePicker] = useState(false);
 
   // ── Auto-scroll logic ──
   // Defer scroll to the next paint cycle so streaming DOM updates are applied first.
@@ -602,6 +604,31 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   const showEmptyInConversation =
     messages.length === 0 && !inlineError && !isStreaming && !location.state?.initialMessage;
 
+  const scopeCount = conversation?.scoped_video_ids?.length ?? 0;
+
+  const handleScopeSave = useCallback(
+    async (ids: string[] | null) => {
+      if (!conversationId) return;
+      try {
+        const updated = await updateConversationScope(conversationId, ids);
+        setConversation((prev) =>
+          prev ? { ...prev, scoped_video_ids: updated.scoped_video_ids ?? null } : prev,
+        );
+        setShowScopePicker(false);
+        addToast(
+          ids && ids.length > 0
+            ? `Scoped to ${ids.length} video${ids.length === 1 ? '' : 's'}`
+            : 'Scope cleared — searching all videos',
+          'success',
+        );
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Failed to update scope';
+        addToast(`Could not update scope: ${msg}`, 'error');
+      }
+    },
+    [conversationId, setConversation, addToast],
+  );
+
   const handleExport = useCallback(() => {
     try {
       if (conversation) {
@@ -638,6 +665,54 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
           position: 'relative',
         }}
       >
+        {/* ── Scope button (visible when conversation is active) ── */}
+        {conversation && (
+          <button
+            onClick={() => setShowScopePicker(true)}
+            title="Choose which videos this conversation draws from"
+            style={{
+              position: 'absolute',
+              top: 12,
+              right: 110,
+              background: '#1e293b',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 7,
+              color: scopeCount > 0 ? '#60a5fa' : '#94a3b8',
+              cursor: 'pointer',
+              padding: '5px 8px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              fontSize: 12,
+              zIndex: 5,
+              transition: 'background 0.15s, color 0.15s',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.color = '#f1f5f9';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.color = scopeCount > 0 ? '#60a5fa' : '#94a3b8';
+            }}
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 13 13"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="5.5" cy="5.5" r="4" />
+              <line x1="8.5" y1="8.5" x2="11.5" y2="11.5" />
+            </svg>
+            {scopeCount > 0
+              ? `Scope: ${scopeCount} video${scopeCount === 1 ? '' : 's'}`
+              : 'Scope: All'}
+          </button>
+        )}
+
         {/* ── Export button (visible when conversation is active) ── */}
         {conversation && messages.length > 0 && (
           <button
@@ -778,6 +853,15 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
       {/* ── Citation modal ── */}
       {selectedCitation && (
         <CitationModal citation={selectedCitation} onClose={() => setSelectedCitation(null)} />
+      )}
+
+      {/* ── Video scope picker (issue #279) ── */}
+      {showScopePicker && (
+        <VideoScopePicker
+          selectedIds={conversation?.scoped_video_ids ?? []}
+          onSave={handleScopeSave}
+          onClose={() => setShowScopePicker(false)}
+        />
       )}
     </div>
   );

--- a/app/frontend/src/components/VideoScopePicker.tsx
+++ b/app/frontend/src/components/VideoScopePicker.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react';
+import { type Video, getVideos } from '../lib/api';
+
+interface VideoScopePickerProps {
+  /** Video ids currently in the conversation's scope (empty = all videos). */
+  selectedIds: string[];
+  /**
+   * Called with the chosen video ids when the user saves. An empty selection
+   * is emitted as null, meaning "all videos" (clears the scope).
+   */
+  onSave: (ids: string[] | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * Modal that lets the user scope a conversation to a subset of the video
+ * library (issue #279). Loads the library via getVideos() and presents a
+ * checkbox per video. "All videos" clears the scope; "Save" applies the
+ * checked set. Styled to match CitationModal (Tailwind primitives).
+ */
+export function VideoScopePicker({ selectedIds, onSave, onClose }: VideoScopePickerProps) {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [checked, setChecked] = useState<Set<string>>(() => new Set(selectedIds));
+
+  useEffect(() => {
+    let cancelled = false;
+    getVideos()
+      .then((data) => {
+        if (!cancelled) setVideos(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load videos');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Close on ESC key
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Lock body scroll while modal is open
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  const toggle = (id: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    const ids = Array.from(checked);
+    // Empty selection means "all videos" — clear the scope.
+    onSave(ids.length > 0 ? ids : null);
+  };
+
+  const handleAllVideos = () => {
+    onSave(null);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Scope conversation to videos"
+    >
+      <div
+        className="bg-slate-800 border border-white/10 rounded-xl p-6 w-[560px] max-w-[calc(100vw-48px)] max-h-[90vh] flex flex-col shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex justify-between items-center mb-1">
+          <h3 className="text-slate-100 text-base font-semibold m-0">Scope this conversation</h3>
+          <button
+            onClick={onClose}
+            className="bg-none border-none text-slate-400 cursor-pointer text-xl leading-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <p className="text-slate-400 text-xs m-0 mb-4">
+          Pick which videos the assistant should answer from. Leave all unchecked to search the
+          whole library.
+        </p>
+
+        {/* Video list */}
+        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1 mb-4">
+          {loading && <p className="text-slate-400 text-sm m-0">Loading videos…</p>}
+          {error && <p className="text-red-400 text-sm m-0">{error}</p>}
+          {!loading && !error && videos.length === 0 && (
+            <p className="text-slate-400 text-sm m-0">No videos in the library yet.</p>
+          )}
+          {!loading &&
+            !error &&
+            videos.map((v) => (
+              <label
+                key={v.id}
+                className="flex items-start gap-3 p-2 rounded-lg cursor-pointer hover:bg-slate-700/50"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked.has(v.id)}
+                  onChange={() => toggle(v.id)}
+                  className="mt-1 cursor-pointer"
+                />
+                <span className="flex flex-col">
+                  <span className="text-slate-100 text-sm">{v.title}</span>
+                  {v.channel_title ? (
+                    <span className="text-slate-400 text-xs">{v.channel_title}</span>
+                  ) : null}
+                </span>
+              </label>
+            ))}
+        </div>
+
+        {/* Footer actions */}
+        <div className="flex justify-between items-center">
+          <button
+            onClick={handleAllVideos}
+            className="text-slate-400 hover:text-slate-200 text-xs transition-colors bg-transparent border-none cursor-pointer"
+          >
+            All videos
+          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className="text-slate-300 text-sm px-3 py-1.5 rounded-lg border border-white/10 bg-transparent hover:bg-slate-700/50 cursor-pointer transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              className="text-white text-sm px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 border-none cursor-pointer transition-colors"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/hooks/useMessages.ts
+++ b/app/frontend/src/hooks/useMessages.ts
@@ -30,6 +30,7 @@ export function useMessages(conversationId: string | null) {
           title: data.title,
           created_at: data.created_at,
           updated_at: data.updated_at,
+          scoped_video_ids: data.scoped_video_ids ?? null,
         });
       })
       .catch((e) => {
@@ -43,5 +44,5 @@ export function useMessages(conversationId: string | null) {
       .finally(() => setLoading(false));
   }, [conversationId]);
 
-  return { messages, setMessages, loading, error, notFound, conversation };
+  return { messages, setMessages, loading, error, notFound, conversation, setConversation };
 }

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,12 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  /**
+   * Video ids this conversation is scoped to (issue #279). When set, the
+   * assistant's answers and citations only come from these videos. null or
+   * absent means unscoped — search the whole library.
+   */
+  scoped_video_ids?: string[] | null;
 }
 
 export interface Citation {
@@ -156,6 +162,13 @@ export const renameConversation = (id: string, title: string) =>
   request<Conversation>(`/conversations/${id}`, {
     method: 'PATCH',
     body: JSON.stringify({ title }),
+  });
+// Scope a conversation to specific videos (issue #279). Pass null (or an
+// empty array) to clear the scope and search the whole library again.
+export const updateConversationScope = (id: string, videoIds: string[] | null) =>
+  request<Conversation>(`/conversations/${id}/scope`, {
+    method: 'PATCH',
+    body: JSON.stringify({ video_ids: videoIds }),
   });
 
 // Videos


### PR DESCRIPTION
Fixes #279

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `fdf0a476-eb0d-4589-98cd-619c53979fa7`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.