### PR TITLE
[bench-FF] impl: address issue

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -603,6 +603,36 @@ async def list_messages(conversation_id: str, user_id: str) -> list[dict]:
     return results
 
 
+async def delete_last_assistant_message(conversation_id: str, user_id: str) -> str | None:
+    """Delete the conversation's most recent message iff its role is 'assistant'.
+
+    Owner-scoped (JOIN on conversations.user_id) and atomic: the role check on
+    the DELETE itself (not just the subquery) makes concurrent regenerates safe —
+    a second request's subquery resolves to the now-last user message, the role
+    predicate fails, zero rows are deleted, and None is returned.
+
+    Returns the deleted message id, or None when nothing was deleted.
+    """
+    async with _acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            DELETE FROM messages
+            WHERE id = (
+                SELECT m.id FROM messages m
+                JOIN conversations c ON c.id = m.conversation_id
+                WHERE m.conversation_id = $1 AND c.user_id = $2
+                ORDER BY m.created_at DESC, m.id DESC
+                LIMIT 1
+            )
+            AND role = 'assistant'
+            RETURNING id
+            """,
+            conversation_id,
+            user_id,
+        )
+    return row["id"] if row else None
+
+
 # ---------------------------------------------------------------------------
 # Channel sync runs
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/messages.py
+++ b/app/backend/routes/messages.py
@@ -1,5 +1,6 @@
 """
 Message routes — POST /api/conversations/{conv_id}/messages
+                 POST /api/conversations/{conv_id}/messages/regenerate
 
 Orchestrates the tool-driven RAG flow:
   1. Verify conversation ownership (404 cross-user, no leak)
@@ -12,6 +13,12 @@ Orchestrates the tool-driven RAG flow:
   6. Stream the response as SSE
   7. Send the sources event (populated from the model's tool calls) before [DONE]
   8. Persist the assistant message after the stream completes
+
+The regenerate flow (issue #280) reuses steps 5-8 via the shared
+`_stream_assistant_response` helper: it validates that the conversation ends
+with an assistant message, charges the same rate limit as a normal send,
+atomically deletes the trailing assistant message, then re-streams a fresh
+answer from the remaining history (which now ends with the user's question).
 """
 
 from __future__ import annotations
@@ -116,6 +123,98 @@ async def create_message(
     all_messages = await repository.list_messages(conv_id, user_id=user_id)
     llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages]
 
+    return await _stream_assistant_response(
+        conv_id, user_id, current_user, llm_messages, user_content
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations/{conv_id}/messages/regenerate
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations/{conv_id}/messages/regenerate")
+async def regenerate_message(
+    conv_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """
+    Regenerate the most recent assistant response (issue #280).
+
+    Validates that the conversation ends with an assistant message preceded
+    by at least one user message, charges one message of quota (same 25/24h
+    cap as a normal send — a 429 leaves the conversation untouched), then
+    atomically deletes the trailing assistant message and re-streams a fresh
+    answer from the remaining history. The SSE output shape is identical to
+    a normal send.
+    """
+    user_id = str(current_user["id"])
+
+    # 1. Verify conversation exists AND belongs to current user.
+    # 404 (not 403) — don't leak existence of other users' conversations.
+    conv = await repository.get_conversation(conv_id, user_id=user_id)
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # 2. Validate regenerability (read-only, before charging quota): the
+    # conversation must end with an assistant message that follows at least
+    # one user message. Invalid regenerates must not consume quota.
+    all_messages = await repository.list_messages(conv_id, user_id=user_id)
+    if (
+        not all_messages
+        or all_messages[-1]["role"] != "assistant"
+        or not any(m["role"] == "user" for m in all_messages[:-1])
+    ):
+        raise HTTPException(status_code=409, detail="Nothing to regenerate")
+
+    # 3. Enforce the 25 msg / user / 24h cap (MISSION §10 invariant #1).
+    #    Runs unconditionally BEFORE the delete and before any LLM work —
+    #    regenerate costs exactly one message of quota, and a 429 leaves the
+    #    conversation untouched (nothing has been deleted yet).
+    try:
+        await rate_limit.check_and_record(user_id)
+    except rate_limit.RateLimitExceeded as exc:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "rate_limit_exceeded",
+                "limit": rate_limit.DAILY_MESSAGE_CAP,
+                "window_hours": rate_limit.WINDOW_HOURS,
+                "reset_at": exc.reset_at.isoformat(),
+            },
+        )
+
+    # 4. Atomically delete the trailing assistant message. The repository
+    # function deletes the last message only if its role is 'assistant'
+    # (owner-scoped) — a concurrent regenerate that lost the race deletes
+    # zero rows and returns None.
+    deleted = await repository.delete_last_assistant_message(conv_id, user_id)
+    if deleted is None:
+        raise HTTPException(status_code=409, detail="Nothing to regenerate")
+
+    # 5. Re-stream from the remaining history (now ends with the user's
+    # last question).
+    llm_messages = [{"role": m["role"], "content": m["content"]} for m in all_messages[:-1]]
+    user_content = next(m["content"] for m in reversed(all_messages[:-1]) if m["role"] == "user")
+    return await _stream_assistant_response(
+        conv_id, user_id, current_user, llm_messages, user_content
+    )
+
+
+async def _stream_assistant_response(
+    conv_id: str,
+    user_id: str,
+    current_user: dict[str, Any],
+    llm_messages: list[dict[str, Any]],
+    user_content: str,
+) -> StreamingResponse:
+    """Shared streaming core for send and regenerate (steps 5-8 of the flow).
+
+    Wires the retrieval tools, streams the LLM response as SSE (marker
+    stripping, sources event, refusal suppression, citation collapse), and
+    persists the assistant message under asyncio.shield. Callers are
+    responsible for ownership checks, rate limiting, and history assembly.
+    """
     # 5. Set up tool plumbing. All retrieval happens inside the LLM loop via
     # tool calls — no pre-retrieval runs here. The executor closure collects
     # every chunk returned by any tool call so the final SSE `sources` event

--- a/app/backend/tests/test_regenerate.py
+++ b/app/backend/tests/test_regenerate.py
@@ -1,0 +1,310 @@
+"""
+Tests for POST /api/conversations/{conv_id}/messages/regenerate (issue #280).
+
+Verifies the ordered guard flow of the regenerate endpoint:
+ownership 404 → regenerability 409 (no quota charge) → rate limit 429
+(conversation untouched) → atomic delete (race-safe 409) → shared SSE stream.
+
+Mocking follows the established patterns in test_sources_event.py /
+test_rate_limit.py: monkeypatched repository functions, a fake stream_chat,
+and httpx.AsyncClient against the real app. Postgres is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from backend import rate_limit
+from backend.auth.tokens import encode_token
+from backend.main import app
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+SOURCE_CITATIONS = [
+    {
+        "chunk_id": "c1",
+        "video_id": "v1",
+        "video_title": "Test Video",
+        "video_url": "https://youtube.com/watch?v=abc",
+        "start_seconds": 10.0,
+        "end_seconds": 20.0,
+        "snippet": "Test snippet",
+    }
+]
+
+
+def _history(conv_id: str) -> list[dict]:
+    """A conversation ending in an assistant answer — the regenerable shape."""
+    return [
+        {
+            "id": "m1",
+            "conversation_id": conv_id,
+            "role": "user",
+            "content": "What is RAG?",
+            "sources": None,
+            "created_at": "2026-01-01T00:00:00Z",
+        },
+        {
+            "id": "m2",
+            "conversation_id": conv_id,
+            "role": "assistant",
+            "content": "Old answer",
+            "sources": None,
+            "created_at": "2026-01-01T00:00:01Z",
+        },
+    ]
+
+
+def _make_stream_chat(answer_text: str, captured_messages: list | None = None):
+    async def mock_stream_chat(
+        messages,
+        tools=None,
+        tool_executor=None,
+        max_tool_calls=0,
+        final_text_out=None,
+        **_kwargs,
+    ):
+        if captured_messages is not None:
+            captured_messages.append(messages)
+        if tool_executor is not None:
+            await tool_executor("search_videos", json.dumps({"query": "test"}))
+        yield f"data: {json.dumps(answer_text)}\n\n"
+        if final_text_out is not None:
+            final_text_out.append(answer_text)
+        yield "data: [DONE]\n\n"
+
+    return mock_stream_chat
+
+
+async def _mock_execute_tool(
+    name, raw_args, video_id_whitelist=None, embedding_cache=None, is_member=False
+):
+    return {"ok": True, "text": "context", "chunks": [dict(c) for c in SOURCE_CITATIONS]}
+
+
+class _RegenHarness:
+    """Bundles the common patch set for regenerate integration tests."""
+
+    def __init__(self, *, history: list[dict] | None = None, answer_text: str = "Fresh answer."):
+        self.user_id = str(uuid4())
+        self.conv_id = str(uuid4())
+        self.token = encode_token(self.user_id)
+        self.history = history if history is not None else _history(self.conv_id)
+        self.captured_llm_messages: list = []
+        self.check_and_record = AsyncMock()
+        self.delete_last = AsyncMock(return_value="m2")
+        self.create_message = AsyncMock(return_value={"id": str(uuid4())})
+        self.answer_text = answer_text
+
+    def patches(self):
+        user_id = self.user_id
+        conv_id = self.conv_id
+        history = self.history
+
+        async def mock_get_user_by_id(uid):
+            return {
+                "id": user_id,
+                "email": "test@example.com",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+
+        async def mock_get_conversation(cid, user_id=None, **_kw):
+            if cid == conv_id:
+                return {
+                    "id": conv_id,
+                    "user_id": user_id,
+                    "title": "Test",
+                    "created_at": "2026-01-01T00:00:00Z",
+                }
+            return None
+
+        async def mock_list_messages(cid, user_id=None, **_kw):
+            return [dict(m) for m in history]
+
+        async def mock_list_videos():
+            return [{"id": "v1", "title": "Test Video", "url": "u"}]
+
+        return (
+            patch("backend.auth.dependencies.users_repo.get_user_by_id", mock_get_user_by_id),
+            patch("backend.db.repository.get_conversation", mock_get_conversation),
+            patch("backend.db.repository.list_messages", mock_list_messages),
+            patch("backend.db.repository.list_videos", mock_list_videos),
+            patch("backend.db.repository.create_message", self.create_message),
+            patch("backend.db.repository.delete_last_assistant_message", self.delete_last),
+            patch("backend.rate_limit.check_and_record", self.check_and_record),
+            patch(
+                "backend.routes.messages.stream_chat",
+                _make_stream_chat(self.answer_text, self.captured_llm_messages),
+            ),
+            patch("backend.routes.messages.execute_tool", _mock_execute_tool),
+        )
+
+    async def post(self, client: AsyncClient, conv_id: str | None = None):
+        return await client.post(
+            f"/api/conversations/{conv_id or self.conv_id}/messages/regenerate",
+            headers={"Cookie": f"session={self.token}"},
+        )
+
+
+async def _run(harness: _RegenHarness, conv_id: str | None = None):
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for p in harness.patches():
+            stack.enter_context(p)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await harness.post(client, conv_id)
+
+
+# ---------------------------------------------------------------------------
+# Ownership — 404, no quota charge, no delete
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_404_for_unknown_conversation():
+    harness = _RegenHarness()
+    response = await _run(harness, conv_id=str(uuid4()))
+
+    assert response.status_code == 404
+    assert not harness.check_and_record.called, "404 must not charge quota"
+    assert not harness.delete_last.called, "404 must not delete anything"
+
+
+# ---------------------------------------------------------------------------
+# Regenerability validation — 409 before quota
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_409_for_empty_conversation():
+    harness = _RegenHarness(history=[])
+    response = await _run(harness)
+
+    assert response.status_code == 409
+    assert not harness.check_and_record.called, "invalid regenerate must not charge quota"
+    assert not harness.delete_last.called
+
+
+async def test_regenerate_409_when_last_message_is_user():
+    harness = _RegenHarness()
+    harness.history = harness.history[:1]  # only the user message remains
+    response = await _run(harness)
+
+    assert response.status_code == 409
+    assert not harness.check_and_record.called, "invalid regenerate must not charge quota"
+    assert not harness.delete_last.called
+
+
+async def test_regenerate_409_when_no_user_message_precedes_assistant():
+    harness = _RegenHarness()
+    harness.history = [harness.history[1]]  # lone assistant message
+    response = await _run(harness)
+
+    assert response.status_code == 409
+    assert not harness.check_and_record.called
+    assert not harness.delete_last.called
+
+
+# ---------------------------------------------------------------------------
+# Rate limit — 429 body matches send path, conversation untouched
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_429_leaves_conversation_intact():
+    from datetime import UTC, datetime
+
+    harness = _RegenHarness()
+    reset_at = datetime(2026, 1, 2, 0, 0, 0, tzinfo=UTC)
+    harness.check_and_record.side_effect = rate_limit.RateLimitExceeded(reset_at=reset_at)
+
+    response = await _run(harness)
+
+    assert response.status_code == 429
+    body = response.json()
+    assert body["error"] == "rate_limit_exceeded"
+    assert body["limit"] == rate_limit.DAILY_MESSAGE_CAP
+    assert body["window_hours"] == rate_limit.WINDOW_HOURS
+    assert body["reset_at"] == reset_at.isoformat()
+    assert not harness.delete_last.called, "429 must run before the delete"
+    assert not harness.create_message.called
+
+
+# ---------------------------------------------------------------------------
+# Happy path — quota charged once, delete called, fresh SSE stream
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_happy_path_streams_and_persists():
+    harness = _RegenHarness()
+    response = await _run(harness)
+
+    assert response.status_code == 200
+    output = response.text
+
+    # Quota charged exactly once; the stale answer was deleted.
+    assert harness.check_and_record.call_count == 1
+    assert harness.check_and_record.call_args.args[0] == harness.user_id
+    harness.delete_last.assert_called_once_with(harness.conv_id, harness.user_id)
+
+    # SSE stream: tokens + sources event before [DONE].
+    assert '"Fresh answer."' in output or "Fresh answer." in output
+    assert "event: sources" in output
+    assert output.index("event: sources") < output.index("data: [DONE]")
+
+    # History sent to the LLM ends with the user's question and excludes the
+    # deleted assistant answer.
+    assert len(harness.captured_llm_messages) == 1
+    llm_messages = harness.captured_llm_messages[0]
+    assert llm_messages[-1] == {"role": "user", "content": "What is RAG?"}
+    assert all(m["content"] != "Old answer" for m in llm_messages)
+
+    # Exactly one persist (the fresh assistant message) — no user-message insert.
+    assert harness.create_message.call_count == 1
+    persist_kwargs = harness.create_message.call_args.kwargs
+    assert persist_kwargs["role"] == "assistant"
+    assert persist_kwargs["content"] == "Fresh answer."
+    assert persist_kwargs["sources"], "non-refusal answer must persist its sources"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — lost race returns 409, no stream
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_409_when_delete_loses_race():
+    harness = _RegenHarness()
+    harness.delete_last.return_value = None
+
+    response = await _run(harness)
+
+    assert response.status_code == 409
+    assert harness.captured_llm_messages == [], "no LLM stream after a lost race"
+    assert not harness.create_message.called
+
+
+# ---------------------------------------------------------------------------
+# Refusal — shared helper still suppresses sources on regenerate
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_refusal_suppresses_sources():
+    refusal = "Those topics are not covered in any of the videos."
+    harness = _RegenHarness(answer_text=refusal)
+
+    response = await _run(harness)
+
+    assert response.status_code == 200
+    output = response.text
+    assert "event: sources" not in output, "refusal must suppress the sources event"
+    assert "data: [DONE]" in output
+
+    assert harness.create_message.call_count == 1
+    persist_kwargs = harness.create_message.call_args.kwargs
+    assert persist_kwargs["role"] == "assistant"
+    assert persist_kwargs["sources"] is None, "refusal must persist sources=None"

--- a/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
+++ b/app/frontend/src/__tests__/ChatArea-regenerate.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Integration tests for the regenerate flow in ChatArea (issue #280).
+ *
+ * Verifies:
+ *   - The regenerate button renders only on the last assistant message
+ *   - Clicking it removes the old answer and shows the streaming bubble
+ *   - On 429 the original answer is restored and the rate-limit inline
+ *     error is shown (the server rejects before deleting anything)
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatArea } from '../components/ChatArea';
+import { type Message as MessageType, RateLimitError } from '../lib/api';
+
+type RegenOnComplete = (result: { fullText: string; sources: unknown[] }) => void;
+
+const ctl = vi.hoisted(() => ({
+  initialMessages: [] as unknown[],
+  regenImpl: null as null | ((convId: string, onComplete: RegenOnComplete) => Promise<void>),
+  addToast: vi.fn(),
+  refreshAuth: vi.fn(),
+}));
+
+vi.mock('../hooks/useMessages', async () => {
+  const { useState } = await import('react');
+  return {
+    useMessages: () => {
+      const [messages, setMessages] = useState(ctl.initialMessages);
+      return {
+        messages,
+        setMessages,
+        loading: false,
+        error: null,
+        notFound: false,
+        conversation: { id: 'conv-1', title: 'Test', created_at: '', updated_at: '' },
+      };
+    },
+  };
+});
+
+vi.mock('../hooks/useStreamingResponse', async () => {
+  const { useState } = await import('react');
+  return {
+    useStreamingResponse: () => {
+      const [isStreaming, setIsStreaming] = useState(false);
+      const startRegenerate = async (convId: string, onComplete: RegenOnComplete) => {
+        setIsStreaming(true);
+        try {
+          if (ctl.regenImpl) await ctl.regenImpl(convId, onComplete);
+        } finally {
+          setIsStreaming(false);
+        }
+      };
+      return {
+        streamingContent: '',
+        streamingSources: [],
+        streamingStatus: null,
+        isStreaming,
+        startStream: vi.fn(),
+        startRegenerate,
+        abortStream: vi.fn(),
+      };
+    },
+  };
+});
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ addToast: ctl.addToast, removeToast: vi.fn() }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'test-user', email: 'test@test', is_admin: false },
+    refresh: ctl.refreshAuth,
+  }),
+}));
+
+function makeMessages(): MessageType[] {
+  return [
+    {
+      id: 'm1',
+      conversation_id: 'conv-1',
+      role: 'user',
+      content: 'First question',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    {
+      id: 'm2',
+      conversation_id: 'conv-1',
+      role: 'assistant',
+      content: 'First answer',
+      created_at: '2026-01-01T00:00:01Z',
+    },
+    {
+      id: 'm3',
+      conversation_id: 'conv-1',
+      role: 'user',
+      content: 'Second question',
+      created_at: '2026-01-01T00:00:02Z',
+    },
+    {
+      id: 'm4',
+      conversation_id: 'conv-1',
+      role: 'assistant',
+      content: 'Second answer',
+      created_at: '2026-01-01T00:00:03Z',
+    },
+  ];
+}
+
+function renderChatArea() {
+  return render(
+    <MemoryRouter>
+      <ChatArea conversationId="conv-1" />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatArea — regenerate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    ctl.initialMessages = makeMessages();
+    ctl.regenImpl = null;
+    ctl.addToast = vi.fn();
+    ctl.refreshAuth = vi.fn();
+  });
+
+  it('renders the regenerate button only on the last assistant message', () => {
+    renderChatArea();
+
+    // Two assistant messages are rendered, but only the final one gets the prop.
+    expect(screen.getByText('First answer')).toBeInTheDocument();
+    expect(screen.getByText('Second answer')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Regenerate response' })).toHaveLength(1);
+  });
+
+  it('removes the last answer and shows the streaming bubble on click', async () => {
+    // Never-resolving stream keeps isStreaming=true after the click.
+    ctl.regenImpl = () => new Promise(() => {});
+
+    renderChatArea();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Second answer')).not.toBeInTheDocument();
+    });
+    // Streaming bubble with empty content renders the typing indicator.
+    await waitFor(() => {
+      expect(document.querySelectorAll('.typing-dot')).toHaveLength(3);
+    });
+    // The button is hidden while the replacement streams.
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('appends the fresh answer when the stream completes', async () => {
+    ctl.regenImpl = async (_convId, onComplete) => {
+      onComplete({ fullText: 'Regenerated answer', sources: [] });
+    };
+
+    renderChatArea();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Regenerated answer')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Second answer')).not.toBeInTheDocument();
+    // Quota counter refreshed after the regenerate spent a message.
+    expect(ctl.refreshAuth).toHaveBeenCalled();
+  });
+
+  it('restores the original answer and shows the rate-limit error on 429', async () => {
+    ctl.regenImpl = async () => {
+      throw new RateLimitError({
+        limit: 25,
+        window_hours: 24,
+        reset_at: '2026-01-02T00:00:00Z',
+      });
+    };
+
+    renderChatArea();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+
+    // The 429 arrives before the server deletes anything — the original
+    // answer must come back.
+    await waitFor(() => {
+      expect(screen.getByText('Second answer')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/daily message limit \(25\/day\)/)).toBeInTheDocument();
+    expect(ctl.addToast).toHaveBeenCalledWith(
+      expect.stringMatching(/daily message limit/),
+      'error',
+    );
+    expect(ctl.refreshAuth).toHaveBeenCalled();
+  });
+
+  it('restores the original answer and shows a generic error on failure', async () => {
+    ctl.regenImpl = async () => {
+      throw new Error('HTTP 500');
+    };
+
+    renderChatArea();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Second answer')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('Failed to regenerate the response. Please try again.'),
+    ).toBeInTheDocument();
+    expect(ctl.addToast).toHaveBeenCalledWith('HTTP 500', 'error');
+  });
+});

--- a/app/frontend/src/components/ChatArea.tsx
+++ b/app/frontend/src/components/ChatArea.tsx
@@ -301,6 +301,7 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   } = useStreamingResponse(conversationId || null);
   const { addToast } = useToast();
@@ -559,6 +560,69 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
     ],
   );
 
+  // ── Regenerate handler — replace the last assistant message with a fresh stream ──
+  const handleRegenerate = useCallback(async () => {
+    if (isStreaming || !conversationId) return;
+    if (messages.length === 0 || messages[messages.length - 1]?.role !== 'assistant') return;
+
+    // Stash the message so it can be restored if the server rejects the
+    // regenerate (the backend checks the rate limit BEFORE deleting anything,
+    // so a 429 means the conversation is untouched server-side).
+    const removed = messages[messages.length - 1];
+    setInlineError(null);
+    setFailedMessageText(null);
+    setMessages((prev) => prev.slice(0, -1));
+    autoScrollRef.current = true;
+    scrollToBottom();
+
+    try {
+      await startRegenerate(conversationId, ({ fullText, sources }) => {
+        const assistantMsg: MessageType = {
+          id: `temp-assistant-${Date.now()}`,
+          conversation_id: conversationId,
+          role: 'assistant',
+          content: fullText,
+          created_at: new Date().toISOString(),
+          sources: sources.length > 0 ? sources : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      });
+      // Pull fresh quota counter — regenerate spends one message of quota.
+      refreshAuth();
+    } catch (e) {
+      // Intentional abort (navigation or user cancel) — the server's shielded
+      // persist saves the partial; a reload reconciles. No error toast.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return;
+      }
+
+      if (e instanceof RateLimitError) {
+        // 429 happens before the server deletes anything — restore the
+        // original answer locally.
+        setMessages((prev) => [...prev, removed]);
+        const friendly = `You've hit your daily message limit (${e.limit}/day). Resets at ${formatResetTime(e.resetAt)}.`;
+        setInlineError(friendly);
+        addToast(friendly, 'error');
+        refreshAuth();
+        return;
+      }
+
+      setMessages((prev) => [...prev, removed]);
+      const errMsg = e instanceof Error ? e.message : 'Failed to regenerate the response';
+      setInlineError('Failed to regenerate the response. Please try again.');
+      addToast(errMsg || 'Network error — response not regenerated', 'error');
+    }
+  }, [
+    conversationId,
+    isStreaming,
+    messages,
+    setMessages,
+    startRegenerate,
+    scrollToBottom,
+    addToast,
+    refreshAuth,
+  ]);
+
   // Send pending message after conversation is created (post-route-change).
   // We read from `location.state.initialMessage`, which survives the
   // LandingPage → ConversationPage remount. Clear state with `replace`
@@ -708,13 +772,18 @@ export function ChatArea({ conversationId, refreshConversationsRef }: ChatAreaPr
             {showEmptyInConversation ? (
               <EmptyState onStarterClick={handleStarterClick} />
             ) : (
-              messages.map((msg) => (
+              messages.map((msg, idx) => (
                 <Message
                   key={msg.id}
                   role={msg.role}
                   content={msg.content}
                   sources={msg.sources}
                   onCitationClick={handleCitationClick}
+                  onRegenerate={
+                    !isStreaming && msg.role === 'assistant' && idx === messages.length - 1
+                      ? handleRegenerate
+                      : undefined
+                  }
                 />
               ))
             )}

--- a/app/frontend/src/components/Message.test.tsx
+++ b/app/frontend/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Citation } from '../lib/api';
 import { Message } from './Message';
@@ -147,5 +147,45 @@ describe('Message — citation chip segment_count label', () => {
       />,
     );
     expect(screen.queryByText(/segments/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Message — regenerate button', () => {
+  it('renders the regenerate button on an assistant message when onRegenerate is provided', () => {
+    render(
+      <Message role="assistant" content="Answer text." isStreaming={false} onRegenerate={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Regenerate response' })).toBeInTheDocument();
+  });
+
+  it('does not render the button when onRegenerate is omitted', () => {
+    render(<Message role="assistant" content="Answer text." isStreaming={false} />);
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button on user messages', () => {
+    render(<Message role="user" content="A question" isStreaming={false} onRegenerate={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the button while streaming', () => {
+    render(
+      <Message role="assistant" content="Partial..." isStreaming={true} onRegenerate={vi.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: 'Regenerate response' })).not.toBeInTheDocument();
+  });
+
+  it('fires the callback on click', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <Message
+        role="assistant"
+        content="Answer text."
+        isStreaming={false}
+        onRegenerate={onRegenerate}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate response' }));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/frontend/src/components/Message.tsx
+++ b/app/frontend/src/components/Message.tsx
@@ -15,6 +15,8 @@ interface MessageProps {
   onCitationClick?: (citation: Citation) => void;
   /** Current tool-call status during streaming (ephemeral progress indicator) */
   streamingStatus?: StreamingStatus | null;
+  /** When provided (assistant messages only), renders a regenerate button */
+  onRegenerate?: () => void;
 }
 
 // ── Typing indicator (3 pulsing dots) ────────────────────────────
@@ -159,6 +161,48 @@ function SourceCitations({
   );
 }
 
+// ── Regenerate button ─────────────────────────────────────────────
+function RegenerateButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+      style={{
+        background: 'transparent',
+        border: 'none',
+        cursor: 'pointer',
+        color: '#94a3b8',
+        fontSize: 12,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: 0,
+        marginTop: 8,
+        transition: 'color 0.15s',
+        fontFamily: 'inherit',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.color = '#f1f5f9')}
+      onMouseLeave={(e) => (e.currentTarget.style.color = '#94a3b8')}
+      aria-label="Regenerate response"
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M10.5 6a4.5 4.5 0 1 1-1.3-3.2" />
+        <polyline points="9.5,0.8 9.5,3.3 7,3.3" />
+      </svg>
+      Regenerate
+    </button>
+  );
+}
+
 // ── Main message component ────────────────────────────────────────
 export function Message({
   role,
@@ -167,6 +211,7 @@ export function Message({
   sources,
   onCitationClick,
   streamingStatus,
+  onRegenerate,
 }: MessageProps) {
   const isUser = role === 'user';
   const hasSources = !isUser && Array.isArray(sources) && sources.length > 0;
@@ -204,6 +249,7 @@ export function Message({
           <>
             <MarkdownRenderer content={content} />
             {hasSources && <SourceCitations sources={sources} onCitationClick={onCitationClick} />}
+            {onRegenerate && !isStreaming && <RegenerateButton onClick={onRegenerate} />}
           </>
         )}
       </div>

--- a/app/frontend/src/hooks/useStreamingResponse.test.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.test.ts
@@ -9,6 +9,7 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RateLimitError } from '../lib/api';
 import { useStreamingResponse } from './useStreamingResponse';
 
 function makeSseStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -534,6 +535,95 @@ describe('conversationId reset — state clears on navigation', () => {
 
     // onComplete was called by startStream when the stream completed above
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ fullText: 'Hello' }));
+  });
+});
+
+describe('startRegenerate — regenerate the last assistant response', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the regenerate endpoint with no body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: makeSseStream(['data: "Hi"\n\n', 'data: [DONE]\n\n']),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startRegenerate('conv-1', vi.fn());
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/conversations/conv-1/messages/regenerate');
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toBeUndefined();
+  });
+
+  it('parses tokens and sources identically to startStream', async () => {
+    const sseChunks = [
+      `event: sources\ndata: ${JSON.stringify([mockCitation])}\n\n`,
+      'data: "Fresh "\n\n',
+      'data: "answer."\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: makeSseStream(sseChunks),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await result.current.startRegenerate('conv-1', onComplete);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith({
+      fullText: 'Fresh answer.',
+      sources: [expect.objectContaining({ chunk_id: 'chunk-1' })],
+    });
+    // Streaming state is reset in the finally block
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('throws RateLimitError on 429', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({
+          error: 'rate_limit_exceeded',
+          limit: 25,
+          window_hours: 24,
+          reset_at: '2026-01-02T00:00:00+00:00',
+        }),
+      }),
+    );
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useStreamingResponse('conv-1'));
+
+    await act(async () => {
+      await expect(result.current.startRegenerate('conv-1', onComplete)).rejects.toBeInstanceOf(
+        RateLimitError,
+      );
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(result.current.isStreaming).toBe(false);
   });
 });
 

--- a/app/frontend/src/hooks/useStreamingResponse.ts
+++ b/app/frontend/src/hooks/useStreamingResponse.ts
@@ -42,10 +42,10 @@ export function useStreamingResponse(conversationId: string | null) {
     }
   }, []);
 
-  const startStream = useCallback(
+  const runStream = useCallback(
     async (
-      conversationId: string,
-      userMessage: string,
+      url: string,
+      body: string | null,
       onComplete: (result: StreamResult) => void,
     ): Promise<void> => {
       setIsStreaming(true);
@@ -61,11 +61,10 @@ export function useStreamingResponse(conversationId: string | null) {
         const abortController = new AbortController();
         streamAbortRef.current = abortController;
 
-        const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+        const res = await fetch(url, {
           method: 'POST',
           credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: userMessage }),
+          ...(body !== null ? { headers: { 'Content-Type': 'application/json' }, body } : {}),
           signal: abortController.signal,
         });
 
@@ -218,12 +217,33 @@ export function useStreamingResponse(conversationId: string | null) {
     [],
   );
 
+  const startStream = useCallback(
+    (
+      conversationId: string,
+      userMessage: string,
+      onComplete: (result: StreamResult) => void,
+    ): Promise<void> =>
+      runStream(
+        `/api/conversations/${conversationId}/messages`,
+        JSON.stringify({ content: userMessage }),
+        onComplete,
+      ),
+    [runStream],
+  );
+
+  const startRegenerate = useCallback(
+    (conversationId: string, onComplete: (result: StreamResult) => void): Promise<void> =>
+      runStream(`/api/conversations/${conversationId}/messages/regenerate`, null, onComplete),
+    [runStream],
+  );
+
   return {
     streamingContent,
     streamingSources,
     streamingStatus,
     isStreaming,
     startStream,
+    startRegenerate,
     abortStream,
   };
 }


### PR DESCRIPTION
Fixes #280

**Benchmark cell:** `FF` (plan=Fable, impl=Fable)
**Source run-id:** `3406e69e-5af7-40f2-884c-58cc7fdb81ae`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.