### PR TITLE
[bench-FO] impl: filter conversation history by date and video (#294)

### DIFF
--- a/app/backend/db/repository.py
+++ b/app/backend/db/repository.py
@@ -12,6 +12,7 @@ import json
 import logging
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 import asyncpg
 
@@ -523,6 +524,73 @@ async def search_conversations_by_title(user_id: str, query: str, limit: int = 2
             pattern,
             limit,
         )
+    return [dict(r) for r in rows]
+
+
+async def filter_conversations(
+    user_id: str,
+    *,
+    query: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    video_id: str | None = None,
+) -> list[dict]:
+    """Return conversations owned by *user_id*, narrowed by optional filters.
+
+    All supplied filters are AND-combined. Rows carry the exact shape of
+    `list_conversations` (``c.*`` plus a ``preview`` correlated subquery) and the
+    same ``ORDER BY c.updated_at DESC`` ordering, so the sidebar renders them
+    identically. With no optional filter supplied this returns the same set as
+    `list_conversations`.
+
+    Filters:
+      - ``query``: case-insensitive title substring (ILIKE). Same un-escaped
+        ``%``/``_`` semantics as `search_conversations_by_title`.
+      - ``date_from``: lower bound on ``updated_at``, inclusive (``>=``).
+      - ``date_to``: upper bound on ``updated_at``, exclusive (``<``). Callers
+        pass the start of the day *after* the desired range so there are no
+        off-by-one-day surprises.
+      - ``video_id``: keep only conversations with at least one message whose
+        ``sources`` JSONB array cites this video. Messages with NULL/empty
+        ``sources`` simply don't match.
+
+    The SQL text is assembled from static fragments only; every user value is
+    bound as a ``$n`` parameter — no user data is ever interpolated into the
+    query string.
+    """
+    clauses = ["c.user_id = $1"]
+    params: list[Any] = [user_id]
+
+    if query is not None:
+        params.append(f"%{query}%")
+        clauses.append(f"c.title ILIKE ${len(params)}")
+    if date_from is not None:
+        params.append(date_from)
+        clauses.append(f"c.updated_at >= ${len(params)}")
+    if date_to is not None:
+        params.append(date_to)
+        clauses.append(f"c.updated_at < ${len(params)}")
+    if video_id is not None:
+        params.append(json.dumps([{"video_id": video_id}]))
+        clauses.append(
+            "EXISTS (SELECT 1 FROM messages m "
+            f"WHERE m.conversation_id = c.id AND m.sources @> ${len(params)}::jsonb)"
+        )
+
+    where_sql = " AND ".join(clauses)
+    sql = f"""
+        SELECT c.*,
+               (SELECT content
+                FROM messages
+                WHERE conversation_id = c.id
+                ORDER BY created_at DESC
+                LIMIT 1) AS preview
+        FROM conversations c
+        WHERE {where_sql}
+        ORDER BY c.updated_at DESC
+    """
+    async with _acquire() as conn:
+        rows = await conn.fetch(sql, *params)
     return [dict(r) for r in rows]
 
 

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -103,7 +103,15 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routes (imported here to keep main.py clean)
 # ---------------------------------------------------------------------------
-from backend.routes import admin, auth, channels, conversations, ingest, messages  # noqa: E402
+from backend.routes import (  # noqa: E402
+    admin,
+    auth,
+    channels,
+    conversation_filters,
+    conversations,
+    ingest,
+    messages,
+)
 
 # Auth routes are public (signup/login don't require a session; /me and /logout
 # rely on their own dependency/cookie behaviour).
@@ -112,6 +120,9 @@ app.include_router(auth.router, prefix="/api")
 # User-scoped routes require authentication — MISSION.md §10 invariant:
 # "All chat access requires authentication — there is no anonymous mode."
 _auth_required = [Depends(get_current_user)]
+# Must register before conversations.router: /conversations/filter would
+# otherwise be captured by /conversations/{conv_id}.
+app.include_router(conversation_filters.router, prefix="/api", dependencies=_auth_required)
 app.include_router(conversations.router, prefix="/api", dependencies=_auth_required)
 app.include_router(messages.router, prefix="/api", dependencies=_auth_required)
 

--- a/app/backend/routes/conversation_filters.py
+++ b/app/backend/routes/conversation_filters.py
@@ -1,0 +1,56 @@
+"""Conversation filter route.
+
+Lives in its own module — deliberately separate from `routes/conversations.py`,
+which is a protected (human-authored) path — so the date/video filter endpoint
+can be added without editing that file. The handler is user-scoped
+(MISSION §10 #3): it only ever queries the authenticated caller's own
+conversations.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from backend.auth.dependencies import get_current_user
+from backend.db import repository
+
+router = APIRouter()
+
+
+def _coerce_utc(dt: datetime | None) -> datetime | None:
+    """Treat a naive datetime as UTC.
+
+    asyncpg compares TIMESTAMPTZ columns against tz-aware datetimes; a naive
+    value would raise at bind time. The frontend always sends Z-suffixed ISO
+    strings, but coerce defensively so the API never 500s on naive input.
+    """
+    if dt is not None and dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+@router.get("/conversations/filter")
+async def filter_conversations(
+    q: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    video_id: str | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Filter the caller's conversations by title text, ``updated_at`` range, and
+    cited video. All params are optional and AND-combined; results come back
+    newest-first (``updated_at DESC``), matching the default conversation list.
+
+    Must be registered BEFORE ``/conversations/{conv_id}`` or FastAPI routes
+    "filter" to the path-parameter handler and returns 404.
+    """
+    return await repository.filter_conversations(
+        user_id=str(current_user["id"]),
+        query=q,
+        date_from=_coerce_utc(date_from),
+        date_to=_coerce_utc(date_to),
+        video_id=video_id,
+    )

--- a/app/backend/tests/test_conversation_filters_route.py
+++ b/app/backend/tests/test_conversation_filters_route.py
@@ -1,0 +1,141 @@
+"""Route tests for GET /api/conversations/filter.
+
+These run without a real database: `repository.filter_conversations` is
+monkeypatched to capture the parsed arguments, and the auth dependency is
+overridden. The point is to verify FastAPI query-param parsing (datetimes,
+optional params), UTC coercion of naive datetimes, and — critically — that the
+route is registered ahead of /conversations/{conv_id} so it isn't shadowed.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("JWT_SECRET", "test-secret-please-do-not-use-in-prod")
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture the args the route hands to repository.filter_conversations."""
+    calls: dict[str, Any] = {}
+
+    async def fake_filter_conversations(
+        user_id,
+        *,
+        query=None,
+        date_from=None,
+        date_to=None,
+        video_id=None,
+    ):
+        calls["user_id"] = user_id
+        calls["query"] = query
+        calls["date_from"] = date_from
+        calls["date_to"] = date_to
+        calls["video_id"] = video_id
+        return []
+
+    from backend.db import repository
+
+    monkeypatch.setattr(repository, "filter_conversations", fake_filter_conversations)
+    return calls
+
+
+def _make_client():
+    from backend.auth.dependencies import get_current_user
+    from backend.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: {
+        "id": "user-1",
+        "email": "u@example.com",
+    }
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="https://testserver")
+    return app, client
+
+
+async def test_params_parse_and_user_from_auth(captured):
+    app, client = _make_client()
+    try:
+        r = await client.get(
+            "/api/conversations/filter",
+            params={
+                "q": "rag",
+                "date_from": "2026-05-01T00:00:00Z",
+                "date_to": "2026-05-08T00:00:00Z",
+                "video_id": "vid-9",
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert captured["user_id"] == "user-1"
+        assert captured["query"] == "rag"
+        assert captured["video_id"] == "vid-9"
+        # Aware-datetime equality compares the UTC instant, not the tzinfo object.
+        assert captured["date_from"] == datetime(2026, 5, 1, tzinfo=UTC)
+        assert captured["date_to"] == datetime(2026, 5, 8, tzinfo=UTC)
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+async def test_missing_params_are_none(captured):
+    app, client = _make_client()
+    try:
+        r = await client.get("/api/conversations/filter")
+        assert r.status_code == 200, r.text
+        assert captured["query"] is None
+        assert captured["date_from"] is None
+        assert captured["date_to"] is None
+        assert captured["video_id"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+async def test_naive_datetime_coerced_to_utc(captured):
+    app, client = _make_client()
+    try:
+        r = await client.get(
+            "/api/conversations/filter",
+            params={"date_from": "2026-05-01T12:00:00"},
+        )
+        assert r.status_code == 200, r.text
+        assert captured["date_from"] == datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        assert captured["date_from"].tzinfo is not None
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+async def test_malformed_date_returns_422(captured):
+    app, client = _make_client()
+    try:
+        r = await client.get(
+            "/api/conversations/filter",
+            params={"date_from": "not-a-date"},
+        )
+        assert r.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+async def test_route_not_shadowed_by_conv_id(captured):
+    """Regression for the include-order requirement: /conversations/filter must
+    hit the filter handler, not the /conversations/{conv_id} path-param handler
+    (which would 404 since "filter" is not a real conversation id)."""
+    app, client = _make_client()
+    try:
+        r = await client.get("/api/conversations/filter")
+        assert r.status_code == 200, r.text
+        # The filter repository function was reached — the path-param handler
+        # for /conversations/{conv_id} never calls it.
+        assert "user_id" in captured
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()

--- a/app/backend/tests/test_repository_filter_conversations.py
+++ b/app/backend/tests/test_repository_filter_conversations.py
@@ -1,0 +1,128 @@
+"""Tests for repository.filter_conversations.
+
+Live-Postgres repository tests are skipped repo-wide pending the asyncpg/Alembic
+rewrite, so these assert on the SQL text and the bound parameters handed to
+`conn.fetch` (mocked) rather than on query results. The point is to lock in the
+clause assembly: user scoping is always $1, placeholders are numbered
+sequentially, the date upper bound is exclusive, and user values are bound as
+parameters (never interpolated).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from backend.db import repository
+
+
+def _patch_acquire(mock_conn):
+    mock_acquire = MagicMock()
+    mock_acquire.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_acquire.__aexit__ = AsyncMock(return_value=None)
+    return patch.object(repository, "_acquire", return_value=mock_acquire)
+
+
+def _make_conn():
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+    return mock_conn
+
+
+def _fetch_call(mock_conn):
+    args = mock_conn.fetch.call_args[0]
+    sql = args[0]
+    params = list(args[1:])
+    return sql, params
+
+
+async def test_no_filters_only_user_scope():
+    conn = _make_conn()
+    with _patch_acquire(conn):
+        await repository.filter_conversations("user-1")
+    sql, params = _fetch_call(conn)
+    assert params == ["user-1"]
+    assert "c.user_id = $1" in sql
+    assert "ORDER BY c.updated_at DESC" in sql
+    assert "AS preview" in sql
+    # No optional clauses present.
+    assert "ILIKE" not in sql
+    assert "c.updated_at >=" not in sql
+    assert "c.updated_at <" not in sql
+    assert "@>" not in sql
+
+
+async def test_query_filter():
+    conn = _make_conn()
+    with _patch_acquire(conn):
+        await repository.filter_conversations("user-1", query="rust")
+    sql, params = _fetch_call(conn)
+    assert params == ["user-1", "%rust%"]
+    assert "c.title ILIKE $2" in sql
+
+
+async def test_date_from_filter_inclusive():
+    conn = _make_conn()
+    dt = datetime(2026, 5, 1, tzinfo=UTC)
+    with _patch_acquire(conn):
+        await repository.filter_conversations("user-1", date_from=dt)
+    sql, params = _fetch_call(conn)
+    assert params == ["user-1", dt]
+    assert "c.updated_at >= $2" in sql
+
+
+async def test_date_to_uses_exclusive_upper_bound():
+    conn = _make_conn()
+    dt = datetime(2026, 5, 8, tzinfo=UTC)
+    with _patch_acquire(conn):
+        await repository.filter_conversations("user-1", date_to=dt)
+    sql, params = _fetch_call(conn)
+    assert params == ["user-1", dt]
+    assert "c.updated_at < $2" in sql
+    assert "c.updated_at <= $2" not in sql
+
+
+async def test_video_filter_uses_jsonb_containment():
+    conn = _make_conn()
+    with _patch_acquire(conn):
+        await repository.filter_conversations("user-1", video_id="vid-9")
+    sql, params = _fetch_call(conn)
+    assert params == ["user-1", json.dumps([{"video_id": "vid-9"}])]
+    assert "EXISTS" in sql
+    assert "@>" in sql
+    assert "$2::jsonb" in sql
+
+
+async def test_all_filters_sequential_placeholders_and_and_joined():
+    conn = _make_conn()
+    df = datetime(2026, 5, 1, tzinfo=UTC)
+    dt = datetime(2026, 5, 8, tzinfo=UTC)
+    with _patch_acquire(conn):
+        await repository.filter_conversations(
+            "user-1", query="rag", date_from=df, date_to=dt, video_id="vid-9"
+        )
+    sql, params = _fetch_call(conn)
+    assert params == [
+        "user-1",
+        "%rag%",
+        df,
+        dt,
+        json.dumps([{"video_id": "vid-9"}]),
+    ]
+    assert "c.user_id = $1" in sql
+    assert "c.title ILIKE $2" in sql
+    assert "c.updated_at >= $3" in sql
+    assert "c.updated_at < $4" in sql
+    assert "$5::jsonb" in sql
+    assert " AND " in sql
+
+
+async def test_user_scope_always_first_param():
+    """user_id is bound as $1 regardless of which other filters are supplied."""
+    conn = _make_conn()
+    with _patch_acquire(conn):
+        await repository.filter_conversations("user-xyz", video_id="v", query="q")
+    sql, params = _fetch_call(conn)
+    assert params[0] == "user-xyz"
+    assert "c.user_id = $1" in sql

--- a/app/frontend/src/components/Sidebar.test.tsx
+++ b/app/frontend/src/components/Sidebar.test.tsx
@@ -59,6 +59,7 @@ describe('Sidebar handleNewChat', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     navigateMock.mockReset();
+    vi.spyOn(api, 'getVideos').mockResolvedValue([] as api.Video[]);
   });
 
   describe('guard logic for empty conversations', () => {
@@ -288,6 +289,7 @@ describe('Sidebar logout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     navigateMock.mockReset();
+    vi.spyOn(api, 'getVideos').mockResolvedValue([] as api.Video[]);
   });
 
   it('shows the user email and a Log out button when authed', async () => {
@@ -337,5 +339,81 @@ describe('Sidebar logout', () => {
     expect(logoutMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledWith('/login');
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('Sidebar filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    navigateMock.mockReset();
+    vi.spyOn(api, 'getVideos').mockResolvedValue([
+      { id: 'vid-1', title: 'Intro to RAG', description: '', url: '', created_at: '' },
+      { id: 'vid-2', title: 'Vectors 101', description: '', url: '', created_at: '' },
+    ] as api.Video[]);
+  });
+
+  it('renders the date inputs and the video dropdown populated from getVideos', async () => {
+    render(
+      <MemoryRouter>
+        <Sidebar activeConversationId={undefined} isOpen={true} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText('Filter from date')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter to date')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by video')).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'Intro to RAG' })).toBeInTheDocument();
+  });
+
+  it('shows a Clear filters button only once a filter is set, and clears it', async () => {
+    render(
+      <MemoryRouter>
+        <Sidebar activeConversationId={undefined} isOpen={true} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
+
+    const from = screen.getByLabelText('Filter from date') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(from, { target: { value: '2026-05-01' } });
+    });
+
+    const clearBtn = screen.getByRole('button', { name: /clear filters/i });
+    expect(clearBtn).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(clearBtn);
+    });
+
+    expect(from.value).toBe('');
+    expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
+  });
+
+  it('shows filter-specific empty copy when a filter is active and no matches', async () => {
+    const { useConversations } = await import('../hooks/useConversations');
+    vi.mocked(useConversations).mockReturnValue({
+      conversations: [] as api.Conversation[],
+      loading: false,
+      error: null,
+      refetch: vi.fn().mockResolvedValue(undefined),
+      rename: vi.fn(),
+      filteredConversations: [] as api.Conversation[],
+    });
+
+    render(
+      <MemoryRouter>
+        <Sidebar activeConversationId={undefined} isOpen={true} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    // Wait for the options to load before selecting one.
+    await screen.findByRole('option', { name: 'Intro to RAG' });
+    const video = screen.getByLabelText('Filter by video') as HTMLSelectElement;
+    await act(async () => {
+      fireEvent.change(video, { target: { value: 'vid-1' } });
+    });
+
+    expect(screen.getByText('No conversations match your filters')).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useConversations } from '../hooks/useConversations';
 import { useToast } from '../hooks/useToast';
-import { type Conversation, createConversation, deleteConversation } from '../lib/api';
+import {
+  type Conversation,
+  type Video,
+  createConversation,
+  deleteConversation,
+  getVideos,
+} from '../lib/api';
 import { VideoExplorer } from './VideoExplorer';
 
 // ── Relative time helper ─────────────────────────────────────────
@@ -413,8 +419,20 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
-  const { conversations, loading, refetch, rename, filteredConversations } =
-    useConversations(debouncedQuery);
+  // Date + video filters (combine with the text search, server-side).
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [videoFilterId, setVideoFilterId] = useState('');
+  const [videos, setVideos] = useState<Video[]>([]);
+  const filtersActive = !!(dateFrom || dateTo || videoFilterId);
+  const { conversations, loading, refetch, rename, filteredConversations } = useConversations(
+    debouncedQuery,
+    {
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
+      videoId: videoFilterId || undefined,
+    },
+  );
   const { user, logout } = useAuth();
   const [creatingNew, setCreatingNew] = useState(false);
   const [newChatError, setNewChatError] = useState<string | null>(null);
@@ -430,6 +448,28 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  // Populate the video filter dropdown once on mount. Non-fatal: if the list
+  // can't load, the dropdown simply stays at "All videos".
+  useEffect(() => {
+    let cancelled = false;
+    getVideos()
+      .then((vids) => {
+        if (!cancelled) setVideos(vids);
+      })
+      .catch(() => {
+        /* video filter just stays empty */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleClearFilters = () => {
+    setDateFrom('');
+    setDateTo('');
+    setVideoFilterId('');
+  };
 
   // Store refetch in the shared ref so ChatArea can trigger it
   useEffect(() => {
@@ -601,6 +641,88 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
           />
         </div>
 
+        {/* ── Date + video filters ── */}
+        <div
+          style={{ padding: '0 12px 8px', display: 'flex', flexDirection: 'column', gap: 6 }}
+        >
+          <div style={{ display: 'flex', gap: 6 }}>
+            <input
+              type="date"
+              aria-label="Filter from date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                padding: '6px 8px',
+                borderRadius: 8,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 13,
+                outline: 'none',
+              }}
+            />
+            <input
+              type="date"
+              aria-label="Filter to date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                padding: '6px 8px',
+                borderRadius: 8,
+                background: '#1e293b',
+                border: '1px solid #334155',
+                color: '#f1f5f9',
+                fontSize: 13,
+                outline: 'none',
+              }}
+            />
+          </div>
+          <select
+            aria-label="Filter by video"
+            value={videoFilterId}
+            onChange={(e) => setVideoFilterId(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              borderRadius: 8,
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#f1f5f9',
+              fontSize: 13,
+              outline: 'none',
+            }}
+          >
+            <option value="">All videos</option>
+            {videos.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.title}
+              </option>
+            ))}
+          </select>
+          {filtersActive && (
+            <button
+              onClick={handleClearFilters}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
+              style={{
+                alignSelf: 'flex-start',
+                background: 'transparent',
+                border: '1px solid #334155',
+                borderRadius: 8,
+                color: '#94a3b8',
+                cursor: 'pointer',
+                fontSize: 12,
+                padding: '4px 10px',
+              }}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
         {/* ── Conversation list ── */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {loading ? (
@@ -630,10 +752,14 @@ export function Sidebar({ activeConversationId, isOpen, onClose, conversationsRe
               >
                 <path d="M6,4 L30,4 A2,2 0 0,1 32,6 L32,24 A2,2 0 0,1 30,26 L10,26 L4,32 L4,6 A2,2 0 0,1 6,4 Z" />
               </svg>
-              {debouncedQuery.trim() ? (
-                <p style={{ margin: 0, fontSize: 13 }}>
-                  No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
-                </p>
+              {debouncedQuery.trim() || filtersActive ? (
+                debouncedQuery.trim() ? (
+                  <p style={{ margin: 0, fontSize: 13 }}>
+                    No matches for <strong style={{ color: '#94a3b8' }}>"{debouncedQuery}"</strong>
+                  </p>
+                ) : (
+                  <p style={{ margin: 0, fontSize: 13 }}>No conversations match your filters</p>
+                )
               ) : (
                 <>
                   <p style={{ margin: 0, fontSize: 13 }}>No conversations yet</p>

--- a/app/frontend/src/hooks/useConversations.test.ts
+++ b/app/frontend/src/hooks/useConversations.test.ts
@@ -215,4 +215,60 @@ describe('useConversations', () => {
       expect(result.current.filteredConversations[0].id).toBe('1');
     });
   });
+
+  describe('date/video filters', () => {
+    it('uses getConversations and never filterConversations when no filters set', async () => {
+      const convos = [{ id: '1', title: 'A', created_at: '', updated_at: '', preview: 'x' }];
+      const getSpy = vi
+        .spyOn(api, 'getConversations')
+        .mockResolvedValue(convos as api.Conversation[]);
+      const filterSpy = vi
+        .spyOn(api, 'filterConversations')
+        .mockResolvedValue([] as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('', {}));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(getSpy).toHaveBeenCalled();
+      expect(filterSpy).not.toHaveBeenCalled();
+    });
+
+    it('calls filterConversations with q, video_id and an exclusive next-day date_to', async () => {
+      const convos = [{ id: '1', title: 'A', created_at: '', updated_at: '', preview: 'x' }];
+      vi.spyOn(api, 'getConversations').mockResolvedValue([] as api.Conversation[]);
+      const filterSpy = vi
+        .spyOn(api, 'filterConversations')
+        .mockResolvedValue(convos as api.Conversation[]);
+
+      const { result } = renderHook(() =>
+        useConversations('rag', { dateFrom: '2026-05-01', dateTo: '2026-05-08', videoId: 'vid-9' }),
+      );
+
+      await waitFor(() => expect(filterSpy).toHaveBeenCalled());
+      const arg = filterSpy.mock.calls[0][0];
+      expect(arg.q).toBe('rag');
+      expect(arg.video_id).toBe('vid-9');
+      expect(arg.date_from).toBe(new Date('2026-05-01T00:00:00').toISOString());
+      // dateTo is rendered as the start of the NEXT day (exclusive upper bound).
+      expect(arg.date_to).toBe(new Date('2026-05-09T00:00:00').toISOString());
+
+      // Client-side title filter is skipped when server filters are active, so
+      // the row stays even though its title doesn't contain "rag".
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+    });
+
+    it('still excludes preview === null rows in the filter path', async () => {
+      const convos = [
+        { id: '1', title: 'A', created_at: '', updated_at: '', preview: 'x' },
+        { id: '2', title: 'B', created_at: '', updated_at: '', preview: null },
+      ];
+      vi.spyOn(api, 'getConversations').mockResolvedValue([] as api.Conversation[]);
+      vi.spyOn(api, 'filterConversations').mockResolvedValue(convos as api.Conversation[]);
+
+      const { result } = renderHook(() => useConversations('', { videoId: 'vid-9' }));
+
+      await waitFor(() => expect(result.current.filteredConversations).toHaveLength(1));
+      expect(result.current.filteredConversations[0].id).toBe('1');
+    });
+  });
 });

--- a/app/frontend/src/hooks/useConversations.ts
+++ b/app/frontend/src/hooks/useConversations.ts
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Conversation, getConversations, renameConversation } from '../lib/api';
+import {
+  type Conversation,
+  filterConversations,
+  getConversations,
+  renameConversation,
+} from '../lib/api';
 
-export function useConversations(searchQuery?: string) {
+export interface ConversationFilters {
+  dateFrom?: string; // yyyy-mm-dd local calendar day (inclusive)
+  dateTo?: string; // yyyy-mm-dd local calendar day (inclusive)
+  videoId?: string;
+}
+
+export function useConversations(searchQuery?: string, filters?: ConversationFilters) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -9,11 +20,41 @@ export function useConversations(searchQuery?: string) {
   // when the user types faster than the network replies.
   const fetchIdRef = useRef(0);
 
+  const dateFrom = filters?.dateFrom;
+  const dateTo = filters?.dateTo;
+  const videoId = filters?.videoId;
+  const filtersActive = !!(dateFrom || dateTo || videoId);
+  const trimmedQuery = (searchQuery ?? '').trim();
+  // Only the filter path refetches on text changes (server applies `q`).
+  // In the default path the client-side title filter handles search without a
+  // refetch, so keep the text query out of `load`'s deps there.
+  const queryDep = filtersActive ? trimmedQuery : '';
+
   const load = useCallback(async () => {
     const myId = ++fetchIdRef.current;
     try {
       setLoading(true);
-      const data = await getConversations();
+      let data: Conversation[];
+      if (filtersActive) {
+        // Convert local calendar days to UTC instants. `date_to` is the start
+        // of the day AFTER the chosen end day, making the upper bound exclusive
+        // so there are no off-by-one-day surprises across timezones.
+        const date_from = dateFrom ? new Date(`${dateFrom}T00:00:00`).toISOString() : undefined;
+        let date_to: string | undefined;
+        if (dateTo) {
+          const next = new Date(`${dateTo}T00:00:00`);
+          next.setDate(next.getDate() + 1);
+          date_to = next.toISOString();
+        }
+        data = await filterConversations({
+          q: trimmedQuery || undefined,
+          date_from,
+          date_to,
+          video_id: videoId || undefined,
+        });
+      } else {
+        data = await getConversations();
+      }
       if (myId === fetchIdRef.current) setConversations(data);
     } catch (e) {
       if (myId === fetchIdRef.current) {
@@ -22,7 +63,8 @@ export function useConversations(searchQuery?: string) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, []);
+    // trimmedQuery is captured via queryDep (only meaningful when filtersActive).
+  }, [filtersActive, dateFrom, dateTo, videoId, queryDep]);
 
   useEffect(() => {
     load();
@@ -45,10 +87,13 @@ export function useConversations(searchQuery?: string) {
   // Keep conversations unfiltered for guard logic in Sidebar.tsx.
   const withMessages = conversations.filter((c) => c.preview !== null);
 
-  const trimmed = (searchQuery ?? '').trim().toLowerCase();
-  const filteredConversations = trimmed
-    ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
-    : withMessages;
+  // When server-side filters are active the backend already applied the text
+  // query, so skip the client-side title filter to avoid double-filtering.
+  const trimmed = trimmedQuery.toLowerCase();
+  const filteredConversations =
+    trimmed && !filtersActive
+      ? withMessages.filter((c) => c.title.toLowerCase().includes(trimmed))
+      : withMessages;
 
   return {
     conversations,

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -146,6 +146,27 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const getConversations = () => request<Conversation[]>('/conversations');
 export const searchConversations = (q: string) =>
   request<Conversation[]>(`/conversations/search?q=${encodeURIComponent(q)}`);
+
+export interface ConversationFilterParams {
+  q?: string;
+  date_from?: string; // ISO 8601 UTC instant (inclusive lower bound)
+  date_to?: string; // ISO 8601 UTC instant (exclusive upper bound)
+  video_id?: string;
+}
+
+/**
+ * Server-side conversation filtering by title text, updated_at range, and
+ * cited video. All params are optional and AND-combined; results come back
+ * newest-first. Only defined, non-empty keys are sent.
+ */
+export const filterConversations = (params: ConversationFilterParams) => {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set('q', params.q);
+  if (params.date_from) qs.set('date_from', params.date_from);
+  if (params.date_to) qs.set('date_to', params.date_to);
+  if (params.video_id) qs.set('video_id', params.video_id);
+  return request<Conversation[]>(`/conversations/filter?${qs.toString()}`);
+};
 export const createConversation = () =>
   request<Conversation>('/conversations', { method: 'POST', body: '{}' });
 export const getConversation = (id: string) =>


### PR DESCRIPTION
Fixes #294

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `80961ecc-25d1-4ac5-90d8-2d9284bf6b59`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.