### PR TITLE
[bench-FO] impl: address issue

### DIFF
--- a/app/backend/config.py
+++ b/app/backend/config.py
@@ -161,8 +161,6 @@ CATALOG_ENABLED: bool = os.environ.get("CATALOG_ENABLED", "false").strip().lower
 CATALOG_TIER: str = (
     os.environ.get("CATALOG_TIER", "standard").strip().lower()
 )  # "standard" or "extended"
-# TTL in seconds for the extended prompt-cache tier (Anthropic API requires an integer).
-CATALOG_CACHE_TTL_SECONDS: int = int(os.environ.get("CATALOG_CACHE_TTL_SECONDS", "3600"))
 
 # Cap on how many characters the get_video_transcript tool returns to the
 # model. Long videos can produce 40K+ tokens of transcript; beyond ~30K

--- a/app/backend/rag/catalog.py
+++ b/app/backend/rag/catalog.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import logging
 
-from backend.config import CATALOG_CACHE_TTL_SECONDS
 from backend.db import repository
 
 logger = logging.getLogger(__name__)
+
+# Anthropic's cache_control.ttl accepts only the duration strings "5m" or
+# "1h" — not an integer count of seconds.
+EXTENDED_CACHE_TTL = "1h"
 
 _catalog_cache: list[dict] | None = None
 
@@ -78,7 +81,7 @@ def build_catalog_block(videos: list[dict], tier: str) -> dict:
 
     cache_control: dict = {"type": "ephemeral"}
     if tier == "extended":
-        cache_control["ttl"] = CATALOG_CACHE_TTL_SECONDS  # integer seconds per Anthropic API
+        cache_control["ttl"] = EXTENDED_CACHE_TTL
 
     return {
         "type": "text",

--- a/app/backend/tests/test_catalog.py
+++ b/app/backend/tests/test_catalog.py
@@ -71,7 +71,7 @@ def test_build_catalog_block_standard() -> None:
 def test_build_catalog_block_extended() -> None:
     videos = [{"id": "vid-abc", "title": "My Video", "url": "https://youtube.com/watch?v=abc"}]
     block = catalog.build_catalog_block(videos, "extended")
-    assert block["cache_control"] == {"type": "ephemeral", "ttl": 3600}
+    assert block["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
 
 def test_build_catalog_block_untitled_fallback() -> None:
@@ -263,13 +263,16 @@ async def test_build_system_prompt_catalog_treats_missing_source_type_as_youtube
 # ---------------------------------------------------------------------------
 
 
-def test_build_catalog_block_extended_ttl_is_integer() -> None:
-    """CATALOG_TIER='extended' must produce an integer ttl, not a string."""
-    with patch("backend.rag.catalog.CATALOG_CACHE_TTL_SECONDS", 3600):
-        videos = [{"id": "v", "title": "Vid", "url": "https://youtu.be/x"}]
-        block = catalog.build_catalog_block(videos, "extended")
-    assert isinstance(block["cache_control"]["ttl"], int)
-    assert block["cache_control"]["ttl"] == 3600
+def test_build_catalog_block_extended_ttl_is_anthropic_duration() -> None:
+    """Anthropic's cache_control.ttl only accepts the strings "5m" or "1h".
+
+    Regression test for #246: the extended tier previously sent integer
+    seconds (3600), which the API does not accept.
+    """
+    videos = [{"id": "v", "title": "Vid", "url": "https://youtu.be/x"}]
+    block = catalog.build_catalog_block(videos, "extended")
+    assert block["cache_control"]["ttl"] == "1h"
+    assert not isinstance(block["cache_control"]["ttl"], int)
 
 
 def test_build_catalog_block_missing_url() -> None:


### PR DESCRIPTION
Fixes #246

**Benchmark cell:** `FO` (plan=Fable, impl=Opus)
**Source run-id:** `48042a22-61a3-4c50-9eb9-d050fde267b5`

Held-constant: explore + self-review on Sonnet.

Produced by the mixed-provider routing benchmark.
See `benchmark-evaluator` workflow for the scored verdict.