### PR TITLE
[bench-FO] review: address self-review findings

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -603,6 +603,41 @@ async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     return results
 
 
+async def delete_last_assistant_message(conversation_id: str, user_id: str) -> bool:
+    """Atomically delete the conversation's most recent message *only if* it is
+    an assistant message and the conversation belongs to the user.
+
+    Used by the regenerate flow (issue #280): the stale assistant answer is
+    removed before a fresh one is streamed in its place. The ``role =
+    'assistant'`` guard on the outer DELETE makes "only delete if the *last*
+    message is an assistant message" atomic — no read-then-delete race.
+
+    Returns True if a row was deleted, False otherwise (last message was a
+    user message, empty conversation, or wrong user).
+    """
+    async with _acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            DELETE FROM messages
+            WHERE id = (
+                SELECT m.id FROM messages m
+                JOIN conversations c ON c.id = m.conversation_id
+                WHERE m.conversation_id = $1 AND c.user_id = $2
+                ORDER BY m.created_at DESC
+                LIMIT 1
+            )
+            AND role = 'assistant'
+            RETURNING id
+            """,
+            conversation_id,
+            user_id,
+        )
+    if row is None:
+        return False
+    await touch_conversation(conversation_id, user_id)
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Channel sync runs
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -112,6 +112,92 @@ async def create_message(
     if inserted is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    return await _stream_assistant_response(conv_id, user_id, current_user, user_content)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/messages/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/messages/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate the most recent assistant response (issue #280).
+
+    Deletes the conversation's last assistant message and re-streams a fresh
+    answer against the existing history. The guards run in the same order as
+    ``create_message`` — ownership (404), then rate-limit (429, before any
+    delete or stream so a capped user keeps their old answer and cannot bypass
+    the 25/day cap), then an atomic "delete only if the last message is an
+    assistant message". The endpoint is tolerant: if the conversation already
+    ends with a user message (e.g. a prior regenerate failed mid-stream and
+    nothing was persisted), it skips the delete and just streams.
+
+    Returns:
+        StreamingResponse with Content-Type: text/event-stream, byte-compatible
+        with a normal send.
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user (404, no leak).
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. Need at least one prior user message to regenerate against.
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+    last_user_content = next(
+        (m["content"] for m in reversed(all_messages) if m["role"] == "user"), None
+    )
+    if last_user_content is None:
+        raise HTTPException(status_code=409, detail="Nothing to regenerate")
+
+    # 3. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1) BEFORE
+    #    deleting anything or streaming, so a rate-limited user keeps their old
+    #    answer and regenerating counts against the cap (cannot be gamed).
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 4. Atomically drop the stale assistant answer. A False result just means
+    #    the conversation already ends with a user message — still safe to stream.
+    await repository.delete_last_assistant_message(conv_id, user_id)
+
+    return await _stream_assistant_response(conv_id, user_id, current_user, last_user_content)
+
+
+# ---------------------------------------------------------------------------
+# Shared streaming pipeline
+# ---------------------------------------------------------------------------
+
+
+async def _stream_assistant_response(
+    conv_id: str,
+    user_id: str,
+    current_user: dict[str, Any],
+    user_content: str,
+) -> StreamingResponse:
+    """Run the tool-driven RAG pipeline and stream the assistant response as SSE.
+
+    Shared by ``create_message`` (normal send) and ``regenerate_message``
+    (issue #280). Assumes ownership and rate-limit guards have already run and,
+    for the send path, that the user message is already persisted. ``user_content``
+    is only used by the ``_maybe_set_conversation_title`` call in the finally
+    block (a no-op on regenerate, since the title is already set).
+    """
     # 4. Retrieve conversation history for LLM context
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,381 @@
+"""
+Tests for regenerating the last assistant response (issue #280).
+
+Covers the POST /api/conversations/{conv_id}/messages/regenerate route:
+ownership (404), empty-conversation guard (409), rate-limit (429, before any
+delete), the happy path (stale answer deleted, fresh answer streamed +
+persisted), and the tolerant path (conversation already ends with a user
+message). Also a repository unit test for delete_last_assistant_message.
+
+Follows the mocking patterns in test_sources_event.py: monkeypatched
+stream_chat / repository functions, httpx.AsyncClient against the ASGI app.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.auth.tokens import encode_token
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_ANSWER_TEXT = "The video explains that this feature works well."
+_ANSWER_CHUNK = f"data: {json.dumps(_ANSWER_TEXT)}\n\n"
+_DONE_CHUNK = "data: [DONE]\n\n"
+
+_SOURCE_CITATIONS = [
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Test Video",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "Test snippet",
+    }
+]
+
+
+async def _mock_stream_chat(
+    messages,
+    tools=None,
+    tool_executor=None,
+    max_tool_calls=0,
+    final_text_out=None,
+    **_kwargs,
+):
+    if tool_executor is not None:
+        await tool_executor("search_videos", json.dumps({"query": "test"}))
+    yield _ANSWER_CHUNK
+    if final_text_out is not None:
+        final_text_out.append(_ANSWER_TEXT)
+    yield _DONE_CHUNK
+
+
+async def _mock_execute_tool(
+    name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+):
+    return {"ok": True, "text": "context", "chunks": _SOURCE_CITATIONS}
+
+
+async def _mock_list_videos():
+    return [{"id": "v1", "title": "Test Video", "url": "https://youtube.com/watch?v=abc"}]
+
+
+def _user_factory(test_user_id: str):
+    async def _get_user_by_id(user_id):
+        return {
+            "id": test_user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    return _get_user_by_id
+
+
+def _history(test_conv_id: str, last_role: str = "assistant"):
+    """Conversation history ending in either an assistant or user message."""
+    msgs = [
+        {
+            "id": "m1",
+            "conversation_id": test_conv_id,
+            "role": "user",
+            "content": "What is hybrid RAG?",
+            "created_at": "2026-01-01T00:00:00Z",
+            "sources": None,
+        },
+        {
+            "id": "m2",
+            "conversation_id": test_conv_id,
+            "role": "assistant",
+            "content": "Old answer.",
+            "created_at": "2026-01-01T00:00:01Z",
+            "sources": None,
+        },
+    ]
+    if last_role == "user":
+        return msgs[:1]
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# Route tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateRoute:
+    async def test_404_when_conversation_not_owned(self) -> None:
+        """Unknown / other-user conversation → 404, no leak."""
+        from backend.main import app
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        async def mock_get_conversation(conv_id, user_id):
+            return None
+
+        with (
+            patch(
+                "backend.auth.dependencies.users_repo.get_user_by_id", _user_factory(test_user_id)
+            ),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+        assert resp.status_code == 404
+
+    async def test_409_when_no_user_message(self) -> None:
+        """Empty conversation (no user message) → 409 Nothing to regenerate."""
+        from backend.main import app
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {"id": test_conv_id, "user_id": test_user_id, "title": "Test"}
+
+        async def mock_list_messages(conv_id, user_id):
+            return []
+
+        delete_mock = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "backend.auth.dependencies.users_repo.get_user_by_id", _user_factory(test_user_id)
+            ),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.delete_last_assistant_message", delete_mock),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+        assert resp.status_code == 409
+        delete_mock.assert_not_called()
+
+    async def test_429_preserves_old_answer(self) -> None:
+        """Rate-limited → 429 with the create_message body shape, and the old
+        answer is NOT deleted (cap cannot be bypassed by regenerating)."""
+        from datetime import UTC, datetime
+
+        from backend import rate_limit
+        from backend.main import app
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {"id": test_conv_id, "user_id": test_user_id, "title": "Test"}
+
+        async def mock_list_messages(conv_id, user_id):
+            return _history(test_conv_id)
+
+        reset_at = datetime(2026, 1, 2, tzinfo=UTC)
+
+        async def mock_check_and_record(user_id):
+            raise rate_limit.RateLimitExceeded(reset_at=reset_at)
+
+        delete_mock = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "backend.auth.dependencies.users_repo.get_user_by_id", _user_factory(test_user_id)
+            ),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.rate_limit.check_and_record", mock_check_and_record),
+            patch("backend.db.repository.delete_last_assistant_message", delete_mock),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+        assert body["window_hours"] == rate_limit.WINDOW_HOURS
+        assert "reset_at" in body
+        # Old answer preserved — delete never ran.
+        delete_mock.assert_not_called()
+
+    async def test_happy_path_deletes_and_streams(self) -> None:
+        """Last message is an assistant message → it is deleted, rate-limit is
+        recorded once, a fresh answer streams with sources + [DONE], and the new
+        assistant message is persisted."""
+        from backend.main import app
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {
+                "id": test_conv_id,
+                "user_id": test_user_id,
+                "title": "Existing title",
+            }
+
+        async def mock_list_messages(conv_id, user_id):
+            return _history(test_conv_id)
+
+        check_mock = AsyncMock(return_value=None)
+        delete_mock = AsyncMock(return_value=True)
+        create_mock = AsyncMock(side_effect=lambda **kw: {"id": str(uuid4()), **kw})
+
+        with (
+            patch(
+                "backend.auth.dependencies.users_repo.get_user_by_id", _user_factory(test_user_id)
+            ),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.rate_limit.check_and_record", check_mock),
+            patch("backend.db.repository.delete_last_assistant_message", delete_mock),
+            patch("backend.db.repository.create_message", create_mock),
+            patch("backend.db.repository.list_videos", _mock_list_videos),
+            patch("backend.routes.messages.stream_chat", _mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", _mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 200
+        output = resp.text
+        assert "event: sources" in output
+        assert "data: [DONE]" in output
+
+        # Rate-limit recorded exactly once (counts against the cap).
+        assert check_mock.call_count == 1
+        # Stale assistant message deleted with the right conv/user.
+        delete_mock.assert_awaited_once_with(test_conv_id, test_user_id)
+        # The fresh assistant message was persisted.
+        assert create_mock.await_count == 1
+        assert create_mock.await_args is not None
+        assert create_mock.await_args.kwargs["role"] == "assistant"
+
+    async def test_tolerant_when_delete_returns_false(self) -> None:
+        """Conversation already ends with a user message (delete returns False)
+        → still streams successfully."""
+        from backend.main import app
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        token = encode_token(test_user_id)
+
+        async def mock_get_conversation(conv_id, user_id):
+            return {"id": test_conv_id, "user_id": test_user_id, "title": "Test"}
+
+        async def mock_list_messages(conv_id, user_id):
+            return _history(test_conv_id, last_role="user")
+
+        check_mock = AsyncMock(return_value=None)
+        delete_mock = AsyncMock(return_value=False)
+        create_mock = AsyncMock(side_effect=lambda **kw: {"id": str(uuid4()), **kw})
+
+        with (
+            patch(
+                "backend.auth.dependencies.users_repo.get_user_by_id", _user_factory(test_user_id)
+            ),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.rate_limit.check_and_record", check_mock),
+            patch("backend.db.repository.delete_last_assistant_message", delete_mock),
+            patch("backend.db.repository.create_message", create_mock),
+            patch("backend.db.repository.list_videos", _mock_list_videos),
+            patch("backend.routes.messages.stream_chat", _mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", _mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={token}"},
+                )
+
+        assert resp.status_code == 200
+        assert "data: [DONE]" in resp.text
+        delete_mock.assert_awaited_once()
+        assert create_mock.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Repository unit test
+# ---------------------------------------------------------------------------
+
+
+class _FakeAcquire:
+    """Dual-purpose awaitable + async context manager wrapping a mock conn."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __await__(self):
+        async def _do():
+            return self._conn
+
+        return _do().__await__()
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestDeleteLastAssistantMessageRepo:
+    async def test_returns_true_and_touches_when_row_deleted(self) -> None:
+        """When the outer DELETE removes a row (last message was an assistant
+        message), returns True and touches the conversation."""
+        from backend.db import repository
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value={"id": "m2"})
+
+        with (
+            patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)),
+            patch.object(repository, "touch_conversation", AsyncMock()) as touch_mock,
+        ):
+            result = await repository.delete_last_assistant_message("conv-1", "user-1")
+
+        assert result is True
+        touch_mock.assert_awaited_once_with("conv-1", "user-1")
+
+    async def test_returns_false_when_no_row_deleted(self) -> None:
+        """When the DELETE removes nothing (trailing user message, empty
+        conversation, or wrong user), returns False and does not touch."""
+        from backend.db import repository
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+
+        with (
+            patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)),
+            patch.object(repository, "touch_conversation", AsyncMock()) as touch_mock,
+        ):
+            result = await repository.delete_last_assistant_message("conv-1", "user-1")
+
+        assert result is False
+        touch_mock.assert_not_called()

--- a/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for the regenerate flow in ChatArea (issue #280).
+ *
+ * Verifies:
+ *  - The Regenerate button appears only on the LAST assistant message.
+ *  - Clicking it removes the stale assistant message and streams a replacement
+ *    that lands with its own sources.
+ *  - A RateLimitError restores the original message and surfaces the limit error.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArea } from '../components/ChatArea';
+import { RateLimitError, type Message as MessageType } from '../lib/api';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+// ── Controllable message state shared with the useMessages mock ──
+const INITIAL_MESSAGES: MessageType[] = [
+  {
+    id: 'u1',
+    conversation_id: 'conv-1',
+    role: 'user',
+    content: 'What is hybrid RAG?',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'a1',
+    conversation_id: 'conv-1',
+    role: 'assistant',
+    content: 'Old answer.',
+    created_at: '2026-01-01T00:00:01Z',
+    sources: [
+      {
+        chunk_id: 'old-c',
+        video_id: 'v0',
+        video_title: 'Old Video',
+        video_url: 'https://youtube.com/watch?v=old',
+        start_seconds: 1,
+        end_seconds: 2,
+        snippet: 'old snippet',
+      },
+    ],
+  },
+];
+
+let initialMessagesForRender: MessageType[] = INITIAL_MESSAGES;
+
+vi.mock('../hooks/useMessages', () => ({
+  useMessages: () => {
+    const [messages, setMessages] = useState<MessageType[]>(initialMessagesForRender);
+    return {
+      messages,
+      setMessages,
+      loading: false,
+      error: null,
+      notFound: false,
+      conversation: { id: 'conv-1', title: 'Test', created_at: '', updated_at: '' },
+    };
+  },
+}));
+
+const regenerateStreamMock = { current: vi.fn() };
+
+vi.mock('../hooks/useStreamingResponse', () => ({
+  useStreamingResponse: () => ({
+    streamingContent: '',
+    streamingSources: [],
+    streamingStatus: null,
+    isStreaming: false,
+    startStream: vi.fn(),
+    regenerateStream: (...args: unknown[]) => regenerateStreamMock.current(...args),
+    abortStream: vi.fn(),
+  }),
+}));
+
+const addToastMock = { current: vi.fn() };
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ addToast: addToastMock.current, removeToast: vi.fn() }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u', email: 'e', is_admin: false }, refresh: vi.fn() }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Element.prototype.scrollIntoView = vi.fn();
+  initialMessagesForRender = INITIAL_MESSAGES;
+  addToastMock.current = vi.fn();
+  regenerateStreamMock.current = vi.fn();
+});
+
+function renderChatArea() {
+  return render(
+    <MemoryRouter>
+      <ChatArea conversationId="conv-1" />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatArea regenerate (issue #280)', () => {
+  it('shows the regenerate button only on the last assistant message', async () => {
+    renderChatArea();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Regenerate response' })).toBeInTheDocument();
+    });
+    // Only one regenerate button (the single trailing assistant message).
+    expect(screen.getAllByRole('button', { name: 'Regenerate response' })).toHaveLength(1);
+  });
+
+  it('removes the stale answer and streams a replacement with new sources', async () => {
+    regenerateStreamMock.current = vi
+      .fn()
+      .mockImplementation(async (_convId: string, onComplete: (r: unknown) => void) => {
+        onComplete({
+          fullText: 'Fresh answer.',
+          sources: [
+            {
+              chunk_id: 'new-c',
+              video_id: 'v1',
+              video_title: 'New Video',
+              video_url: 'https://youtube.com/watch?v=new',
+              start_seconds: 5,
+              end_seconds: 6,
+              snippet: 'new snippet',
+            },
+          ],
+        });
+      });
+
+    renderChatArea();
+
+    const btn = await screen.findByRole('button', { name: 'Regenerate response' });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fresh answer.')).toBeInTheDocument();
+    });
+    // Old answer is gone, replaced by the fresh one.
+    expect(screen.queryByText('Old answer.')).not.toBeInTheDocument();
+    expect(regenerateStreamMock.current).toHaveBeenCalledTimes(1);
+    expect(regenerateStreamMock.current.mock.calls[0][0]).toBe('conv-1');
+  });
+
+  it('restores the original answer and shows the limit error on RateLimitError', async () => {
+    regenerateStreamMock.current = vi.fn().mockImplementation(async () => {
+      throw new RateLimitError({
+        limit: 25,
+        window_hours: 24,
+        reset_at: '2026-01-02T00:00:00Z',
+      });
+    });
+
+    renderChatArea();
+
+    const btn = await screen.findByRole('button', { name: 'Regenerate response' });
+    fireEvent.click(btn);
+
+    // Original answer restored after the rejection.
+    await waitFor(() => {
+      expect(screen.getByText('Old answer.')).toBeInTheDocument();
+    });
+    expect(addToastMock.current).toHaveBeenCalledWith(
+      expect.stringContaining('daily message limit'),
+      'error',
+    );
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    regenerateStream,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -321,6 +322,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // Inline error state (for failed sends)
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [failedMessageText, setFailedMessageText] = useState<string | null>(null);
+  // When true, the inline-error Retry button re-fires regenerate (issue #280)
+  // instead of resending failedMessageText.
+  const [retryIsRegenerate, setRetryIsRegenerate] = useState(false);
   // Track the temp user message ID so we can remove it on failure
   const pendingUserMsgIdRef = useRef<string | null>(null);
   // Citation modal state
@@ -574,14 +578,94 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     handleSend(msg);
   }, [conversationId, location.state, navigate, handleSend]);
 
+  // ── Regenerate handler (issue #280) ──
+  // Re-runs the last user query and replaces the last assistant message with a
+  // fresh stream. Counts against the daily cap server-side (rate-limit check
+  // runs before the old message is deleted), so it can't be used to bypass it.
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId || isStreaming) return;
+    // Only valid when the last message is an assistant reply preceded by a
+    // user message (mirrors the server's "Nothing to regenerate" guard).
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return;
+    if (!messages.some((m) => m.role === 'user')) return;
+
+    setInlineError(null);
+    setFailedMessageText(null);
+    setRetryIsRegenerate(false);
+
+    // Snapshot the stale assistant message so we can restore it if the request
+    // is rejected before anything is deleted server-side (e.g. rate limit).
+    const snapshot = last;
+    setMessages((prev) => prev.slice(0, -1));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await regenerateStream(conversationId, ({ fullText, sources }) => {
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      // Pull fresh quota counter so the sidebar updates (regenerate counts).
+      refreshAuth();
+    } catch (e) {
+      // Intentional abort (navigation or user cancel) — no error toast.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        // Capped before any server-side delete — restore the original answer.
+        setMessages((prev) => [...prev, snapshot]);
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        setFailedMessageText(null);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      // Other errors: the server may have already deleted the old message, so
+      // restoring it would lie (a reload shows server truth). Leave it removed,
+      // surface a retryable inline error. Retry is safe — the endpoint tolerates
+      // a conversation that already ends with a user message.
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate';
+      setInlineError('Failed to regenerate the response. Please try again.');
+      setRetryIsRegenerate(true);
+      addToast(errMsg || 'Network error — could not regenerate', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    setMessages,
+    regenerateStream,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+  ]);
+
   // ── Retry failed message — re-attempt the API call with same content ──
   const handleRetry = useCallback(() => {
+    if (retryIsRegenerate) {
+      setRetryIsRegenerate(false);
+      setInlineError(null);
+      handleRegenerate();
+      return;
+    }
     if (!failedMessageText) return;
     const text = failedMessageText;
     setInlineError(null);
     setFailedMessageText(null);
     handleSend(text);
-  }, [failedMessageText, handleSend]);
+  }, [retryIsRegenerate, handleRegenerate, failedMessageText, handleSend]);
 
   // ── Starter click handler ──
   const handleStarterClick = useCallback((text: string) => {
@@ -708,15 +792,20 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
-              messages.map((msg) => (
-                <Message
-                  key={msg.id}
-                  role={msg.role}
-                  content={msg.content}
-                  sources={msg.sources}
-                  onCitationClick={handleCitationClick}
-                />
-              ))
+              messages.map((msg, i) => {
+                const isLast = i === messages.length - 1;
+                const canRegenerate = isLast && msg.role === 'assistant' && !isStreaming;
+                return (
+                  <Message
+                    key={msg.id}
+                    role={msg.role}
+                    content={msg.content}
+                    sources={msg.sources}
+                    onCitationClick={handleCitationClick}
+                    onRegenerate={canRegenerate ? handleRegenerate : undefined}
+                  />
+                );
+              })
             )}
 
             {/* Streaming assistant bubble */}

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Citation } from '../lib/api';
 import { Message } from './Message';
@@ -147,5 +147,35 @@ describe('Message — citation chip segment_count label', () => {
       />,
     );
     expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — regenerate button (issue #280)', () => {
+  it('renders the regenerate button when onRegenerate is provided', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." isStreaming={false} onRegenerate={onRegenerate} />,
+    );
+    expect(screen.getByRole('button', { name: 'Regenerate response' })).toBeInTheDocument();
+  });
+
+  it('invokes onRegenerate when the button is clicked', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message role="assistant" content="An answer." isStreaming={false} onRegenerate={onRegenerate} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the button when onRegenerate is absent', () => {
+    render(<Message role="assistant" content="An answer." isStreaming={false} />);
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button for user messages', () => {
+    const onRegenerate = vi.fn();
+    render(<Message role="user" content="My question." onRegenerate={onRegenerate} />);
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -26,22 +26,7 @@ function RegenerateButton({ onRegenerate }: { onRegenerate: () => void }) {
     <button
       onClick={onRegenerate}
       aria-label="Regenerate response"
-      className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
-      style={{
-        marginTop: 10,
-        background: 'transparent',
-        border: 'none',
-        cursor: 'pointer',
-        color: '#94a3b8',
-        fontSize: 12,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 5,
-        padding: 0,
-        transition: 'color 0.15s',
-      }}
-      onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
-      onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+      className="mt-[10px] flex items-center gap-[5px] p-0 bg-transparent border-0 cursor-pointer text-slate-400 text-xs transition-colors duration-150 hover:text-slate-100 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
     >
       <svg
         width="13"

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,51 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** When provided (last assistant message, not streaming), renders a
+   *  "Regenerate" button that re-runs the last query (issue #280). */
+  onRegenerate?: () => void;
+}
+
+// ── Regenerate button (issue #280) ────────────────────────────────
+function RegenerateButton({ onRegenerate }: { onRegenerate: () => void }) {
+  return (
+    <button
+      onClick={onRegenerate}
+      aria-label="Regenerate response"
+      className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+      style={{
+        marginTop: 10,
+        background: 'transparent',
+        border: 'none',
+        cursor: 'pointer',
+        color: '#94a3b8',
+        fontSize: 12,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: 0,
+        transition: 'color 0.15s',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
+      onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+    >
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="23 4 23 10 17 10" />
+        <polyline points="1 20 1 14 7 14" />
+        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+      </svg>
+      Regenerate
+    </button>
+  );
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,6 +212,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +250,7 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && <RegenerateButton onRegenerate={onRegenerate} />}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -439,6 +439,63 @@ describe('status event SSE parsing — hook state transitions', () => {
   });
 });
 
+describe('regenerateStream (issue #280)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the regenerate endpoint with no body and parses tokens + sources', async () => {
+    const sseChunks = [
+      `event: sources\ndata: ${JSON.stringify([mockCitation])}\n\n`,
+      'data: "Fresh answer"\n\n',
+      'data: [DONE]\n\n',
+    ];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(sseChunks),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.regenerateStream('conv-1', onComplete);
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/messages/regenerate');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullText: 'Fresh answer',
+        sources: [expect.objectContaining({ chunk_id: 'chunk-1' })],
+      }),
+    );
+  });
+
+  it('throws RateLimitError on a 429 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ limit: 25, window_hours: 24, reset_at: '2026-01-02T00:00:00Z' }),
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await expect(
+      act(async () => {
+        await result.current.regenerateStream('conv-1', vi.fn());
+      }),
+    ).rejects.toMatchObject({ limit: 25 });
+  });
+});
+
 describe('abortStream', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -42,10 +42,13 @@ export function useStreamingResponse(conversationId: string | null) {
     }
   }, []);
 
-  const startStream = useCallback(
+  // Shared fetch + SSE-parse loop used by both startStream (normal send) and
+  // regenerateStream (issue #280). `body` is the JSON request body, or null for
+  // the regenerate endpoint which takes no body.
+  const runStream = useCallback(
     async (
-      conversationId: string,
-      userMessage: string,
+      url: string,
+      body: string | null,
       onComplete: (result: StreamResult) => void,
     ): Promise<void> => {
       setIsStreaming(true);
@@ -61,11 +64,11 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+        const res = await fetch(url, {
           method: 'POST',
           credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
+          headers: body !== null ? { 'Content-Type': 'application/json' } : undefined,
+          body: body ?? undefined,
           signal: abortController.signal,
         });
 
@@ -218,12 +221,36 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startStream = useCallback(
+    (
+      conversationId: string,
+      userMessage: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> =>
+      runStream(
+        `/api/conversations/${conversationId}/messages`,
+        JSON.stringify({ content: userMessage }),
+        onComplete,
+      ),
+    [runStream],
+  );
+
+  // Regenerate the last assistant message (issue #280). POSTs to the regenerate
+  // endpoint with no body; reuses the shared SSE machinery so the streaming UX
+  // is identical to a normal send.
+  const regenerateStream = useCallback(
+    (conversationId: string, onComplete: (result: StreamResult) => void): Promise<void> =>
+      runStream(`/api/conversations/${conversationId}/messages/regenerate`, null, onComplete),
+    [runStream],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    regenerateStream,
     abortStream,
   };
 }


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `0a75df65-a7a5-41dd-a9e6-fa429c2ae4bf`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.