### PR TITLE
[bench-OF] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -603,6 +603,32 @@ async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     return results
 
 
+async def delete_last_assistant_message(conversation_id: str, user_id: str) -> str | None:
+    """Delete the most recent assistant message in a conversation (owner-scoped).
+
+    Returns the deleted message id, or None if there is no assistant message
+    or the conversation does not belong to the user.
+    """
+    async with _acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            DELETE FROM messages
+            WHERE id = (
+                SELECT m.id FROM messages m
+                JOIN conversations c ON c.id = m.conversation_id
+                WHERE m.conversation_id = $1 AND c.user_id = $2
+                  AND m.role = 'assistant'
+                ORDER BY m.created_at DESC
+                LIMIT 1
+            )
+            RETURNING id
+            """,
+            conversation_id,
+            user_id,
+        )
+    return row["id"] if row else None
+
+
 # ---------------------------------------------------------------------------
 # Channel sync runs
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -112,6 +112,82 @@ async def create_message(
     if inserted is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    return await _stream_assistant_response(conv_id, user_id, current_user, user_content)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/messages/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/messages/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Re-run the conversation's most recent user turn and stream a fresh
+    assistant answer in place of the old one.
+
+    Invariant ordering matches create_message: ownership check → rate-limit
+    check_and_record → mutate. Regeneration counts against the 25 msg/24h
+    cap (MISSION §10 invariant #1), and because the quota is recorded
+    before the stale answer is deleted, an over-cap user cannot use
+    regenerate to bypass the counter.
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user.
+    # 404 (not 403) — don't leak existence of other users' conversations.
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. There must be something to regenerate AND the last turn must be an
+    # assistant answer. Read first so we don't burn a quota slot on a no-op.
+    msgs = await repository.list_messages(conv_id, user_id=user_id)
+    if not msgs or msgs[-1]["role"] != "assistant":
+        raise HTTPException(status_code=409, detail="No assistant message to regenerate")
+    last_user = next((m for m in reversed(msgs) if m["role"] == "user"), None)
+    if last_user is None:
+        raise HTTPException(status_code=409, detail="No prior user message to regenerate from")
+
+    # 3. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1) —
+    # BEFORE any mutation, so an over-cap user keeps their old answer and
+    # cannot consume OpenRouter budget.
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 4. Drop the stale assistant answer so the history fed to the model
+    # ends at the user's question.
+    await repository.delete_last_assistant_message(conv_id, user_id)
+
+    # 5. Stream a fresh answer.
+    return await _stream_assistant_response(conv_id, user_id, current_user, last_user["content"])
+
+
+async def _stream_assistant_response(
+    conv_id: str,
+    user_id: str,
+    current_user: dict[str, Any],
+    title_seed: str,
+) -> StreamingResponse:
+    """Shared streaming block for create_message and regenerate_message:
+    load history → wire tools → stream SSE → persist the assistant message.
+
+    ``title_seed`` is the user prompt passed to _maybe_set_conversation_title
+    (a no-op once a title is set, so safe for regenerate).
+    """
     # 4. Retrieve conversation history for LLM context
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
@@ -293,7 +369,7 @@ async def create_message(
                 # unexpected errors logged but not re-raised (message was saved above).
                 try:
                     await asyncio.shield(
-                        _maybe_set_conversation_title(conv_id, user_id, user_content)
+                        _maybe_set_conversation_title(conv_id, user_id, title_seed)
                     )
                 except asyncio.CancelledError:
                     pass

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,351 @@
+"""
+Tests for POST /api/conversations/{conv_id}/messages/regenerate (issue #280).
+
+Verifies the regenerate endpoint:
+- streams a fresh assistant answer (tokens + sources event + [DONE]) after
+  deleting the stale one,
+- counts regeneration against the 25 msg/24h cap (MISSION §10 invariant #1),
+- rejects over-cap requests with 429 BEFORE any mutation (no quota bypass),
+- rejects conversations with nothing to regenerate (409) without burning a
+  quota slot,
+- returns 404 for cross-user access (no existence leak).
+
+Follows the integration patterns in test_sources_event.py /
+test_message_persist_shield.py: patch repository.* and the route's
+stream_chat import, drive the app with httpx.AsyncClient.
+"""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend.auth.tokens import encode_token
+from backend.main import app
+
+
+def _user_msg(conv_id: str, content: str = "What is RAG?") -> dict:
+    return {
+        "id": str(uuid4()),
+        "conversation_id": conv_id,
+        "role": "user",
+        "content": content,
+        "sources": None,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+
+def _assistant_msg(conv_id: str, content: str = "Old answer.") -> dict:
+    return {
+        "id": str(uuid4()),
+        "conversation_id": conv_id,
+        "role": "assistant",
+        "content": content,
+        "sources": None,
+        "created_at": "2026-01-01T00:00:01Z",
+    }
+
+
+def _make_mocks(test_user_id: str, test_conv_id: str, history: list[dict]):
+    """Build the standard mock set used by every test in this module."""
+
+    async def mock_get_user_by_id(user_id):
+        return {
+            "id": test_user_id,
+            "email": "test@example.com",
+            "password_hash": "hashed",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+    async def mock_get_conversation(conv_id, user_id):
+        if conv_id == test_conv_id:
+            return {
+                "id": test_conv_id,
+                "user_id": test_user_id,
+                "title": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        return None
+
+    async def mock_list_messages(conv_id, user_id):
+        return history
+
+    async def mock_list_videos():
+        return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+    return mock_get_user_by_id, mock_get_conversation, mock_list_messages, mock_list_videos
+
+
+def _make_stream_chat(answer_text: str = "Fresh answer."):
+    """A stream_chat fake that runs one tool call and yields tokens + [DONE]."""
+    source_citations = [
+        {
+            "chunk_id": "c1",
+            "video_id": "v1",
+            "video_title": "Test Video",
+            "video_url": "https://youtube.com/watch?v=abc",
+            "start_seconds": 10.0,
+            "end_seconds": 20.0,
+            "snippet": "Test snippet",
+        }
+    ]
+
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(answer_text)}\n\n"
+        if final_text_out is not None:
+            final_text_out.append(answer_text)
+        yield "data: [DONE]\n\n"
+
+    async def mock_execute_tool(
+        name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+    ):
+        return {"ok": True, "text": "context", "chunks": source_citations}
+
+    return mock_stream_chat, mock_execute_tool
+
+
+class TestRegenerateHappyPath:
+    async def test_regenerate_streams_fresh_answer(self) -> None:
+        """Deletes the stale answer, streams tokens + sources + [DONE], and
+        persists the new assistant message."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        history = [_user_msg(test_conv_id), _assistant_msg(test_conv_id)]
+        get_user, get_conv, list_msgs, list_videos = _make_mocks(
+            test_user_id, test_conv_id, history
+        )
+        mock_stream_chat, mock_execute_tool = _make_stream_chat("Fresh answer.")
+
+        mock_delete = AsyncMock(return_value=history[1]["id"])
+        mock_create = AsyncMock(return_value={"id": str(uuid4())})
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", get_user),
+            patch("backend.db.repository.get_conversation", get_conv),
+            patch("backend.db.repository.list_messages", list_msgs),
+            patch("backend.db.repository.list_videos", list_videos),
+            patch("backend.db.repository.delete_last_assistant_message", mock_delete),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        assert response.status_code == 200
+        output = response.text
+        assert "Fresh answer." in output
+        assert "event: sources" in output
+        assert "data: [DONE]" in output
+
+        # The stale assistant row was deleted (owner-scoped).
+        mock_delete.assert_awaited_once_with(test_conv_id, test_user_id)
+
+        # The fresh answer was persisted as an assistant message — and no
+        # user message was inserted (regenerate re-runs the existing turn).
+        assert mock_create.await_count == 1
+        persisted = mock_create.call_args.kwargs
+        assert persisted["role"] == "assistant"
+        assert persisted["content"] == "Fresh answer."
+
+    async def test_regenerate_counts_against_rate_limit(self) -> None:
+        """check_and_record is awaited exactly once on the happy path."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        history = [_user_msg(test_conv_id), _assistant_msg(test_conv_id)]
+        get_user, get_conv, list_msgs, list_videos = _make_mocks(
+            test_user_id, test_conv_id, history
+        )
+        mock_stream_chat, mock_execute_tool = _make_stream_chat()
+
+        mock_check = AsyncMock(return_value=None)
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", get_user),
+            patch("backend.db.repository.get_conversation", get_conv),
+            patch("backend.db.repository.list_messages", list_msgs),
+            patch("backend.db.repository.list_videos", list_videos),
+            patch("backend.db.repository.delete_last_assistant_message", AsyncMock()),
+            patch("backend.db.repository.create_message", AsyncMock(return_value={"id": "m"})),
+            patch("backend.rate_limit.check_and_record", mock_check),
+            patch("backend.routes.messages.stream_chat", mock_stream_chat),
+            patch("backend.routes.messages.execute_tool", mock_execute_tool),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        assert response.status_code == 200
+        assert mock_check.await_count == 1
+        mock_check.assert_awaited_once_with(test_user_id)
+
+
+class TestRegenerateRateLimit:
+    async def test_regenerate_over_cap_returns_429_and_does_not_delete(self) -> None:
+        """Over-cap regenerate is rejected with the standard 429 body and the
+        stale answer is NOT deleted (no mutation, no quota bypass)."""
+        from backend import rate_limit
+
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        history = [_user_msg(test_conv_id), _assistant_msg(test_conv_id)]
+        get_user, get_conv, list_msgs, list_videos = _make_mocks(
+            test_user_id, test_conv_id, history
+        )
+
+        reset_at = datetime(2026, 1, 2, 12, 0, 0, tzinfo=UTC)
+        mock_check = AsyncMock(side_effect=rate_limit.RateLimitExceeded(reset_at=reset_at))
+        mock_delete = AsyncMock()
+        mock_create = AsyncMock()
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", get_user),
+            patch("backend.db.repository.get_conversation", get_conv),
+            patch("backend.db.repository.list_messages", list_msgs),
+            patch("backend.db.repository.list_videos", list_videos),
+            patch("backend.db.repository.delete_last_assistant_message", mock_delete),
+            patch("backend.db.repository.create_message", mock_create),
+            patch("backend.rate_limit.check_and_record", mock_check),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+        assert body["window_hours"] == rate_limit.WINDOW_HOURS
+        assert body["reset_at"] == reset_at.isoformat()
+
+        # No mutation happened — the old answer survives.
+        mock_delete.assert_not_awaited()
+        mock_create.assert_not_awaited()
+
+
+class TestRegeneratePreconditions:
+    async def test_regenerate_no_assistant_returns_409_and_does_not_record(self) -> None:
+        """History ending with a user message → 409, and no quota slot burned."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        history = [_user_msg(test_conv_id)]
+        get_user, get_conv, list_msgs, list_videos = _make_mocks(
+            test_user_id, test_conv_id, history
+        )
+
+        mock_check = AsyncMock()
+        mock_delete = AsyncMock()
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", get_user),
+            patch("backend.db.repository.get_conversation", get_conv),
+            patch("backend.db.repository.list_messages", list_msgs),
+            patch("backend.db.repository.list_videos", list_videos),
+            patch("backend.db.repository.delete_last_assistant_message", mock_delete),
+            patch("backend.rate_limit.check_and_record", mock_check),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        assert response.status_code == 409
+        mock_check.assert_not_awaited()
+        mock_delete.assert_not_awaited()
+
+    async def test_regenerate_empty_history_returns_409(self) -> None:
+        """An empty conversation has nothing to regenerate."""
+        test_user_id = str(uuid4())
+        test_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        get_user, get_conv, list_msgs, list_videos = _make_mocks(test_user_id, test_conv_id, [])
+
+        mock_check = AsyncMock()
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", get_user),
+            patch("backend.db.repository.get_conversation", get_conv),
+            patch("backend.db.repository.list_messages", list_msgs),
+            patch("backend.db.repository.list_videos", list_videos),
+            patch("backend.rate_limit.check_and_record", mock_check),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{test_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        assert response.status_code == 409
+        mock_check.assert_not_awaited()
+
+
+class TestRegenerateScoping:
+    async def test_regenerate_cross_user_returns_404(self) -> None:
+        """A conversation the user doesn't own → 404 (no existence leak), no mutation."""
+        test_user_id = str(uuid4())
+        other_conv_id = str(uuid4())
+        valid_token = encode_token(test_user_id)
+
+        async def mock_get_user_by_id(user_id):
+            return {
+                "id": test_user_id,
+                "email": "test@example.com",
+                "password_hash": "hashed",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        async def mock_get_conversation(conv_id, user_id):
+            return None
+
+        mock_check = AsyncMock()
+        mock_delete = AsyncMock()
+
+        with (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.delete_last_assistant_message", mock_delete),
+            patch("backend.rate_limit.check_and_record", mock_check),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    f"/api/conversations/{other_conv_id}/messages/regenerate",
+                    headers={"Cookie": f"session={valid_token}"},
+                )
+
+        assert response.status_code == 404
+        mock_check.assert_not_awaited()
+        mock_delete.assert_not_awaited()

--- a/app/backend/tests/test_repository_regenerate.py
+++ b/app/backend/tests/test_repository_regenerate.py
@@ -1,0 +1,82 @@
+"""
+Repository tests for delete_last_assistant_message (issue #280).
+
+Postgres isn't available in the test environment, so these follow the
+mocked-connection pattern from test_sources_event.py: a fake _acquire()
+returns a recording connection and we assert on the SQL shape, parameter
+binding, and return-value handling.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from backend.db import repository
+
+
+class _FakeAcquire:
+    """Dual-purpose awaitable + async context manager wrapping a mock conn."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __await__(self):
+        async def _do():
+            return self._conn
+
+        return _do().__await__()
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestDeleteLastAssistantMessage:
+    async def test_returns_deleted_id(self) -> None:
+        """When the DELETE matches a row, the deleted id is returned."""
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value={"id": "msg-assistant-2"})
+
+        with patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)):
+            deleted = await repository.delete_last_assistant_message("conv-1", "user-1")
+
+        assert deleted == "msg-assistant-2"
+
+    async def test_returns_none_when_no_assistant_or_not_owner(self) -> None:
+        """No matching row (no assistant message, or conversation belongs to
+        another user) → None, never an exception."""
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+
+        with patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)):
+            deleted = await repository.delete_last_assistant_message("conv-1", "intruder")
+
+        assert deleted is None
+
+    async def test_query_is_owner_scoped_and_targets_latest_assistant_row_only(self) -> None:
+        """The SQL must enforce ownership via a JOIN on conversations.user_id,
+        filter to role='assistant', and delete at most the single most recent
+        row (ORDER BY created_at DESC LIMIT 1) — user messages are untouched."""
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value={"id": "msg-1"})
+
+        with patch.object(repository, "_acquire", lambda: _FakeAcquire(mock_conn)):
+            await repository.delete_last_assistant_message("conv-1", "user-1")
+
+        assert mock_conn.fetchrow.await_count == 1
+        args = mock_conn.fetchrow.call_args.args
+        sql = args[0]
+        # Parameterized binding — conversation id then user id, no f-strings.
+        assert args[1] == "conv-1"
+        assert args[2] == "user-1"
+        assert "$1" in sql and "$2" in sql
+        # Owner scoping through the conversations table.
+        assert "JOIN conversations" in sql
+        assert "user_id = $2" in sql
+        # Only assistant rows are eligible.
+        assert "role = 'assistant'" in sql
+        # Only the single most recent one is deleted.
+        assert "ORDER BY m.created_at DESC" in sql
+        assert "LIMIT 1" in sql
+        assert sql.strip().startswith("DELETE FROM messages")
+        assert "RETURNING id" in sql

--- a/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Behavior tests for the Regenerate flow in ChatArea (issue #280).
+ *
+ * Uses the REAL useStreamingResponse hook with a stubbed global fetch so the
+ * test exercises the full path: click Regenerate → optimistic removal of the
+ * old assistant bubble → POST /messages/regenerate → SSE stream → streamed
+ * replacement appended. The useMessages mock is backed by real React state
+ * so setMessages updates are observable in the DOM.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArea } from '../components/ChatArea';
+import type { Message as MessageType } from '../lib/api';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mutable refs captured by the hoisted mock factories — reset in beforeEach.
+const initialMessagesRef: { current: MessageType[] } = { current: [] };
+const addToastRef = { current: vi.fn() };
+const refreshAuthRef = { current: vi.fn() };
+
+// Stateful useMessages mock: real useState so ChatArea's setMessages calls
+// re-render the component and the optimistic removal/append is observable.
+vi.mock('../hooks/useMessages', async () => {
+  const { useState } = await import('react');
+  return {
+    useMessages: () => {
+      const [messages, setMessages] = useState<MessageType[]>(initialMessagesRef.current);
+      return {
+        messages,
+        setMessages,
+        loading: false,
+        error: null,
+        notFound: false,
+        conversation: { id: 'conv-1', title: 'Test', created_at: '', updated_at: '' },
+      };
+    },
+  };
+});
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({
+    addToast: addToastRef.current,
+    removeToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user', email: 'test@test', is_admin: false },
+    refresh: refreshAuthRef.current,
+  }),
+}));
+
+function makeSseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function conversationEndingInAssistant(): MessageType[] {
+  return [
+    {
+      id: 'u1',
+      conversation_id: 'conv-1',
+      role: 'user',
+      content: 'What is RAG?',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    {
+      id: 'a1',
+      conversation_id: 'conv-1',
+      role: 'assistant',
+      content: 'Old answer.',
+      created_at: '2026-01-01T00:00:01Z',
+    },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Element.prototype.scrollIntoView = vi.fn();
+  initialMessagesRef.current = conversationEndingInAssistant();
+  addToastRef.current = vi.fn();
+  refreshAuthRef.current = vi.fn();
+});
+
+describe('ChatArea — Regenerate flow (issue #280)', () => {
+  it('removes the old assistant bubble and appends the streamed replacement', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(['data: "New answer."\n\n', 'data: [DONE]\n\n']),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Old answer.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('New answer.')).toBeInTheDocument();
+    });
+    // The old answer was replaced, not kept alongside the new one.
+    expect(screen.queryByText('Old answer.')).not.toBeInTheDocument();
+
+    // The request went to the regenerate endpoint with no JSON body.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/messages/regenerate');
+    expect(init.body).toBeUndefined();
+
+    // Quota counter refreshed — regeneration counts against usage.
+    await waitFor(() => {
+      expect(refreshAuthRef.current).toHaveBeenCalled();
+    });
+  });
+
+  it('restores the old answer and shows the friendly message on RateLimitError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({
+        error: 'rate_limit_exceeded',
+        limit: 25,
+        window_hours: 24,
+        reset_at: '2026-01-02T12:00:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /regenerate/i }));
+
+    // The old answer must come back — unlike a normal send, it was removed
+    // optimistically before the request failed.
+    await waitFor(() => {
+      expect(screen.getByText('Old answer.')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(addToastRef.current).toHaveBeenCalledWith(
+        expect.stringContaining("You've hit your daily message limit (25/day)"),
+        'error',
+      );
+    });
+  });
+
+  it('does not offer Regenerate when the conversation ends with a user message', () => {
+    initialMessagesRef.current = [
+      {
+        id: 'u1',
+        conversation_id: 'conv-1',
+        role: 'user',
+        content: 'Unanswered question',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <ChatArea conversationId="conv-1" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('button', { name: /regenerate/i })).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -574,6 +574,80 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     handleSend(msg);
   }, [conversationId, location.state, navigate, handleSend]);
 
+  // ── Regenerate the last assistant response (issue #280) ──
+  // Removes the old answer optimistically, streams a fresh one via the
+  // /regenerate endpoint, and restores the old answer on failure (unlike
+  // a normal send, the old message was already removed from view).
+  const handleRegenerate = useCallback(async () => {
+    if (!conversationId || isStreaming) return;
+
+    const lastMsg = messages[messages.length - 1];
+    if (!lastMsg || lastMsg.role !== 'assistant') return;
+    const removedAssistant = lastMsg;
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+    const lastUserContent = lastUser?.content ?? '';
+
+    setInlineError(null);
+    setFailedMessageText(null);
+
+    // Optimistically remove the old answer; the server reconstructs the
+    // conversation context itself, so the text is only needed locally.
+    setMessages((prev) => prev.filter((m) => m.id !== removedAssistant.id));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await startStream(
+        conversationId,
+        lastUserContent,
+        ({ fullText, sources }) => {
+          const assistantMsg: MessageType = {
+            id: `temp-assistant-${Date.now()}`,
+            conversation_id: conversationId,
+            role: 'assistant',
+            content: fullText,
+            created_at: new Date().toISOString(),
+            sources: sources.length > 0 ? sources : undefined,
+          };
+          setMessages((prev) => [...prev, assistantMsg]);
+        },
+        { regenerate: true },
+      );
+      // Pull fresh quota counter — regeneration counts against the cap.
+      refreshAuth();
+    } catch (e) {
+      // Restore the optimistically removed answer (it was the last message).
+      setMessages((prev) => [...prev, removedAssistant]);
+
+      // Intentional abort (navigation or user cancel) — restore silently
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        setFailedMessageText(null);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate response';
+      setInlineError('Failed to regenerate the response. Please try again.');
+      addToast(errMsg || 'Network error — could not regenerate', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    setMessages,
+    startStream,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+  ]);
+
   // ── Retry failed message — re-attempt the API call with same content ──
   const handleRetry = useCallback(() => {
     if (!failedMessageText) return;
@@ -601,6 +675,12 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
   // before dispatchedInitialRef fires (#205).
   const showEmptyInConversation =
     messages.length === 0 && !inlineError && !isStreaming && !location.state?.initialMessage;
+
+  // Regenerate is only offered on the latest answer, and only when the
+  // conversation actually ends with an assistant message (nothing to
+  // regenerate after a failed send that left a trailing user message).
+  const lastMessage = messages[messages.length - 1];
+  const lastAssistantId = lastMessage?.role === 'assistant' ? lastMessage.id : undefined;
 
   const handleExport = useCallback(() => {
     try {
@@ -715,6 +795,9 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  onRegenerate={
+                    !isStreaming && msg.id === lastAssistantId ? handleRegenerate : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Citation } from '../lib/api';
 import { Message } from './Message';
@@ -147,5 +147,31 @@ describe('Message — citation chip segment_count label', () => {
       />,
     );
     expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — Regenerate button (issue #280)', () => {
+  it('renders the Regenerate button on an assistant message when onRegenerate is passed', () => {
+    render(
+      <Message role="assistant" content="Answer text." onRegenerate={vi.fn()} />, //
+    );
+    expect(screen.getByRole('button', { name: /regenerate/i })).toBeInTheDocument();
+  });
+
+  it('does not render the button when onRegenerate is omitted', () => {
+    render(<Message role="assistant" content="Answer text." />);
+    expect(screen.queryByRole('button', { name: /regenerate/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button on user messages even if onRegenerate is passed', () => {
+    render(<Message role="user" content="A question" onRegenerate={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /regenerate/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onRegenerate when clicked', () => {
+    const onRegenerate = vi.fn();
+    render(<Message role="assistant" content="Answer text." onRegenerate={onRegenerate} />);
+    fireEvent.click(screen.getByRole('button', { name: /regenerate/i }));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,8 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** Renders a "Regenerate" button — only passed to the last assistant message */
+  onRegenerate?: () => void;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -167,6 +169,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +207,31 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && (
+              <div style={{ marginTop: 8 }}>
+                <button
+                  onClick={onRegenerate}
+                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#94a3b8',
+                    fontSize: 12,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: 0,
+                    transition: 'color 0.15s',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
+                  onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+                  aria-label="Regenerate response"
+                >
+                  ↻ Regenerate
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -439,6 +439,91 @@ describe('status event SSE parsing — hook state transitions', () => {
   });
 });
 
+describe('startStream — regenerate option (issue #280)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the /regenerate endpoint with no body when { regenerate: true }', async () => {
+    const sseChunks = ['data: "Fresh answer"\n\n', 'data: [DONE]\n\n'];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(sseChunks),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'last question', onComplete, {
+        regenerate: true,
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/messages/regenerate');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    // SSE parsing is identical to a normal send
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ fullText: 'Fresh answer' }),
+    );
+  });
+
+  it('keeps the normal /messages endpoint and body when option is omitted', async () => {
+    const sseChunks = ['data: "Answer"\n\n', 'data: [DONE]\n\n'];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(sseChunks),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'hello', vi.fn());
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/messages');
+    expect(init.body).toBe(JSON.stringify({ content: 'hello' }));
+  });
+
+  it('parses the sources event identically on a regenerate stream', async () => {
+    const sseChunks = [
+      `event: sources\ndata: ${JSON.stringify([mockCitation])}\n\n`,
+      'data: "Fresh"\n\n',
+      'data: [DONE]\n\n',
+    ];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startStream('conv-1', 'q', onComplete, { regenerate: true });
+    });
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullText: 'Fresh',
+        sources: [expect.objectContaining({ chunk_id: 'chunk-1' })],
+      }),
+    );
+  });
+});
+
 describe('abortStream', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -47,6 +47,7 @@ export function useStreamingResponse(conversationId: string | null) {
       conversationId: string,
       userMessage: string,
       onComplete: (result: StreamResult) => void,
+      options?: { regenerate?: boolean },
     ): Promise<void> => {
       setIsStreaming(true);
       setStreamingContent('');
@@ -61,11 +62,15 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+        // Regenerate re-runs the last user turn server-side — no body needed.
+        const url = options?.regenerate
+          ? `/api/conversations/${conversationId}/messages/regenerate`
+          : `/api/conversations/${conversationId}/messages`;
+        const res = await fetch(url, {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
+          ...(options?.regenerate ? {} : { body: JSON.stringify({ content: userMessage }) }),
           signal: abortController.signal,
         });
 


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `OF` (plan=Opus, impl=Fable)
**Source run-id:** `fb36f787-50d0-40b1-9933-4080cc90cef1`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.