### PR TITLE
[bench-OO] review: address self-review findings

### DIFF
--- a/app/backend/alembic/versions/0006_add_messages_sources_gin_index.py
+++ b/app/backend/alembic/versions/0006_add_messages_sources_gin_index.py
@@ -1,0 +1,34 @@
+"""Add GIN index on messages.sources for fast video-filter containment checks.
+
+Issue #294 adds a "filter conversations by video" feature. The video link lives
+inside `messages.sources` JSONB as `[{"video_id": "...", ...}]`, and filtering
+uses a `sources @> '[{"video_id":"X"}]'::jsonb` containment check. Without a GIN
+index that check is a sequential scan over messages; the index keeps it fast.
+
+NOTE: plain `CREATE INDEX` (not CONCURRENTLY) — Alembic wraps each migration in a
+transaction and `CREATE INDEX CONCURRENTLY` cannot run inside one. Plain index
+creation is fine at current table sizes.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-31
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE INDEX IF NOT EXISTS ix_messages_sources_gin ON messages USING GIN (sources)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_messages_sources_gin")

--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -526,6 +526,74 @@ async def search_conversations_by_title(user_id: str, query: str, limit: int = 2
     return [dict(r) for r in rows]
 
 
+async def search_conversations(
+    user_id: str,
+    *,
+    query: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    video_id: str | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    """Filter a user's conversations by any combination of title text, date range,
+    and the video discussed, ordered most-recent-first (issue #294).
+
+    All filters are optional and combine with AND. Owner scope (`c.user_id = $1`)
+    is non-negotiable and always applied first — never weaken it.
+
+    Date-column decision: filter on `created_at` ("when the conversation happened"
+    per the issue), but sort on `updated_at DESC` to match the existing list
+    ordering / "most-recent-first". A reviewer can flip the filter column to
+    `updated_at` if preferred.
+
+    The video link lives only inside `messages.sources` JSONB (Citation objects
+    shaped `[{"video_id": ...}]`), so the video filter uses an EXISTS containment
+    check across the conversation's messages (backed by the GIN index from
+    migration 0006).
+    """
+    # WHERE is built dynamically with a positional-param list, always starting
+    # from the owner scope. Only the ILIKE pattern value is interpolated into a
+    # Python string (the established pattern in search_conversations_by_title);
+    # every value still binds as a parameter — no SQL is built from user input.
+    params: list[object] = [user_id]
+    where = ["c.user_id = $1"]
+
+    if query:
+        params.append(f"%{query}%")
+        where.append(f"c.title ILIKE ${len(params)}")
+    if date_from:
+        params.append(date_from)
+        where.append(f"c.created_at >= ${len(params)}::timestamptz")
+    if date_to:
+        params.append(date_to)
+        where.append(f"c.created_at <= ${len(params)}::timestamptz")
+    if video_id:
+        params.append(json.dumps([{"video_id": video_id}]))
+        where.append(
+            "EXISTS (SELECT 1 FROM messages m "
+            f"WHERE m.conversation_id = c.id AND m.sources @> ${len(params)}::jsonb)"
+        )
+
+    params.append(limit)
+    limit_param = len(params)
+
+    sql = f"""
+        SELECT c.*,
+               (SELECT content
+                FROM messages
+                WHERE conversation_id = c.id
+                ORDER BY created_at DESC
+                LIMIT 1) AS preview
+        FROM conversations c
+        WHERE {" AND ".join(where)}
+        ORDER BY c.updated_at DESC
+        LIMIT ${limit_param}
+    """
+    async with _acquire() as conn:
+        rows = await conn.fetch(sql, *params)
+    return [dict(r) for r in rows]
+
+
 # ---------------------------------------------------------------------------
 # Messages
 # ---------------------------------------------------------------------------

--- a/app/backend/routes/conversations.py
+++ b/app/backend/routes/conversations.py
@@ -45,14 +45,27 @@ async def create_conversation(
 
 @router.get("/conversations/search")
 async def search_conversations(
-    q: str,
+    q: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    video_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    """Title-contains search. Must be declared BEFORE /conversations/{conv_id}
-    or FastAPI routes "search" to the path-parameter handler and returns 404."""
-    return await repository.search_conversations_by_title(
+    """Filter conversations by title text, date range, and/or video (issue #294),
+    combinable and ordered most-recent-first.
+
+    Must be declared BEFORE /conversations/{conv_id} or FastAPI routes "search" to
+    the path-parameter handler and returns 404.
+
+    Owner scope is enforced by the repository — user_id comes solely from the
+    authenticated session, never from a request parameter.
+    """
+    return await repository.search_conversations(
         user_id=str(current_user["id"]),
         query=q,
+        date_from=date_from,
+        date_to=date_to,
+        video_id=video_id,
     )
 
 

--- a/app/backend/tests/test_search_conversations.py
+++ b/app/backend/tests/test_search_conversations.py
@@ -22,7 +22,9 @@ pytestmark = pytest.mark.skip(
 
 from backend.db.repository import (  # noqa: E402
     create_conversation,
+    create_message,
     create_video,
+    search_conversations,
     search_conversations_by_title,
     search_videos_admin,
 )
@@ -209,3 +211,93 @@ async def test_search_videos_admin_matches_description_and_channel_title():
     results = await search_videos_admin("Rust Channel")
     assert len(results) == 1
     assert results[0]["title"] == "Generic Title"
+
+
+# ---------------------------------------------------------------------------
+# search_conversations — combined date / video / title filter (issue #294)
+# ---------------------------------------------------------------------------
+
+
+async def test_search_conversations_no_filters_lists_owner_rows():
+    """With no filters set, it behaves like the conversation list (owner-scoped)."""
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="Chat A")
+    await create_conversation(user_id=user_id, title="Chat B")
+
+    results = await search_conversations(user_id)
+    titles = {r["title"] for r in results}
+    assert titles == {"Chat A", "Chat B"}
+
+
+async def test_search_conversations_only_owner_rows():
+    """Owner scope is enforced even with other filters applied."""
+    alice_id = str(uuid4())
+    bob_id = str(uuid4())
+    await create_conversation(user_id=alice_id, title="Alice Topic")
+    await create_conversation(user_id=bob_id, title="Bob Topic")
+
+    results = await search_conversations(alice_id, query="topic")
+    titles = {r["title"] for r in results}
+    assert titles == {"Alice Topic"}
+
+
+async def test_search_conversations_title_and_date_combine():
+    """Title and date-range filters combine with AND."""
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="Python in 2026")
+
+    # A wide window around now should include the freshly-created conversation.
+    results = await search_conversations(
+        user_id,
+        query="python",
+        date_from="2000-01-01T00:00:00Z",
+        date_to="2100-01-01T00:00:00Z",
+    )
+    assert len(results) == 1
+    assert results[0]["title"] == "Python in 2026"
+
+    # A window entirely in the past excludes it.
+    results = await search_conversations(
+        user_id,
+        query="python",
+        date_to="2001-01-01T00:00:00Z",
+    )
+    assert results == []
+
+
+async def test_search_conversations_video_filter_matches_via_sources():
+    """video_id filter matches conversations whose messages cite that video."""
+    user_id = str(uuid4())
+    conv_with = await create_conversation(user_id=user_id, title="Has video")
+    conv_without = await create_conversation(user_id=user_id, title="No video")
+
+    await create_message(
+        conversation_id=conv_with["id"],
+        user_id=user_id,
+        role="assistant",
+        content="answer",
+        sources=[{"video_id": "vid-target", "video_title": "Target"}],
+    )
+    # A different video cited elsewhere must not match.
+    await create_message(
+        conversation_id=conv_without["id"],
+        user_id=user_id,
+        role="assistant",
+        content="answer",
+        sources=[{"video_id": "vid-other", "video_title": "Other"}],
+    )
+
+    results = await search_conversations(user_id, video_id="vid-target")
+    titles = {r["title"] for r in results}
+    assert titles == {"Has video"}
+
+
+async def test_search_conversations_ordered_most_recent_first():
+    """Results are ordered by updated_at DESC (most-recent-first)."""
+    user_id = str(uuid4())
+    await create_conversation(user_id=user_id, title="Older")
+    await create_conversation(user_id=user_id, title="Newer")
+
+    results = await search_conversations(user_id)
+    # Newer conversation (created later → later updated_at) comes first.
+    assert results[0]["title"] == "Newer"

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -446,7 +446,9 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     debouncedQuery,
     {
       dateFrom: dateFrom || undefined,
-      dateTo: dateTo || undefined,
+      // Append end-of-day so YYYY-MM-DD casts to 23:59:59 in Postgres, not 00:00:00 —
+      // otherwise conversations on the "to" day after midnight would be excluded.
+      dateTo: dateTo ? `${dateTo}T23:59:59` : undefined,
       videoId: videoId || undefined,
     },
   );

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -3,8 +3,31 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import {
+  type Conversation,
+  type Video,
+  createConversation,
+  deleteConversation,
+  getVideos,
+} from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
+
+// ── Date-range presets ───────────────────────────────────────────
+// Compute with native Date math (no date library, per scope). Returns an ISO
+// `from` (start) and `to` (end) — undefined means "unbounded on that side".
+type DatePreset = { dateFrom?: string; dateTo?: string };
+
+function presetThisWeek(): DatePreset {
+  const from = new Date();
+  from.setDate(from.getDate() - 7);
+  return { dateFrom: from.toISOString() };
+}
+
+function presetLastMonth(): DatePreset {
+  const from = new Date();
+  from.setMonth(from.getMonth() - 1);
+  return { dateFrom: from.toISOString() };
+}
 
 // ── Relative time helper ─────────────────────────────────────────
 function formatRelativeTime(dateStr: string): string {
@@ -413,8 +436,21 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
-  const { conversations, loading, refetch, rename, filteredConversations } =
-    useConversations(debouncedQuery);
+  // ── Date / video filters (issue #294) ──
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [videoId, setVideoId] = useState('');
+  const [videos, setVideos] = useState<Video[]>([]);
+  const { conversations, loading, refetch, rename, filteredConversations } = useConversations(
+    debouncedQuery,
+    {
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
+      videoId: videoId || undefined,
+    },
+  );
+  const filtersActive = !!(dateFrom || dateTo || videoId);
   const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -430,6 +466,27 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  // Load the video list once to populate the filter dropdown (issue #294).
+  useEffect(() => {
+    let cancelled = false;
+    getVideos()
+      .then((v) => {
+        if (!cancelled) setVideos(v);
+      })
+      .catch(() => {
+        // Non-fatal: the video filter dropdown just stays empty.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const clearFilters = () => {
+    setDateFrom('');
+    setDateTo('');
+    setVideoId('');
+  };
 
   // Store refetch in the shared ref so ChatArea can trigger it
   useEffect(() => {
@@ -601,6 +658,187 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           />
         </div>
 
+        {/* ── Filters (date range + video) — issue #294 ── */}
+        <div style={{ padding: '0 12px 8px' }}>
+          <button
+            onClick={() => setFiltersOpen((o) => !o)}
+            aria-expanded={filtersOpen}
+            className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              background: 'transparent',
+              border: 'none',
+              color: filtersActive ? '#3b82f6' : '#94a3b8',
+              cursor: 'pointer',
+              fontSize: 12,
+              padding: '2px 0',
+            }}
+          >
+            <span>{filtersOpen ? '▾' : '▸'}</span>
+            Filters
+            {filtersActive && (
+              <span
+                style={{
+                  fontSize: 11,
+                  background: 'rgba(59,130,246,0.2)',
+                  color: '#3b82f6',
+                  borderRadius: 6,
+                  padding: '0 6px',
+                }}
+              >
+                active
+              </span>
+            )}
+          </button>
+
+          {filtersOpen && (
+            <div
+              style={{
+                marginTop: 8,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+                padding: 10,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                borderRadius: 8,
+              }}
+            >
+              {/* Date presets */}
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {(
+                  [
+                    ['This week', presetThisWeek],
+                    ['Last month', presetLastMonth],
+                  ] as const
+                ).map(([label, fn]) => (
+                  <button
+                    key={label}
+                    onClick={() => {
+                      const { dateFrom: f, dateTo: t } = fn();
+                      setDateFrom(f ? f.slice(0, 10) : '');
+                      setDateTo(t ? t.slice(0, 10) : '');
+                    }}
+                    className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                    style={{
+                      background: 'transparent',
+                      border: '1px solid #334155',
+                      borderRadius: 6,
+                      color: '#94a3b8',
+                      cursor: 'pointer',
+                      fontSize: 12,
+                      padding: '4px 8px',
+                    }}
+                  >
+                    {label}
+                  </button>
+                ))}
+                <button
+                  onClick={() => {
+                    setDateFrom('');
+                    setDateTo('');
+                  }}
+                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid #334155',
+                    borderRadius: 6,
+                    color: '#94a3b8',
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    padding: '4px 8px',
+                  }}
+                >
+                  All time
+                </button>
+              </div>
+
+              {/* Custom date range */}
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <input
+                  type="date"
+                  aria-label="From date"
+                  value={dateFrom}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    padding: '5px 8px',
+                    borderRadius: 6,
+                    background: '#0f172a',
+                    border: '1px solid #334155',
+                    color: '#f1f5f9',
+                    fontSize: 12,
+                    outline: 'none',
+                  }}
+                />
+                <span style={{ color: '#475569', fontSize: 12 }}>–</span>
+                <input
+                  type="date"
+                  aria-label="To date"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    padding: '5px 8px',
+                    borderRadius: 6,
+                    background: '#0f172a',
+                    border: '1px solid #334155',
+                    color: '#f1f5f9',
+                    fontSize: 12,
+                    outline: 'none',
+                  }}
+                />
+              </div>
+
+              {/* Video filter */}
+              <select
+                aria-label="Filter by video"
+                value={videoId}
+                onChange={(e) => setVideoId(e.target.value)}
+                style={{
+                  width: '100%',
+                  padding: '6px 8px',
+                  borderRadius: 6,
+                  background: '#0f172a',
+                  border: '1px solid #334155',
+                  color: '#f1f5f9',
+                  fontSize: 12,
+                  outline: 'none',
+                }}
+              >
+                <option value="">All videos</option>
+                {videos.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.title}
+                  </option>
+                ))}
+              </select>
+
+              {filtersActive && (
+                <button
+                  onClick={clearFilters}
+                  className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+                  style={{
+                    alignSelf: 'flex-start',
+                    background: 'transparent',
+                    border: 'none',
+                    color: '#3b82f6',
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    padding: 0,
+                  }}
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
         {/* ── Conversation list ── */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {loading ? (
@@ -630,7 +868,9 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              {debouncedQuery.trim() ? (
+              {filtersActive ? (
+                <p style={{ margin: 0, fontSize: 13 }}>No conversations match these filters</p>
+              ) : debouncedQuery.trim() ? (
                 <p style={{ margin: 0, fontSize: 13 }}>
                   No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
                 </p>

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -215,4 +215,98 @@ describe('useConversations', () => {
       expect(result.current.filteredConversations[0].id).toBe('1');
     });
   });
+
+  describe('server-side filters (date / video)', () => {
+    it('calls searchConversations and surfaces its result when videoId is set', async () => {
+      const getSpy = vi.spyOn(api, 'getConversations');
+      const searchSpy = vi.spyOn(api, 'searchConversations').mockResolvedValue([
+        { id: 'v1', title: 'About a video', created_at: '', updated_at: '', preview: 'Hi' },
+        // preview === null must still be filtered out on the server-side path
+        { id: 'v2', title: 'Empty', created_at: '', updated_at: '', preview: null },
+      ] as api.Conversation[]);
+
+      const { result } = renderHook(() =>
+        useConversations(undefined, { videoId: 'vid-123' }),
+      );
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('v1');
+      expect(searchSpy).toHaveBeenCalledWith({
+        q: undefined,
+        dateFrom: undefined,
+        dateTo: undefined,
+        videoId: 'vid-123',
+      });
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    it('passes date range params through to searchConversations', async () => {
+      const searchSpy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValue([] as api.Conversation[]);
+
+      const { result } = renderHook(() =>
+        useConversations('react', { dateFrom: '2026-01-01', dateTo: '2026-02-01' }),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(searchSpy).toHaveBeenCalledWith({
+        q: 'react',
+        dateFrom: '2026-01-01',
+        dateTo: '2026-02-01',
+        videoId: undefined,
+      });
+    });
+
+    it('does not apply client-side title filtering on the server-side path', async () => {
+      // The server already applied the title match; the client must surface the
+      // server result verbatim (minus preview === null), not re-filter by title.
+      vi.spyOn(api, 'searchConversations').mockResolvedValue([
+        { id: '1', title: 'Totally unrelated', created_at: '', updated_at: '', preview: 'Hi' },
+      ] as api.Conversation[]);
+
+      const { result } = renderHook(() =>
+        useConversations('python', { videoId: 'vid-9' }),
+      );
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('1');
+    });
+
+    it('re-fetches when a filter changes', async () => {
+      const searchSpy = vi
+        .spyOn(api, 'searchConversations')
+        .mockResolvedValueOnce([
+          { id: 'a', title: 'A', created_at: '', updated_at: '', preview: 'Hi' },
+        ] as api.Conversation[])
+        .mockResolvedValueOnce([
+          { id: 'b', title: 'B', created_at: '', updated_at: '', preview: 'Yo' },
+        ] as api.Conversation[]);
+
+      const { result, rerender } = renderHook(
+        ({ videoId }: { videoId: string }) => useConversations(undefined, { videoId }),
+        { initialProps: { videoId: 'vid-1' } },
+      );
+
+      await waitFor(() => expect(result.current.filteredConversations[0]?.id).toBe('a'));
+
+      rerender({ videoId: 'vid-2' });
+
+      await waitFor(() => expect(result.current.filteredConversations[0]?.id).toBe('b'));
+      expect(searchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses getConversations (not the server endpoint) when no filters are set', async () => {
+      const getSpy = vi.spyOn(api, 'getConversations').mockResolvedValue([
+        { id: '1', title: 'Chat', created_at: '', updated_at: '', preview: 'Hello' },
+      ] as api.Conversation[]);
+      const searchSpy = vi.spyOn(api, 'searchConversations');
+
+      const { result } = renderHook(() => useConversations('chat'));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(getSpy).toHaveBeenCalled();
+      expect(searchSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -47,7 +47,9 @@ export function useConversations(searchQuery?: string, filters?: ConversationFil
     }
     // searchQuery only affects the fetch when a server-side filter is active;
     // otherwise it's applied client-side below and must not retrigger a load.
-  }, [filtersActive, filters?.dateFrom, filters?.dateTo, filters?.videoId, searchQuery]);
+    // Use `filtersActive ? searchQuery : null` so typing doesn't retrigger
+    // getConversations() on the non-filter path (null is stable when inactive).
+  }, [filtersActive, filters?.dateFrom, filters?.dateTo, filters?.videoId, filtersActive ? searchQuery : null]);
 
   useEffect(() => {
     load();

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Conversation, getConversations, renameConversation } from '../lib/api';
+import {
+  type Conversation,
+  getConversations,
+  renameConversation,
+  searchConversations,
+} from '../lib/api';
 
-export function useConversations(searchQuery?: string) {
+export interface ConversationFilterArgs {
+  dateFrom?: string;
+  dateTo?: string;
+  videoId?: string;
+}
+
+export function useConversations(searchQuery?: string, filters?: ConversationFilterArgs) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -9,11 +20,23 @@ export function useConversations(searchQuery?: string) {
   // when the user types faster than the network replies.
   const fetchIdRef = useRef(0);
 
+  // A date or video filter requires server-side filtering (the video link lives
+  // only inside messages.sources, which the client never loads). Title-only
+  // search stays on the existing client-side path so prior behavior is unchanged.
+  const filtersActive = !!(filters?.dateFrom || filters?.dateTo || filters?.videoId);
+
   const load = useCallback(async () => {
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = await getConversations();
+      const data = filtersActive
+        ? await searchConversations({
+            q: searchQuery,
+            dateFrom: filters?.dateFrom,
+            dateTo: filters?.dateTo,
+            videoId: filters?.videoId,
+          })
+        : await getConversations();
       if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
       if (myId === fetchIdRef.current) {
@@ -22,7 +45,9 @@ export function useConversations(searchQuery?: string) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, []);
+    // searchQuery only affects the fetch when a server-side filter is active;
+    // otherwise it's applied client-side below and must not retrigger a load.
+  }, [filtersActive, filters?.dateFrom, filters?.dateTo, filters?.videoId, searchQuery]);
 
   useEffect(() => {
     load();
@@ -45,10 +70,13 @@ export function useConversations(searchQuery?: string) {
   // Keep conversations unfiltered for guard logic in Sidebar.tsx.
   const withMessages = conversations.filter((c) => c.preview !== null);
 
+  // When a server-side filter is active the backend already applied the title
+  // match, so skip the client-side substring filter to avoid double-filtering.
   const trimmed = (searchQuery ?? '').trim().toLowerCase();
-  const filteredConversations = trimmed
-    ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
-    : withMessages;
+  const filteredConversations =
+    !filtersActive && trimmed
+      ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
+      : withMessages;
 
   return {
     conversations,

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -144,8 +144,22 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 // Conversations
 export const getConversations = () => request<Conversation[]>('/conversations');
-export const searchConversations = (q: string) =>
-  request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
+
+export interface ConversationFilters {
+  q?: string;
+  dateFrom?: string; // ISO date/datetime, filters on created_at >=
+  dateTo?: string; // ISO date/datetime, filters on created_at <=
+  videoId?: string; // matches conversations whose messages cite this video
+}
+
+export const searchConversations = (f: ConversationFilters) => {
+  const p = new URLSearchParams();
+  if (f.q) p.set('q', f.q);
+  if (f.dateFrom) p.set('date_from', f.dateFrom);
+  if (f.dateTo) p.set('date_to', f.dateTo);
+  if (f.videoId) p.set('video_id', f.videoId);
+  return request<Conversation[]>(`/conversations/search?${p.toString()}`);
+};
 export const createConversation = () =>
   request<Conversation>('/conversations', { method: 'POST', body: '{}' });
 export const getConversation = (id: string) =>


### PR DESCRIPTION
Fixes #294

**Benchmark cell:** `OO` (plan=Opus, impl=Opus)
**Source run-id:** `c4aa6508-bc17-4d63-8965-413fc840ee67`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.