### PR TITLE
[bench-OO] feat(conversations): scope a conversation to specific videos

### DIFF
--- a/app/backend/alembic/versions/0006_add_scoped_video_ids_to_conversations.py
+++ b/app/backend/alembic/versions/0006_add_scoped_video_ids_to_conversations.py
@@ -1,0 +1,37 @@
+"""Add per-conversation video scope (issue #279).
+
+Adds a nullable ``scoped_video_ids TEXT[]`` column to ``conversations``. When a
+conversation is created with a non-empty list, every retrieval path for that
+conversation's messages filters chunks to those ``video_id``s. NULL/empty means
+"search the whole library" (the pre-#279 default), so existing rows upgrade
+in-place with no behavior change.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("scoped_video_ids", postgresql.ARRAY(sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "scoped_video_ids")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -253,6 +253,7 @@ async def keyword_search(
     top_k: int,
     language: str = "english",
     allowed_source_types: list[str] | None = None,
+    video_id_filter: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks matching a full-text query using tsvector.
@@ -265,6 +266,10 @@ async def keyword_search(
             this list are excluded. Defaults to ['youtube'] which is the
             backwards-compatible behavior for callers that don't yet know
             about Dynamous content (issue #147).
+        video_id_filter: Conversation-scope filter (issue #279) — when not None,
+            only chunks whose video_id is in this list are returned. None means
+            no video filtering (search the whole library). Composes with
+            allowed_source_types; it does not replace it.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -272,9 +277,10 @@ async def keyword_search(
     """
     if allowed_source_types is None:
         allowed_source_types = ["youtube"]
-    async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
+    # Build the SQL/args conditionally so the unscoped path stays byte-for-byte
+    # identical to the pre-#279 query (no extra clause, no extra param).
+    if video_id_filter is None:
+        sql = """
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
                    ts_rank(search_vector, plainto_tsquery($1)) AS rank
             FROM chunks
@@ -282,11 +288,22 @@ async def keyword_search(
               AND source_type = ANY($3::text[])
             ORDER BY rank DESC
             LIMIT $2
-            """,
-            query,
-            top_k,
-            allowed_source_types,
-        )
+            """
+        args: tuple = (query, top_k, allowed_source_types)
+    else:
+        sql = """
+            SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                   ts_rank(search_vector, plainto_tsquery($1)) AS rank
+            FROM chunks
+            WHERE search_vector @@ plainto_tsquery($1)
+              AND source_type = ANY($3::text[])
+              AND video_id = ANY($4::text[])
+            ORDER BY rank DESC
+            LIMIT $2
+            """
+        args = (query, top_k, allowed_source_types, video_id_filter)
+    async with _acquire() as conn:
+        rows = await conn.fetch(sql, *args)
     return [dict(r) for r in rows]
 
 
@@ -294,6 +311,7 @@ async def vector_search_pg(
     query_embedding: list[float],
     top_k: int,
     allowed_source_types: list[str] | None = None,
+    video_id_filter: list[str] | None = None,
 ) -> list[dict]:
     """
     Return top-K chunks by pgvector cosine similarity.
@@ -311,6 +329,10 @@ async def vector_search_pg(
             compatibility (issue #147). The pool's `hnsw.iterative_scan =
             relaxed_order` setting (see db/postgres.py) keeps the HNSW index
             usable under this filter.
+        video_id_filter: Conversation-scope filter (issue #279) — when not None,
+            only chunks whose video_id is in this list are returned. None means
+            no video filtering (search the whole library). Composes with
+            allowed_source_types; it does not replace it.
 
     Returns:
         List of chunk dicts with keys: id, video_id, content, chunk_index,
@@ -319,20 +341,31 @@ async def vector_search_pg(
     if allowed_source_types is None:
         allowed_source_types = ["youtube"]
     embedding_json = json.dumps(query_embedding)
-    async with _acquire() as conn:
-        rows = await conn.fetch(
-            """
+    # Build the SQL/args conditionally so the unscoped path stays byte-for-byte
+    # identical to the pre-#279 query (no extra clause, no extra param).
+    if video_id_filter is None:
+        sql = """
             SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
                    embedding::vector <=> $1::vector AS distance
             FROM chunks
             WHERE source_type = ANY($3::text[])
             ORDER BY distance
             LIMIT $2
-            """,
-            embedding_json,
-            top_k,
-            allowed_source_types,
-        )
+            """
+        args: tuple = (embedding_json, top_k, allowed_source_types)
+    else:
+        sql = """
+            SELECT id, video_id, content, chunk_index, start_seconds, end_seconds, snippet,
+                   embedding::vector <=> $1::vector AS distance
+            FROM chunks
+            WHERE source_type = ANY($3::text[])
+              AND video_id = ANY($4::text[])
+            ORDER BY distance
+            LIMIT $2
+            """
+        args = (embedding_json, top_k, allowed_source_types, video_id_filter)
+    async with _acquire() as conn:
+        rows = await conn.fetch(sql, *args)
     return [dict(r) for r in rows]
 
 
@@ -415,20 +448,35 @@ async def replace_chunks_for_video(
 # ---------------------------------------------------------------------------
 
 
-async def create_conversation(*, user_id: str, title: str = "New Conversation") -> dict:
+async def create_conversation(
+    *,
+    user_id: str,
+    title: str = "New Conversation",
+    scoped_video_ids: list[str] | None = None,
+) -> dict:
+    """Create a conversation, optionally scoped to a subset of videos.
+
+    ``scoped_video_ids`` is the immutable-at-creation video filter (issue #279).
+    A non-empty list restricts every retrieval in this conversation to those
+    ``video_id``s; ``None`` or an empty list stores NULL and searches the whole
+    library (the default behavior). Empty lists are normalized to NULL so the
+    retrieval layer can treat "no scope" uniformly.
+    """
     conv_id = _new_id()
     now = _now()
+    scoped = scoped_video_ids or None
     async with _acquire() as conn:
         await conn.execute(
             """
-            INSERT INTO conversations (id, user_id, title, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO conversations (id, user_id, title, created_at, updated_at, scoped_video_ids)
+            VALUES ($1, $2, $3, $4, $5, $6)
             """,
             conv_id,
             user_id,
             title,
             now,
             now,
+            scoped,
         )
     return {
         "id": conv_id,
@@ -436,6 +484,7 @@ async def create_conversation(*, user_id: str, title: str = "New Conversation") 
         "title": title,
         "created_at": now,
         "updated_at": now,
+        "scoped_video_ids": scoped,
     }
 
 

--- a/app/backend/rag/retriever_hybrid.py
+++ b/app/backend/rag/retriever_hybrid.py
@@ -40,6 +40,7 @@ async def retrieve_hybrid(
     query_embedding: list[float],
     top_k: int = 5,
     is_member: bool = False,
+    video_id_filter: list[str] | None = None,
 ) -> list[dict]:
     """
     Hybrid retrieval via Reciprocal Rank Fusion (RRF).
@@ -52,6 +53,9 @@ async def retrieve_hybrid(
             = 'dynamous'`) is included alongside the default YouTube content.
             Non-members see YouTube chunks only. The filter is applied at the
             SQL layer — non-member retrieval never touches Dynamous chunks.
+        video_id_filter: Conversation-scope filter (issue #279) — when not None,
+            both sub-searches are restricted to these video_ids. None means no
+            video filtering (search the whole library).
 
     Returns:
         A list of dicts (length <= top_k), each containing:
@@ -88,11 +92,13 @@ async def retrieve_hybrid(
         top_k=fetch_k,
         language=KEYWORD_LANGUAGE,
         allowed_source_types=allowed_source_types,
+        video_id_filter=video_id_filter,
     )
     vector_task = repository.vector_search_pg(
         query_embedding,
         top_k=fetch_k,
         allowed_source_types=allowed_source_types,
+        video_id_filter=video_id_filter,
     )
 
     keyword_hits, vector_hits = await keyword_task, await vector_task

--- a/app/backend/rag/tools.py
+++ b/app/backend/rag/tools.py
@@ -410,6 +410,7 @@ async def execute_search_hybrid(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_id_filter: list[str] | None = None,
 ) -> dict[str, Any]:
     """Hybrid (keyword + semantic via RRF) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -425,7 +426,13 @@ async def execute_search_hybrid(
 
     try:
         embedding = await _embed_query(query, embedding_cache)
-        chunks = await retrieve_hybrid(query, embedding, top_k=top_k, is_member=is_member)
+        chunks = await retrieve_hybrid(
+            query,
+            embedding,
+            top_k=top_k,
+            is_member=is_member,
+            video_id_filter=video_id_filter,
+        )
     except Exception as exc:
         logger.warning("search_hybrid failed: %s", exc, exc_info=True)
         return {"ok": False, "error": f"search failed: {exc}"}
@@ -439,6 +446,7 @@ async def execute_search_hybrid(
 async def execute_search_keyword(
     raw_arguments: str | dict,
     is_member: bool = False,
+    video_id_filter: list[str] | None = None,
 ) -> dict[str, Any]:
     """Keyword-only (tsvector FTS) search."""
     from backend.config import KEYWORD_LANGUAGE, RETRIEVAL_MAX_PER_VIDEO
@@ -459,6 +467,7 @@ async def execute_search_keyword(
             top_k=top_k,
             language=KEYWORD_LANGUAGE,
             allowed_source_types=allowed,
+            video_id_filter=video_id_filter,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -475,6 +484,7 @@ async def execute_search_semantic(
     raw_arguments: str | dict,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_id_filter: list[str] | None = None,
 ) -> dict[str, Any]:
     """Semantic-only (pgvector cosine) search."""
     from backend.config import RETRIEVAL_MAX_PER_VIDEO
@@ -492,7 +502,10 @@ async def execute_search_semantic(
     try:
         embedding = await _embed_query(query, embedding_cache)
         raw = await repository.vector_search_pg(
-            embedding, top_k=top_k, allowed_source_types=allowed
+            embedding,
+            top_k=top_k,
+            allowed_source_types=allowed,
+            video_id_filter=video_id_filter,
         )
         chunks = await _hydrate_chunks(raw)
     except Exception as exc:
@@ -603,6 +616,7 @@ async def execute_tool(
     video_id_whitelist: set[str] | None = None,
     embedding_cache: dict[str, list[float]] | None = None,
     is_member: bool = False,
+    video_id_filter: list[str] | None = None,
 ) -> dict[str, Any]:
     """Dispatch by tool name. Unknown names return an error dict so the
     model sees the refusal and stops calling.
@@ -612,16 +626,28 @@ async def execute_tool(
 
     ``is_member`` controls retrieval ACL: True surfaces both YouTube and
     Dynamous (paid) chunks; False sees YouTube only.
+
+    ``video_id_filter`` is the per-conversation scope (issue #279): when not
+    None, the search tools only return chunks from those videos. The transcript
+    tool relies on the (already-narrowed) ``video_id_whitelist`` instead.
     """
     if name == "search_videos":
         return await execute_search_hybrid(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_id_filter=video_id_filter,
         )
     if name == "keyword_search_videos":
-        return await execute_search_keyword(raw_arguments, is_member=is_member)
+        return await execute_search_keyword(
+            raw_arguments, is_member=is_member, video_id_filter=video_id_filter
+        )
     if name == "semantic_search_videos":
         return await execute_search_semantic(
-            raw_arguments, embedding_cache=embedding_cache, is_member=is_member
+            raw_arguments,
+            embedding_cache=embedding_cache,
+            is_member=is_member,
+            video_id_filter=video_id_filter,
         )
     if name == "get_video_transcript":
         return await execute_get_video_transcript(

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -19,6 +19,10 @@ router = APIRouter()
 
 class ConversationCreate(BaseModel):
     title: str = "New Conversation"
+    # Optional, immutable-at-creation video scope (issue #279). A non-empty list
+    # restricts this conversation's retrieval to those video_ids; None/omitted
+    # searches the whole library (the default behavior).
+    scoped_video_ids: list[str] | None = None
 
 
 class ConversationRename(BaseModel):
@@ -37,9 +41,11 @@ async def create_conversation(
 ):
     """Create a new empty conversation. Body is optional; defaults to title='New Conversation'."""
     title = body.title if body else "New Conversation"
+    scoped_video_ids = body.scoped_video_ids if body else None
     return await repository.create_conversation(
         user_id=str(current_user["id"]),
         title=title,
+        scoped_video_ids=scoped_video_ids,
     )
 
 

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -80,6 +80,12 @@ async def create_message(
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    # Per-conversation video scope (issue #279). Set once at creation and
+    # immutable thereafter; None/empty means "search the whole library". This
+    # is the only consumer — it's threaded into the tool executor below so
+    # every retrieval in this turn (and every later turn) respects the scope.
+    scoped_video_ids: list[str] | None = conv.get("scoped_video_ids") or None
+
     # 2. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1).
     #    Must run BEFORE any LLM or DB write so a rate-limited user cannot
     #    consume OpenRouter budget or leave an orphan user-message row. The
@@ -139,6 +145,14 @@ async def create_message(
             )
             video_id_whitelist = set()
 
+        # When the conversation is scoped (issue #279), narrow the transcript
+        # whitelist to the in-scope videos so the model can't pull an
+        # out-of-scope full transcript. Intersect with the loaded library set so
+        # ids that no longer exist drop out. The search tools enforce scope via
+        # ``video_id_filter`` below; this is the transcript tool's guard.
+        if scoped_video_ids:
+            video_id_whitelist = video_id_whitelist & set(scoped_video_ids)
+
         # Captured at the start of the turn so the entire tool sequence sees
         # consistent ACL — even if /me later flips is_member, the in-flight
         # turn won't change behavior mid-flight.
@@ -155,6 +169,7 @@ async def create_message(
                 video_id_whitelist=whitelist,
                 embedding_cache=embedding_cache,
                 is_member=is_member_for_turn,
+                video_id_filter=scoped_video_ids,
             )
             if result.get("ok") and result.get("chunks"):
                 tool_chunks_acc.extend(result["chunks"])

--- a/app/backend/tests/test_citations.py
+++ b/app/backend/tests/test_citations.py
@@ -117,7 +117,7 @@ async def _post_message(*, answer_tokens: list[str], retrieved_chunks: list[dict
         yield "data: [DONE]\n\n"
 
     async def mock_execute_tool(
-        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False, video_id_filter=None
     ):
         return {"ok": True, "text": "ctx", "chunks": retrieved_chunks}
 

--- a/app/backend/tests/test_conversations_route.py
+++ b/app/backend/tests/test_conversations_route.py
@@ -1,0 +1,65 @@
+"""
+Route-level tests for per-conversation video scope (issue #279).
+
+The create_conversation handler is a plain async function, so we call it
+directly with a fake current_user and a mocked repository boundary — this
+exercises the request model + handler wiring without standing up the full
+ASGI/auth/DB stack (which the broader cross-user suite in
+test_conversation_scoping.py still requires and currently skips).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.routes import conversations as conv_route
+from backend.routes.conversations import ConversationCreate, create_conversation
+
+
+def test_model_accepts_scoped_video_ids():
+    body = ConversationCreate(title="T", scoped_video_ids=["v1", "v2"])
+    assert body.scoped_video_ids == ["v1", "v2"]
+
+
+def test_model_defaults_scope_to_none():
+    body = ConversationCreate()
+    assert body.scoped_video_ids is None
+    assert body.title == "New Conversation"
+
+
+@pytest.mark.asyncio
+async def test_handler_passes_scope_to_repo(monkeypatch):
+    captured: dict = {}
+
+    async def fake_create(*, user_id, title, scoped_video_ids=None):
+        captured.update(user_id=user_id, title=title, scoped_video_ids=scoped_video_ids)
+        return {
+            "id": "c1",
+            "user_id": user_id,
+            "title": title,
+            "scoped_video_ids": scoped_video_ids,
+        }
+
+    monkeypatch.setattr(conv_route.repository, "create_conversation", fake_create)
+
+    body = ConversationCreate(title="Scoped", scoped_video_ids=["v1", "v2"])
+    result = await create_conversation(body=body, current_user={"id": "u1"})
+
+    assert captured["scoped_video_ids"] == ["v1", "v2"]
+    assert captured["user_id"] == "u1"
+    assert result["scoped_video_ids"] == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_handler_omitted_scope_is_none(monkeypatch):
+    captured: dict = {}
+
+    async def fake_create(*, user_id, title, scoped_video_ids=None):
+        captured["scoped_video_ids"] = scoped_video_ids
+        return {"id": "c1", "user_id": user_id, "title": title, "scoped_video_ids": None}
+
+    monkeypatch.setattr(conv_route.repository, "create_conversation", fake_create)
+
+    # No body at all → handler must default scope to None (search everything).
+    await create_conversation(body=None, current_user={"id": "u1"})
+    assert captured["scoped_video_ids"] is None

--- a/app/backend/tests/test_repository_scope.py
+++ b/app/backend/tests/test_repository_scope.py
@@ -1,0 +1,112 @@
+"""
+Tests for per-conversation video scope (issue #279) at the repository layer.
+
+Covers:
+  - create_conversation round-trips scoped_video_ids and normalizes empty→NULL.
+  - keyword_search / vector_search_pg apply the video_id_filter as an additive
+    `video_id = ANY(...)` clause, and leave the unscoped path unchanged.
+
+All DB access is mocked via the same _acquire pattern used in
+test_repository_hybrid_search.py — no live Postgres.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from backend.db import repository
+
+
+def _mock_acquire(fetch_return=None):
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=fetch_return or [])
+    mock_conn.execute = AsyncMock(return_value=None)
+
+    mock_acquire = AsyncMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+    return mock_acquire, mock_conn
+
+
+class TestCreateConversationScope:
+    async def test_persists_scoped_video_ids(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.create_conversation(
+                user_id="u1",
+                title="Scoped chat",
+                scoped_video_ids=["v1", "v2"],
+            )
+
+        # The INSERT carries the scoped list as the 6th positional arg ($6).
+        call_args = mock_conn.execute.call_args
+        sql = call_args[0][0]
+        assert "scoped_video_ids" in sql
+        assert call_args[0][6] == ["v1", "v2"]
+        # The returned dict surfaces the scope and preserves ownership fields.
+        assert result["scoped_video_ids"] == ["v1", "v2"]
+        assert result["user_id"] == "u1"
+        assert result["title"] == "Scoped chat"
+
+    async def test_empty_list_normalized_to_none(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.create_conversation(
+                user_id="u1",
+                scoped_video_ids=[],
+            )
+
+        # Empty list stores NULL so retrieval treats it as "search everything".
+        assert mock_conn.execute.call_args[0][6] is None
+        assert result["scoped_video_ids"] is None
+
+    async def test_default_is_none(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            result = await repository.create_conversation(user_id="u1")
+
+        assert mock_conn.execute.call_args[0][6] is None
+        assert result["scoped_video_ids"] is None
+
+
+class TestKeywordSearchScope:
+    async def test_unscoped_path_unchanged(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("hello", top_k=5)
+
+        sql = mock_conn.fetch.call_args[0][0]
+        args = mock_conn.fetch.call_args[0]
+        # No video filter clause and no 4th param when filter is None.
+        assert "video_id = ANY" not in sql
+        assert len(args) == 4  # sql, query, top_k, allowed_source_types
+
+    async def test_filter_adds_clause_and_arg(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.keyword_search("hello", top_k=5, video_id_filter=["v1", "v2"])
+
+        sql = mock_conn.fetch.call_args[0][0]
+        args = mock_conn.fetch.call_args[0]
+        assert "video_id = ANY($4::text[])" in sql
+        assert args[4] == ["v1", "v2"]
+
+
+class TestVectorSearchScope:
+    async def test_unscoped_path_unchanged(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5)
+
+        sql = mock_conn.fetch.call_args[0][0]
+        args = mock_conn.fetch.call_args[0]
+        assert "video_id = ANY" not in sql
+        assert len(args) == 4  # sql, embedding_json, top_k, allowed_source_types
+
+    async def test_filter_adds_clause_and_arg(self):
+        mock_acquire, mock_conn = _mock_acquire()
+        with patch.object(repository, "_acquire", return_value=mock_acquire):
+            await repository.vector_search_pg([0.1] * 1536, top_k=5, video_id_filter=["v1"])
+
+        sql = mock_conn.fetch.call_args[0][0]
+        args = mock_conn.fetch.call_args[0]
+        assert "video_id = ANY($4::text[])" in sql
+        assert args[4] == ["v1"]

--- a/app/backend/tests/test_retriever_hybrid.py
+++ b/app/backend/tests/test_retriever_hybrid.py
@@ -152,10 +152,17 @@ class TestRetrieveHybrid:
 
             # Verify correct arguments passed (over-fetch factor applied)
             mock_kw.assert_called_once_with(
-                "test query", top_k=fetch_k, language="english", allowed_source_types=["youtube"]
+                "test query",
+                top_k=fetch_k,
+                language="english",
+                allowed_source_types=["youtube"],
+                video_id_filter=None,
             )
             mock_vec.assert_called_once_with(
-                [0.1] * 1536, top_k=fetch_k, allowed_source_types=["youtube"]
+                [0.1] * 1536,
+                top_k=fetch_k,
+                allowed_source_types=["youtube"],
+                video_id_filter=None,
             )
 
             # Verify result shape has all required citation fields

--- a/app/backend/tests/test_sources_event.py
+++ b/app/backend/tests/test_sources_event.py
@@ -767,7 +767,7 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False, video_id_filter=None
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -871,7 +871,7 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False, video_id_filter=None
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -976,7 +976,7 @@ class TestRefusalSourcesSuppressionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False, video_id_filter=None
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 
@@ -1091,7 +1091,7 @@ class TestChunkExpansionIntegration:
             yield done_chunk
 
         async def mock_execute_tool(
-            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+            name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False, video_id_filter=None
         ):
             return {"ok": True, "text": "context", "chunks": source_citations}
 

--- a/app/backend/tests/test_tools.py
+++ b/app/backend/tests/test_tools.py
@@ -96,7 +96,7 @@ _FAKE_CHUNKS = [
 
 @pytest.mark.asyncio
 async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
-    async def fake_retrieve(_q, _emb, top_k=5, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_id_filter=None):
         assert top_k == 10
         return _FAKE_CHUNKS
 
@@ -112,7 +112,7 @@ async def test_execute_search_hybrid_happy_path(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, video_id_filter=None):
         return [
             {
                 "id": "c1",
@@ -140,7 +140,7 @@ async def test_execute_search_keyword_hydrates_raw_chunks(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_id_filter=None):
         return [
             {
                 "id": "c2",
@@ -169,7 +169,7 @@ async def test_execute_search_semantic_embeds_and_hydrates(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_search_empty_results_returns_canned_message(monkeypatch) -> None:
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, video_id_filter=None):
         return []
 
     monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
@@ -257,7 +257,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
         for i in range(6)
     ]
 
-    async def fake_retrieve(_q, _emb, top_k=10, is_member=False):
+    async def fake_retrieve(_q, _emb, top_k=10, is_member=False, video_id_filter=None):
         return many_chunks
 
     monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
@@ -273,7 +273,7 @@ async def test_execute_search_hybrid_respects_per_video_cap(monkeypatch) -> None
 async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_keyword."""
 
-    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None):
+    async def fake_keyword(_q, top_k=10, language="english", allowed_source_types=None, video_id_filter=None):
         return [
             {
                 "id": f"c{i}",
@@ -303,7 +303,7 @@ async def test_execute_search_keyword_respects_per_video_cap(monkeypatch) -> Non
 async def test_execute_search_semantic_respects_per_video_cap(monkeypatch) -> None:
     """Cap must be enforced end-to-end inside execute_search_semantic."""
 
-    async def fake_vector(_emb, top_k=10, allowed_source_types=None):
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_id_filter=None):
         return [
             {
                 "id": f"c{i}",

--- a/app/backend/tests/test_tools_scope.py
+++ b/app/backend/tests/test_tools_scope.py
@@ -1,0 +1,102 @@
+"""
+Tests for per-conversation video scope (issue #279) at the tool layer.
+
+execute_tool must forward video_id_filter to every search executor (and on to
+the retrieval functions), while the transcript tool relies on the narrowed
+video_id_whitelist instead. All dependencies are mocked — no live DB.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.rag import tools as tools_module
+from backend.rag.tools import execute_get_video_transcript, execute_tool
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_filter_to_hybrid(monkeypatch):
+    captured: dict = {}
+
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_id_filter=None):
+        captured["video_id_filter"] = video_id_filter
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_tool(
+        "search_videos",
+        json.dumps({"query": "anything"}),
+        video_id_filter=["v1", "v2"],
+    )
+    assert captured["video_id_filter"] == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_filter_to_keyword(monkeypatch):
+    captured: dict = {}
+
+    async def fake_keyword(
+        _q, top_k=10, language="english", allowed_source_types=None, video_id_filter=None
+    ):
+        captured["video_id_filter"] = video_id_filter
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "keyword_search", fake_keyword)
+
+    await execute_tool(
+        "keyword_search_videos",
+        json.dumps({"query": "anything"}),
+        video_id_filter=["v9"],
+    )
+    assert captured["video_id_filter"] == ["v9"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_forwards_filter_to_semantic(monkeypatch):
+    captured: dict = {}
+
+    async def fake_vector(_emb, top_k=10, allowed_source_types=None, video_id_filter=None):
+        captured["video_id_filter"] = video_id_filter
+        return []
+
+    monkeypatch.setattr(tools_module.repository, "vector_search_pg", fake_vector)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    await execute_tool(
+        "semantic_search_videos",
+        json.dumps({"query": "anything"}),
+        video_id_filter=["v3"],
+    )
+    assert captured["video_id_filter"] == ["v3"]
+
+
+@pytest.mark.asyncio
+async def test_unscoped_passes_none_filter(monkeypatch):
+    captured: dict = {"sentinel": True}
+
+    async def fake_retrieve(_q, _emb, top_k=5, is_member=False, video_id_filter="UNSET"):
+        captured["video_id_filter"] = video_id_filter
+        return []
+
+    monkeypatch.setattr("backend.rag.retriever_hybrid.retrieve_hybrid", fake_retrieve)
+    monkeypatch.setattr("backend.rag.embeddings.embed_text", lambda _s: [0.0] * 1536)
+
+    # No video_id_filter passed → None reaches retrieval (search whole library).
+    await execute_tool("search_videos", json.dumps({"query": "anything"}))
+    assert captured["video_id_filter"] is None
+
+
+@pytest.mark.asyncio
+async def test_transcript_rejects_out_of_scope_video():
+    """When the whitelist is narrowed to the scoped set, a transcript request
+    for an out-of-scope (but otherwise valid) video is rejected."""
+    result = await execute_get_video_transcript(
+        {"video_id": "out-of-scope"},
+        video_id_whitelist={"in-scope-1", "in-scope-2"},
+    )
+    assert result["ok"] is False
+    assert "library" in result["error"].lower()

--- a/app/frontend/src/__tests__/VideoScopePicker.test.tsx
+++ b/app/frontend/src/__tests__/VideoScopePicker.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VideoScopePicker } from '../components/VideoScopePicker';
+import * as api from '../lib/api';
+
+const VIDEOS: api.Video[] = [
+  {
+    id: 'v1',
+    title: 'First Video',
+    description: '',
+    url: 'https://youtu.be/1',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'v2',
+    title: 'Second Video',
+    description: '',
+    url: 'https://youtu.be/2',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+];
+
+describe('VideoScopePicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(api, 'getVideos').mockResolvedValue(VIDEOS);
+    vi.spyOn(api, 'createConversation').mockResolvedValue({
+      id: 'c-new',
+      title: 'New Conversation',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      scoped_video_ids: null,
+    });
+  });
+
+  it('creates a scoped conversation with the selected video ids', async () => {
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    render(<VideoScopePicker isOpen={true} onClose={onClose} onCreated={onCreated} />);
+
+    // Wait for videos to load.
+    const first = await screen.findByText('First Video');
+    fireEvent.click(first);
+
+    fireEvent.click(screen.getByRole('button', { name: /start chat/i }));
+
+    await waitFor(() => expect(api.createConversation).toHaveBeenCalledTimes(1));
+    expect(api.createConversation).toHaveBeenCalledWith(['v1']);
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+  });
+
+  it('creates an unscoped conversation when nothing is selected', async () => {
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    render(<VideoScopePicker isOpen={true} onClose={onClose} onCreated={onCreated} />);
+
+    await screen.findByText('First Video');
+    // Default summary indicates search-all.
+    expect(screen.getByTestId('scope-summary').textContent).toMatch(/all videos/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /start chat/i }));
+
+    await waitFor(() => expect(api.createConversation).toHaveBeenCalledTimes(1));
+    // No ids passed → unscoped (search everything).
+    expect(api.createConversation).toHaveBeenCalledWith(undefined);
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <VideoScopePicker isOpen={false} onClose={vi.fn()} onCreated={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(api.getVideos).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -705,6 +705,43 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             ref={messagesWrapperRef}
             style={{ padding: '24px 24px 0', display: 'flex', flexDirection: 'column' }}
           >
+            {/* Scope banner (issue #279) — read-only indicator that this
+                conversation is restricted to a subset of videos. */}
+            {conversation?.scoped_video_ids && conversation.scoped_video_ids.length > 0 && (
+              <div
+                data-testid="scope-banner"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  alignSelf: 'flex-start',
+                  background: 'rgba(59,130,246,0.1)',
+                  border: '1px solid rgba(59,130,246,0.3)',
+                  borderRadius: 8,
+                  padding: '6px 12px',
+                  marginBottom: 16,
+                  fontSize: 13,
+                  color: '#93c5fd',
+                }}
+              >
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="1" y="2" width="12" height="10" rx="2" />
+                  <polygon points="5,4.5 9.5,7 5,9.5" fill="currentColor" stroke="none" />
+                </svg>
+                Scoped to {conversation.scoped_video_ids.length} video
+                {conversation.scoped_video_ids.length === 1 ? '' : 's'}
+              </div>
+            )}
+
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
 import { type Conversation, createConversation, deleteConversation } from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
+import { VideoScopePicker } from './VideoScopePicker';
 
 // ── Relative time helper ─────────────────────────────────────────
 function formatRelativeTime(dateStr: string): string {
@@ -422,6 +423,7 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(false);
   const [explorerOpen, setExplorerOpen] = useState(false);
+  const [scopePickerOpen, setScopePickerOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const { addToast } = useToast();
 
@@ -461,6 +463,15 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     } finally {
       setCreatingNew(false);
     }
+  };
+
+  // ── Scoped new chat (issue #279) ──
+  // The picker creates the conversation itself; we just refresh the list and
+  // navigate to it.
+  const handleScopedCreated = async (conv: Conversation) => {
+    await refetch();
+    navigate(`/c/${conv.id}`);
+    onClose();
   };
 
   // ── Delete flow ──
@@ -568,6 +579,56 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               <line x1="2" y1="7" x2="12" y2="7" />
             </svg>
             {creatingNew ? 'Creating…' : 'New Chat'}
+          </button>
+
+          {/* Scope-to-videos affordance (issue #279) — opens a picker that
+              creates a conversation restricted to the chosen videos. */}
+          <button
+            onClick={() => setScopePickerOpen(true)}
+            title="Start a chat scoped to specific videos"
+            className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            style={{
+              width: '100%',
+              marginTop: 6,
+              background: 'transparent',
+              color: '#94a3b8',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              padding: '7px 16px',
+              cursor: 'pointer',
+              fontWeight: 500,
+              fontSize: 13,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+              transition: 'background 0.15s, color 0.15s, border-color 0.15s',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = '#1e293b';
+              e.currentTarget.style.color = '#f1f5f9';
+              e.currentTarget.style.borderColor = 'rgba(59,130,246,0.4)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = '#94a3b8';
+              e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)';
+            }}
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="1" y="2" width="12" height="10" rx="2" />
+              <polygon points="5,4.5 9.5,7 5,9.5" fill="currentColor" stroke="none" />
+            </svg>
+            Scope to videos
           </button>
 
           {newChatError && (
@@ -854,6 +915,13 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
 
       {/* ── Video Explorer panel ── */}
       <VideoExplorer isOpen={explorerOpen} onClose={() => setExplorerOpen(false)} />
+
+      {/* ── Scope-to-videos picker (issue #279) ── */}
+      <VideoScopePicker
+        isOpen={scopePickerOpen}
+        onClose={() => setScopePickerOpen(false)}
+        onCreated={handleScopedCreated}
+      />
     </>
   );
 }

--- a/app/frontend/src/components/VideoScopePicker.tsx
+++ b/app/frontend/src/components/VideoScopePicker.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useState } from 'react';
+import { type Conversation, type Video, createConversation, getVideos } from '../lib/api';
+
+// ── Video scope picker (issue #279) ───────────────────────────────
+// Modal multi-select that creates a NEW conversation scoped to a subset of
+// videos. "Search all videos" (the default) creates an unscoped conversation
+// — identical to the plain New Chat path. Scope is immutable after creation,
+// so this only ever runs at conversation-creation time.
+interface VideoScopePickerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called with the freshly created conversation so the parent can refetch
+   *  the sidebar list and navigate to it. */
+  onCreated: (conv: Conversation) => void;
+}
+
+export function VideoScopePicker({ isOpen, onClose, onCreated }: VideoScopePickerProps) {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchVideos = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getVideos();
+      setVideos(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load videos');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Load videos and reset selection each time the picker opens.
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedIds(new Set());
+      setSearchQuery('');
+      setCreateError(null);
+      fetchVideos();
+    }
+  }, [isOpen, fetchVideos]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const q = searchQuery.trim().toLowerCase();
+  const filteredVideos = q
+    ? videos.filter((v) =>
+        [v.title, v.channel_title, v.description]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+          .includes(q),
+      )
+    : videos;
+
+  const scopeAll = selectedIds.size === 0;
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setCreateError(null);
+    try {
+      // No selection → unscoped (search-all) conversation. Otherwise scope to
+      // the selected ids.
+      const ids = scopeAll ? undefined : Array.from(selectedIds);
+      const conv = await createConversation(ids);
+      onCreated(conv);
+      onClose();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'Failed to create conversation.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Scope conversation to videos"
+        className="bg-slate-800 border border-white/10 rounded-xl p-6 w-[460px] max-w-[calc(100vw-48px)] max-h-[80vh] flex flex-col shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex justify-between items-center mb-2">
+          <h3 className="text-slate-100 text-base font-semibold m-0">Scope to videos</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="bg-none border-none text-slate-400 cursor-pointer text-lg focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+          >
+            ×
+          </button>
+        </div>
+        <p className="text-xs text-slate-400 mb-3 leading-relaxed">
+          Pick the videos this conversation should draw from. Leave everything unselected to search
+          the whole library. This choice is locked in once the conversation starts.
+        </p>
+
+        {/* Search */}
+        {!loading && !error && videos.length > 0 && (
+          <input
+            type="search"
+            placeholder="Filter videos…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            aria-label="Filter videos"
+            className="w-full p-2 mb-3 bg-slate-900 border border-white/10 rounded-md text-slate-100 text-sm box-border outline-none focus:border-blue-500 transition-colors"
+          />
+        )}
+
+        {/* Video list */}
+        <div className="flex-1 overflow-y-auto -mx-1 px-1 flex flex-col gap-1.5">
+          {loading && <p className="py-6 text-center text-slate-500 text-sm">Loading videos…</p>}
+
+          {!loading && error && (
+            <div className="py-6 text-center">
+              <p className="m-0 text-red-500 text-sm mb-2">{error}</p>
+              <button
+                onClick={fetchVideos}
+                className="bg-slate-700 border border-white/10 rounded-md text-slate-100 cursor-pointer px-4 py-1.5 text-sm focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {!loading && !error && videos.length === 0 && (
+            <p className="py-6 text-center text-slate-500 text-sm">
+              No videos in the library yet.
+            </p>
+          )}
+
+          {!loading && !error && videos.length > 0 && filteredVideos.length === 0 && (
+            <p className="py-6 text-center text-slate-500 text-sm">
+              No videos match &ldquo;{searchQuery}&rdquo;
+            </p>
+          )}
+
+          {!loading &&
+            !error &&
+            filteredVideos.map((video) => (
+              <label
+                key={video.id}
+                className="flex items-start gap-2.5 p-2 rounded-md cursor-pointer hover:bg-slate-700/60 transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(video.id)}
+                  onChange={() => toggle(video.id)}
+                  className="mt-0.5 accent-blue-500 cursor-pointer"
+                />
+                <span className="flex flex-col min-w-0">
+                  <span className="text-sm text-slate-100 leading-tight truncate">
+                    {video.title}
+                  </span>
+                  {video.channel_title && (
+                    <span className="text-xs text-slate-400 truncate">{video.channel_title}</span>
+                  )}
+                </span>
+              </label>
+            ))}
+        </div>
+
+        {createError && <p className="text-red-400 mt-3 text-sm">{createError}</p>}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between gap-3 mt-4 pt-3 border-t border-white/10">
+          <span className="text-xs text-slate-400" data-testid="scope-summary">
+            {scopeAll ? 'Searching all videos' : `Scoped to ${selectedIds.size} video${selectedIds.size === 1 ? '' : 's'}`}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-transparent border border-white/20 rounded-md text-slate-400 text-sm cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={creating || loading}
+              className="px-4 py-2 bg-blue-500 border-none rounded-md text-white text-sm cursor-pointer disabled:opacity-75 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            >
+              {creating ? 'Creating…' : 'Start chat'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/hooks/useMessages.ts
+++ b/app/frontend/src/hooks/useMessages.ts
@@ -30,6 +30,9 @@ export function useMessages(conversationId: string | null) {
           title: data.title,
           created_at: data.created_at,
           updated_at: data.updated_at,
+          // Surface the per-conversation video scope (issue #279) so ChatArea
+          // can render the "Scoped to N videos" banner.
+          scoped_video_ids: data.scoped_video_ids,
         });
       })
       .catch((e) => {

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -41,6 +41,13 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   preview?: string | null;
+  /**
+   * Optional per-conversation video scope (issue #279). When non-empty, the
+   * assistant's retrieval and citations in this conversation are restricted to
+   * these video ids. null/undefined means "search the whole library". Set once
+   * at creation and immutable thereafter.
+   */
+  scoped_video_ids?: string[] | null;
 }
 
 export interface Citation {
@@ -146,8 +153,13 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const getConversations = () => request<Conversation[]>('/conversations');
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
-export const createConversation = () =>
-  request<Conversation>('/conversations', { method: 'POST', body: '{}' });
+export const createConversation = (scopedVideoIds?: string[]) =>
+  request<Conversation>('/conversations', {
+    method: 'POST',
+    body: JSON.stringify({
+      scoped_video_ids: scopedVideoIds?.length ? scopedVideoIds : null,
+    }),
+  });
 export const getConversation = (id: string) =>
   request<ConversationWithMessages>(`/conversations/${id}`);
 export const deleteConversation = (id: string) =>


### PR DESCRIPTION
Fixes #279

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `d27f5e77-41a5-46ab-8599-b0f18ebea372`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.