### PR TITLE
[bench-OO] review: replace inline styles with Tailwind classes on Regenerate button

### DIFF
--- a/.archon/workflows/benchmark-FF.yaml
+++ b/.archon/workflows/benchmark-FF.yaml
@@ -1,0 +1,155 @@
+name: benchmark-FF
+description: |
+  Benchmark cell: plan=Fable, impl=Fable (claude-fable-5 both slots).
+  The premium-tier ceiling. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FF"
+      CELL_DESC="plan=Fable, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FK.yaml
+++ b/.archon/workflows/benchmark-FK.yaml
@@ -1,0 +1,156 @@
+name: benchmark-FK
+description: |
+  Benchmark cell: plan=Fable, impl=Kimi (K2.6 via Pi). The value play —
+  premium-tier planning, cheap implementation. Directly compares to OK (Opus
+  plan) from the prior run. See benchmark-OO.yaml for the full design notes.
+  This file differs only in the plan and implement node provider/model
+  overrides + the cell label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: pi
+    model: kimi-coding/kimi-for-coding
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FK"
+      CELL_DESC="plan=Fable, impl=Kimi"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-FO.yaml
+++ b/.archon/workflows/benchmark-FO.yaml
@@ -1,0 +1,154 @@
+name: benchmark-FO
+description: |
+  Benchmark cell: plan=Fable, impl=Opus. Tests whether Fable's edge lives in
+  the PLANNING step. See benchmark-OO.yaml for the full design notes. This file
+  differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: opus
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="FO"
+      CELL_DESC="plan=Fable, impl=Opus"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/.archon/workflows/benchmark-OF.yaml
+++ b/.archon/workflows/benchmark-OF.yaml
@@ -1,0 +1,154 @@
+name: benchmark-OF
+description: |
+  Benchmark cell: plan=Opus, impl=Fable. Tests whether Fable's edge lives in
+  the IMPLEMENTATION step. See benchmark-OO.yaml for the full design notes. This
+  file differs only in the plan and implement node provider/model overrides + label.
+
+provider: claude
+model: sonnet
+
+nodes:
+  - id: fetch-issue
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "ERROR: No issue number in arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$ISSUE_NUM" > "$ARTIFACTS_DIR/.issue-number"
+      gh issue view "$ISSUE_NUM" --json number,title,body,labels,author,createdAt
+    timeout: 20000
+
+  - id: explore
+    prompt: |
+      You are a codebase explorer. Read the issue and gather context needed
+      to plan a fix. Do NOT edit anything in this node.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Instructions
+
+      Use Read, Grep, and Glob to explore the repository. Look for:
+      - Files and modules involved in the issue
+      - Existing patterns and conventions to follow
+      - Tests that cover the affected code
+      - Constraints in CLAUDE.md, MISSION.md, or FACTORY_RULES.md
+
+      Write your output to `$ARTIFACTS_DIR/exploration.md` with sections:
+      - **What the issue asks**: one paragraph rephrasing the issue
+      - **Relevant files**: bullet list with paths
+      - **Relevant patterns**: any code patterns or constraints the fix must respect
+      - **Risks / edge cases**: what could go wrong
+
+      Keep it focused — under 500 words. Do NOT propose a solution here.
+    depends_on: [fetch-issue]
+    context: fresh
+
+  - id: plan
+    prompt: |
+      You are a planner. Based on the issue and exploration, write a concrete
+      implementation plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Exploration
+      Read `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      Write your plan to `$ARTIFACTS_DIR/plan.md` with sections:
+      - **Approach**: one paragraph
+      - **Files to change**: bullet list with paths and brief reason per file
+      - **Specific changes**: ordered bullet list of code edits
+      - **Tests**: what tests to add or update
+      - **Out of scope**: what NOT to touch
+
+      Prefer minimal, surgical changes. Do NOT execute any edits here.
+    provider: claude
+    model: opus
+    depends_on: [explore]
+    context: fresh
+
+  - id: implement
+    prompt: |
+      You are the implementer. Execute the plan exactly as written.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md` and `$ARTIFACTS_DIR/exploration.md`.
+
+      ## Instructions
+
+      1. Make the edits the plan calls for. Use Read/Edit/Write/Bash tools.
+      2. Stay strictly in scope. Only touch files the plan lists.
+      3. Run cheap sanity checks if applicable.
+      4. When done, stage and commit:
+         `git add -A && git commit -m "impl: address issue"`
+      5. Do NOT push or create a PR.
+    provider: claude
+    model: claude-fable-5
+    depends_on: [plan]
+    context: fresh
+
+  - id: self-review
+    prompt: |
+      You are an independent reviewer. Read the current diff and review it
+      against the issue and the plan.
+
+      ## Issue
+      $fetch-issue.output
+
+      ## Plan
+      Read `$ARTIFACTS_DIR/plan.md`.
+
+      ## Instructions
+
+      1. Run `git diff main...HEAD` to see what changed.
+      2. Critique the diff for: solves-issue, subtle correctness, scope creep,
+         missing tests.
+      3. Fix anything you find. Do NOT add new scope.
+      4. If you make changes, commit them:
+         `git add -A && git commit -m "review: address self-review findings"`
+      5. Write a brief summary or `NOTHING_TO_FIX` to
+         `$ARTIFACTS_DIR/review-result.txt`.
+    depends_on: [implement]
+    context: fresh
+
+  - id: create-pr
+    bash: |
+      set -euo pipefail
+      ISSUE_NUM=$(cat "$ARTIFACTS_DIR/.issue-number")
+      BRANCH=$(git branch --show-current)
+      CELL="OF"
+      CELL_DESC="plan=Opus, impl=Fable"
+      RUN_ID=$(basename "$ARTIFACTS_DIR")
+
+      git push -u origin "$BRANCH"
+
+      BODY="Fixes #${ISSUE_NUM}
+
+      **Benchmark cell:** \`${CELL}\` (${CELL_DESC})
+      **Source run-id:** \`${RUN_ID}\`
+
+      Held-constant: explore + self-review on Sonnet.
+
+      Produced by the mixed-provider routing benchmark.
+      See \`benchmark-evaluator\` workflow for the scored verdict."
+
+      PR_URL=$(gh pr create \
+        --draft \
+        --title "[bench-${CELL}] $(git log -1 --pretty=%s)" \
+        --body "$BODY" \
+        --label "benchmark:${CELL}")
+
+      echo "Created draft PR: $PR_URL"
+      PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' | tail -1)
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "PR #${PR_NUM}"
+    depends_on: [self-review]
+    timeout: 60000

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -577,6 +577,68 @@ async def create_message(
     }
 
 
+async def replace_last_assistant_message(
+    *,
+    conversation_id: str,
+    user_id: str,
+    content: str,
+    sources: list[dict] | None = None,
+) -> dict | None:
+    """Atomically delete the most recent assistant message and insert a
+    replacement (used by the regenerate flow).
+
+    Returns None if the conversation does not belong to the user. The delete
+    and insert run in a single transaction so a reload can never observe the
+    conversation with the old assistant message removed but no replacement.
+    """
+    msg_id = _new_id()
+    now = _now()
+    sources_json = json.dumps(sources) if sources is not None else None
+    async with _acquire() as conn, conn.transaction():
+        # Ownership gate — mirror create_message's cross-user guard. If the
+        # conversation isn't owned by this user, do nothing and signal None.
+        owned = await conn.fetchval(
+            "SELECT 1 FROM conversations WHERE id = $1 AND user_id = $2",
+            conversation_id,
+            user_id,
+        )
+        if not owned:
+            return None
+        # Delete only the single most-recent assistant message.
+        await conn.execute(
+            """
+            DELETE FROM messages
+            WHERE id = (
+                SELECT id FROM messages
+                WHERE conversation_id = $1 AND role = 'assistant'
+                ORDER BY created_at DESC
+                LIMIT 1
+            )
+            """,
+            conversation_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO messages (id, conversation_id, role, content, sources, created_at)
+            VALUES ($1, $2, 'assistant', $3, $4::jsonb, $5)
+            """,
+            msg_id,
+            conversation_id,
+            content,
+            sources_json,
+            now,
+        )
+    await touch_conversation(conversation_id, user_id)
+    return {
+        "id": msg_id,
+        "conversation_id": conversation_id,
+        "role": "assistant",
+        "content": content,
+        "sources": sources,
+        "created_at": now,
+    }
+
+
 async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     """Return messages only if the conversation belongs to the given user."""
     async with _acquire() as conn:

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -116,7 +116,152 @@ async def create_message(
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
 
-    # 5. Set up tool plumbing. All retrieval happens inside the LLM loop via
+    # 5. Persist the completed assistant message + best-effort title update.
+    #    Both writes are shielded so a client disconnect mid-stream can't drop
+    #    the save (see _build_streaming_response for the full rationale).
+    async def _persist(assistant_text: str, sources_to_persist: list[dict] | None) -> None:
+        try:
+            await asyncio.shield(
+                repository.create_message(
+                    conversation_id=conv_id,
+                    user_id=user_id,
+                    role="assistant",
+                    content=assistant_text,
+                    sources=sources_to_persist,
+                )
+            )
+        except asyncio.CancelledError:
+            logger.info(
+                "Client disconnected mid-persist; shielded create_message continues in background"
+            )
+        except Exception as exc:
+            logger.error("Failed to persist assistant message: %s", exc)
+            raise
+        # Title auto-generation is best-effort: client-disconnect swallowed,
+        # unexpected errors logged but not re-raised (message was saved above).
+        try:
+            await asyncio.shield(_maybe_set_conversation_title(conv_id, user_id, user_content))
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.warning("Failed to update conversation title: %s", exc)
+
+    return _build_streaming_response(
+        conv_id=conv_id,
+        user_id=user_id,
+        current_user=current_user,
+        llm_messages=llm_messages,
+        persist=_persist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Re-run the RAG flow against the existing conversation history (with the
+    trailing assistant message excluded) and stream a fresh assistant answer
+    that replaces the old one in place.
+
+    Counts as exactly one message against the daily cap — regenerate cannot be
+    used to bypass MISSION §10 invariant #1.
+
+    Returns:
+        StreamingResponse with Content-Type: text/event-stream (same wire
+        format as create_message).
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user.
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. There must be a trailing assistant message to regenerate. Validate
+    #    BEFORE charging the rate limit so an invalid request doesn't burn quota.
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+    if not all_messages or all_messages[-1]["role"] != "assistant":
+        raise HTTPException(status_code=409, detail="No assistant response to regenerate")
+
+    # 3. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1).
+    #    A regenerate is one message; the audit row is inserted on pass so it
+    #    cannot be used to sneak past the cap.
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 4. Build history excluding the trailing assistant message — the model
+    #    answers the same last user turn afresh.
+    llm_messages = [
+        {"role": m["role"], "content": m["content"]} for m in all_messages[:-1]
+    ]
+
+    # 5. Persist by replacing the most-recent assistant message in place. No
+    #    title generation — the conversation is already titled.
+    async def _persist(assistant_text: str, sources_to_persist: list[dict] | None) -> None:
+        try:
+            await asyncio.shield(
+                repository.replace_last_assistant_message(
+                    conversation_id=conv_id,
+                    user_id=user_id,
+                    content=assistant_text,
+                    sources=sources_to_persist,
+                )
+            )
+        except asyncio.CancelledError:
+            logger.info(
+                "Client disconnected mid-persist; shielded replace continues in background"
+            )
+        except Exception as exc:
+            logger.error("Failed to persist regenerated assistant message: %s", exc)
+            raise
+
+    return _build_streaming_response(
+        conv_id=conv_id,
+        user_id=user_id,
+        current_user=current_user,
+        llm_messages=llm_messages,
+        persist=_persist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared streaming response builder
+# ---------------------------------------------------------------------------
+
+
+def _build_streaming_response(
+    *,
+    conv_id: str,
+    user_id: str,
+    current_user: dict[str, Any],
+    llm_messages: list[dict[str, Any]],
+    persist: Callable[[str, list[dict] | None], Awaitable[None]],
+) -> StreamingResponse:
+    """Wire up the tool-driven RAG stream and return a StreamingResponse.
+
+    Shared by create_message and regenerate_message — the only difference
+    between the two flows is the ``persist`` callback (insert-new vs.
+    replace-last), so everything from tool setup through SSE generation lives
+    here to guarantee zero behavioral drift between the two paths.
+    """
+    # Set up tool plumbing. All retrieval happens inside the LLM loop via
     # tool calls — no pre-retrieval runs here. The executor closure collects
     # every chunk returned by any tool call so the final SSE `sources` event
     # lists exactly what the model actually read. The video_id whitelist is
@@ -126,58 +271,62 @@ async def create_message(
     tool_chunks_acc: list[dict] = []
     embedding_cache: dict[str, list[float]] = {}
     tools_param: list[dict] | None = None
-    executor = None
+    executor: Callable[[str, str], Awaitable[str]] | None = None
     max_tool_calls = 0
-    if LLM_TOOLS_ENABLED:
-        try:
-            all_videos = await repository.list_videos()
-            video_id_whitelist: set[str] = {v["id"] for v in all_videos if v.get("id")}
-        except Exception as exc:
-            logger.warning(
-                "Failed to load video whitelist for tool use; transcript tool calls will be unguarded: %s",
-                exc,
-            )
-            video_id_whitelist = set()
 
-        # Captured at the start of the turn so the entire tool sequence sees
-        # consistent ACL — even if /me later flips is_member, the in-flight
-        # turn won't change behavior mid-flight.
-        is_member_for_turn = bool(current_user.get("is_member", False))
-
-        async def _executor(name: str, raw_args: str) -> str:
-            # Pass `None` (not empty set) when the whitelist failed to load so
-            # the transcript tool falls back to open lookups instead of rejecting
-            # every id.
-            whitelist = video_id_whitelist if video_id_whitelist else None
-            result = await execute_tool(
-                name,
-                raw_args,
-                video_id_whitelist=whitelist,
-                embedding_cache=embedding_cache,
-                is_member=is_member_for_turn,
-            )
-            if result.get("ok") and result.get("chunks"):
-                tool_chunks_acc.extend(result["chunks"])
-            return serialize_tool_result(result)
-
-        tools_param = TOOL_SCHEMAS
-        executor = _executor
-        max_tool_calls = LLM_TOOLS_MAX_PER_TURN
+    # The video-whitelist load is async, so it runs at the top of
+    # event_generator (a sync function can't await) rather than here.
 
     # 6. Stream the response. The model drives retrieval via tool calls;
     # chunks it pulls flow into source_citations via tool_chunks_acc.
     # ``final_text_buf`` receives the assistant's final-round text so the
     # refusal check ignores inter-round commentary ("let me try semantic").
     async def event_generator() -> AsyncGenerator[str, None]:
+        nonlocal tools_param, executor, max_tool_calls
+        if LLM_TOOLS_ENABLED:
+            try:
+                all_videos = await repository.list_videos()
+                video_id_whitelist: set[str] = {v["id"] for v in all_videos if v.get("id")}
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load video whitelist for tool use; transcript tool calls will be unguarded: %s",
+                    exc,
+                )
+                video_id_whitelist = set()
+
+            # Captured at the start of the turn so the entire tool sequence sees
+            # consistent ACL — even if /me later flips is_member, the in-flight
+            # turn won't change behavior mid-flight.
+            is_member_for_turn = bool(current_user.get("is_member", False))
+
+            async def _executor(name: str, raw_args: str) -> str:
+                # Pass `None` (not empty set) when the whitelist failed to load so
+                # the transcript tool falls back to open lookups instead of rejecting
+                # every id.
+                whitelist = video_id_whitelist if video_id_whitelist else None
+                result = await execute_tool(
+                    name,
+                    raw_args,
+                    video_id_whitelist=whitelist,
+                    embedding_cache=embedding_cache,
+                    is_member=is_member_for_turn,
+                )
+                if result.get("ok") and result.get("chunks"):
+                    tool_chunks_acc.extend(result["chunks"])
+                return serialize_tool_result(result)
+
+            tools_param = TOOL_SCHEMAS
+            executor = _executor
+            max_tool_calls = LLM_TOOLS_MAX_PER_TURN
+
         full_response: list[str] = []
         final_text_buf: list[str] = []
         # Two-tier citations (issue #176): strip `[c:<id>]` markers from the
         # stream; use them at [DONE] to flag is_cited on retrieved chunks.
         marker_stripper = CitationMarkerStripper()
         try:
-            # is_member_for_turn is captured above when tools are wired.
-            # Re-bind to a local that's always defined so we can pass it
-            # to stream_chat regardless of whether tools are enabled
+            # Re-bind is_member to a local that's always defined so we can pass
+            # it to stream_chat regardless of whether tools are enabled
             # (catalog filtering belongs to the prompt, not the tools).
             turn_is_member = bool(current_user.get("is_member") or False)
             async for sse_chunk in stream_chat(
@@ -247,13 +396,12 @@ async def create_message(
             # (the model runs several tool rounds before composing the final
             # answer). Some clients/proxies abort long fetches in that window,
             # which cancels this generator's task. Without asyncio.shield, the
-            # `await repository.create_message(...)` re-raises CancelledError
+            # `await repository.<persist>(...)` re-raises CancelledError
             # immediately — and because CancelledError is a BaseException (not
             # Exception) in Python 3.11, it bypasses the try/except below and
-            # silently drops the save. Shielding runs the save as a detached
-            # task that completes independently of the client's connection
-            # state; we catch the re-raised CancelledError so the generator
-            # can exit cleanly.
+            # silently drops the save. Shielding (inside the persist callback)
+            # runs the save as a detached task that completes independently of
+            # the client's connection state.
             assistant_text = _extract_text_from_sse(full_response)
             if assistant_text:
                 # Apply the same refusal detection used for the live SSE
@@ -272,33 +420,7 @@ async def create_message(
                     if not source_citations or _is_refusal(refusal_check_text)
                     else source_citations
                 )
-                try:
-                    await asyncio.shield(
-                        repository.create_message(
-                            conversation_id=conv_id,
-                            user_id=user_id,
-                            role="assistant",
-                            content=assistant_text,
-                            sources=sources_to_persist,
-                        )
-                    )
-                except asyncio.CancelledError:
-                    logger.info(
-                        "Client disconnected mid-persist; shielded create_message continues in background"
-                    )
-                except Exception as exc:
-                    logger.error("Failed to persist assistant message: %s", exc)
-                    raise
-                # Title auto-generation is best-effort: client-disconnect swallowed,
-                # unexpected errors logged but not re-raised (message was saved above).
-                try:
-                    await asyncio.shield(
-                        _maybe_set_conversation_title(conv_id, user_id, user_content)
-                    )
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:
-                    logger.warning("Failed to update conversation title: %s", exc)
+                await persist(assistant_text, sources_to_persist)
 
     return StreamingResponse(
         event_generator(),

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,317 @@
+"""
+Integration tests for POST /api/conversations/{conv_id}/regenerate (issue #280).
+
+The regenerate route re-runs the RAG/streaming flow against the conversation
+history with the trailing assistant message excluded, then replaces that old
+assistant message in place. It must:
+  - stream the same SSE wire format as create_message,
+  - call replace_last_assistant_message exactly once with the fresh content,
+  - exclude the trailing assistant message from the LLM history,
+  - reject when there is nothing to regenerate (409) without charging quota,
+  - 404 on a non-owned conversation,
+  - count as exactly one message against the daily cap (429 when capped).
+
+Mirrors the httpx.AsyncClient + monkeypatch pattern in test_sources_event.py
+and leans on conftest's patch_pg_pool / patch_rate_limit fixtures.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend import rate_limit
+from backend.auth.tokens import encode_token
+
+
+def _answer_stream(answer_text: str):
+    """Build a mock stream_chat that records the history it was called with."""
+    captured: dict = {}
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        captured["messages"] = messages
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(answer_text)}\n\n"
+        if final_text_out is not None:
+            final_text_out.append(answer_text)
+        yield "data: [DONE]\n\n"
+
+    return mock_stream_chat, captured
+
+
+def _user_then_assistant(test_conv_id: str):
+    """History ending in an assistant message (the regenerate-able case)."""
+    return [
+        {
+            "id": "m1",
+            "conversation_id": test_conv_id,
+            "role": "user",
+            "content": "What is hybrid RAG?",
+            "created_at": "2026-01-01T00:00:00Z",
+        },
+        {
+            "id": "m2",
+            "conversation_id": test_conv_id,
+            "role": "assistant",
+            "content": "Old answer.",
+            "created_at": "2026-01-01T00:00:01Z",
+        },
+    ]
+
+
+async def _mock_execute_tool(
+    name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+):
+    return {
+        "ok": True,
+        "text": "context",
+        "chunks": [
+            {
+                "chunk_id": "c1",
+                "video_id": "v1",
+                "video_title": "Test Video",
+                "video_url": "https://youtube.com/watch?v=abc",
+                "start_seconds": 10.0,
+                "end_seconds": 20.0,
+                "snippet": "Test snippet",
+            }
+        ],
+    }
+
+
+def _auth(test_user_id: str):
+    async def mock_get_user_by_id(user_id):
+        return {
+            "id": test_user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    return mock_get_user_by_id
+
+
+def _owned_conversation(test_conv_id: str, test_user_id: str):
+    async def mock_get_conversation(conv_id, user_id):
+        if conv_id == test_conv_id and user_id == test_user_id:
+            return {
+                "id": test_conv_id,
+                "user_id": test_user_id,
+                "title": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        return None
+
+    return mock_get_conversation
+
+
+class TestRegenerateHappyPath:
+    async def test_regenerate_streams_and_replaces(self, message_store) -> None:
+        """200 + text/event-stream; replace called once; history excludes the
+        trailing assistant message; rate limit charged exactly once."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        mock_stream_chat, captured = _answer_stream("Fresh answer about hybrid RAG.")
+        replace_spy = AsyncMock(return_value={"id": str(uuid4())})
+
+        async def mock_list_messages(conv_id, user_id):
+            return _user_then_assistant(test_conv_id)
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _auth(test_user_id)),
+            patch(
+                "backend.db.repository.get_conversation",
+                _owned_conversation(test_conv_id, test_user_id),
+            ),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.replace_last_assistant_message", replace_spy),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", _mock_execute_tool),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        body = response.text
+        assert "Fresh answer about hybrid RAG." in body
+        assert "data: [DONE]" in body
+
+        # replace_last_assistant_message called once with the streamed content.
+        assert replace_spy.call_count == 1
+        assert replace_spy.call_args.kwargs["content"] == "Fresh answer about hybrid RAG."
+
+        # The history handed to the LLM excludes the trailing assistant message.
+        history = captured["messages"]
+        assert history[-1]["role"] == "user"
+        assert all(m["role"] != "assistant" for m in history)
+
+        # Counted exactly once against the cap.
+        assert len(message_store[test_user_id]) == 1
+
+
+class TestRegenerateNothingToRegenerate:
+    async def test_409_when_last_message_is_user(self, message_store) -> None:
+        """If the last message is a user turn, 409 — and no replace, no charge."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        replace_spy = AsyncMock()
+
+        async def mock_list_messages(conv_id, user_id):
+            return [
+                {
+                    "id": "m1",
+                    "conversation_id": test_conv_id,
+                    "role": "user",
+                    "content": "Hi",
+                    "created_at": "2026-01-01T00:00:00Z",
+                }
+            ]
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _auth(test_user_id)),
+            patch(
+                "backend.db.repository.get_conversation",
+                _owned_conversation(test_conv_id, test_user_id),
+            ),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.replace_last_assistant_message", replace_spy),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 409
+        assert replace_spy.call_count == 0
+        # Quota not charged for an invalid request.
+        assert len(message_store[test_user_id]) == 0
+
+    async def test_409_when_no_messages(self, message_store) -> None:
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        replace_spy = AsyncMock()
+
+        async def mock_list_messages(conv_id, user_id):
+            return []
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _auth(test_user_id)),
+            patch(
+                "backend.db.repository.get_conversation",
+                _owned_conversation(test_conv_id, test_user_id),
+            ),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.replace_last_assistant_message", replace_spy),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 409
+        assert replace_spy.call_count == 0
+        assert len(message_store[test_user_id]) == 0
+
+
+class TestRegenerateNotFound:
+    async def test_404_when_conversation_not_owned(self, message_store) -> None:
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        async def mock_get_conversation(conv_id, user_id):
+            return None
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _auth(test_user_id)),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 404
+        assert len(message_store[test_user_id]) == 0
+
+
+class TestRegenerateRateLimited:
+    async def test_429_when_capped(self, message_store) -> None:
+        """At the cap, regenerate returns 429 with the standard body and does
+        not replace the message."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        # Seed the in-memory store to the cap (all within the window).
+        now = datetime.now(UTC)
+        message_store[test_user_id] = [
+            now - timedelta(minutes=i) for i in range(rate_limit.DAILY_MESSAGE_CAP)
+        ]
+
+        replace_spy = AsyncMock()
+
+        async def mock_list_messages(conv_id, user_id):
+            return _user_then_assistant(test_conv_id)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", _auth(test_user_id)),
+            patch(
+                "backend.db.repository.get_conversation",
+                _owned_conversation(test_conv_id, test_user_id),
+            ),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.replace_last_assistant_message", replace_spy),
+        ):
+            transport = ASGITransport(app=_app())
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+        assert body["window_hours"] == rate_limit.WINDOW_HOURS
+        assert "reset_at" in body
+        assert replace_spy.call_count == 0
+
+
+def _app():
+    # Import lazily so conftest env + fixtures are in place first.
+    from backend.main import app
+
+    return app

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -583,6 +584,68 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     handleSend(text);
   }, [failedMessageText, handleSend]);
 
+  // ── Regenerate handler — replace the last assistant message with a fresh take ──
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId || isStreaming) return;
+
+    // The button only renders on the last assistant message, but guard anyway.
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+    if (!lastAssistant) return;
+
+    // Clear any prior inline error and optimistically remove the old answer so
+    // the streaming bubble replaces it in place.
+    setInlineError(null);
+    setFailedMessageText(null);
+    setMessages((prev) => prev.filter((m) => m.id !== lastAssistant.id));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await startRegenerate(conversationId, ({ fullText, sources }) => {
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      // Pull fresh quota counter — a regenerate counts as one message.
+      refreshAuth();
+    } catch (e) {
+      // Restore the original assistant message so nothing is lost on failure.
+      setMessages((prev) => [...prev, lastAssistant]);
+
+      // Intentional abort (navigation or user cancel) — no error toast.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate the response';
+      setInlineError('Failed to regenerate the response. Please try again.');
+      addToast(errMsg || 'Network error — could not regenerate', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    setMessages,
+    startRegenerate,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+  ]);
+
   // ── Starter click handler ──
   const handleStarterClick = useCallback((text: string) => {
     chatInputRef.current?.setInputText(text);
@@ -601,6 +664,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // before dispatchedInitialRef fires (#205).
   const showEmptyInConversation =
     messages.length === 0 && !inlineError && !isStreaming && !location.state?.initialMessage;
+
+  // The Regenerate button is only offered on the most recent assistant message.
+  const lastAssistantId = [...messages].reverse().find((m) => m.role === 'assistant')?.id;
 
   const handleExport = useCallback(() => {
     try {
@@ -715,6 +781,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  onRegenerate={
+                    !isStreaming && msg.id === lastAssistantId ? handleRegenerate : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Citation } from '../lib/api';
 import { Message } from './Message';
@@ -147,5 +147,31 @@ describe('Message — citation chip segment_count label', () => {
       />,
     );
     expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — Regenerate button', () => {
+  it('renders the Regenerate button for an assistant message when onRegenerate is provided', () => {
+    render(
+      <Message role="assistant" content="Answer text." onRegenerate={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /Regenerate/ })).toBeInTheDocument();
+  });
+
+  it('calls onRegenerate when the button is clicked', () => {
+    const onRegenerate = vi.fn();
+    render(<Message role="assistant" content="Answer text." onRegenerate={onRegenerate} />);
+    fireEvent.click(screen.getByRole('button', { name: /Regenerate/ }));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the button when onRegenerate is omitted', () => {
+    render(<Message role="assistant" content="Answer text." />);
+    expect(screen.queryByRole('button', { name: /Regenerate/ })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button for a user message even if onRegenerate is passed', () => {
+    render(<Message role="user" content="My question." onRegenerate={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /Regenerate/ })).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,8 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** When provided (last assistant message only), renders a Regenerate button */
+  onRegenerate?: () => void;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,6 +169,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +207,32 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && (
+              <div style={{ marginTop: 8 }}>
+                <button
+                  onClick={onRegenerate}
+                  title="Regenerate this response"
+                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#94a3b8',
+                    fontSize: 12,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: 0,
+                    fontFamily: 'inherit',
+                    transition: 'color 0.15s',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
+                  onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+                >
+                  ↻ Regenerate
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -208,26 +208,11 @@ export function Message({
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
             {onRegenerate && (
-              <div style={{ marginTop: 8 }}>
+              <div className="mt-2">
                 <button
                   onClick={onRegenerate}
                   title="Regenerate this response"
-                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
-                  style={{
-                    background: 'transparent',
-                    border: 'none',
-                    cursor: 'pointer',
-                    color: '#94a3b8',
-                    fontSize: 12,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 5,
-                    padding: 0,
-                    fontFamily: 'inherit',
-                    transition: 'color 0.15s',
-                  }}
-                  onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
-                  onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+                  className="flex items-center gap-[5px] p-0 bg-transparent border-0 cursor-pointer text-xs text-slate-400 hover:text-slate-100 transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
                 >
                   ↻ Regenerate
                 </button>

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -439,6 +439,57 @@ describe('status event SSE parsing — hook state transitions', () => {
   });
 });
 
+describe('startRegenerate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the regenerate endpoint with no body and parses tokens + sources', async () => {
+    const citation = {
+      chunk_id: 'chunk-1',
+      video_id: 'vid-1',
+      video_title: 'Test Video',
+      video_url: 'https://www.youtube.com/watch?v=abc123',
+      start_seconds: 10,
+      end_seconds: 20,
+      snippet: 'Test snippet text',
+    };
+    const sseChunks = [
+      `event: sources\ndata: ${JSON.stringify([citation])}\n\n`,
+      'data: "Fresh answer"\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(sseChunks),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startRegenerate('conv-1', onComplete);
+    });
+
+    // Hits the regenerate endpoint, not /messages.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/regenerate');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+
+    // Parses tokens + sources identically to startStream.
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullText: 'Fresh answer',
+        sources: [expect.objectContaining({ chunk_id: 'chunk-1' })],
+      }),
+    );
+  });
+});
+
 describe('abortStream', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -42,10 +42,14 @@ export function useStreamingResponse(conversationId: string | null) {
     }
   }, []);
 
-  const startStream = useCallback(
+  // Shared fetch + SSE-parse core. `startStream` and `startRegenerate` are thin
+  // wrappers that differ only in URL and request body — everything below
+  // (401/429/error handling, SSE token/sources/status parsing, state reset) is
+  // identical so the regenerate UX matches a normal send exactly.
+  const runStream = useCallback(
     async (
-      conversationId: string,
-      userMessage: string,
+      url: string,
+      body: object | null,
       onComplete: (result: StreamResult) => void,
     ): Promise<void> => {
       setIsStreaming(true);
@@ -61,11 +65,11 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+        const res = await fetch(url, {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
+          body: body ? JSON.stringify(body) : undefined,
           signal: abortController.signal,
         });
 
@@ -218,12 +222,35 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startStream = useCallback(
+    (
+      conversationId: string,
+      userMessage: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> =>
+      runStream(
+        `/api/conversations/${conversationId}/messages`,
+        { content: userMessage },
+        onComplete,
+      ),
+    [runStream],
+  );
+
+  // Regenerate the last assistant message — no request body; the backend
+  // re-runs the existing conversation history (minus the trailing answer).
+  const startRegenerate = useCallback(
+    (conversationId: string, onComplete: (result: StreamResult) => void): Promise<void> =>
+      runStream(`/api/conversations/${conversationId}/regenerate`, null, onComplete),
+    [runStream],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   };
 }


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `ae507d40-02cd-42e3-aac4-ad62f5113a10`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.